### PR TITLE
Ensure that NaN is not sent as relative time when playing back simulc…

### DIFF
--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -242,6 +242,16 @@ require(
           expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, 'src#r=0', true);
         });
 
+        it('should playback from the live point of a simulcast', function () {
+          setUpMSE(0, WindowTypes.SLIDING, MediaKinds.VIDEO);
+
+          mockDashInstance.getSource.and.returnValue('src');
+
+          mseStrategy.load('src', null, undefined);
+
+          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, 'src', true);
+        });
+
         it('should playback from derived start time for webcast', function () {
           setUpMSE(0, WindowTypes.GROWING, MediaKinds.VIDEO, 100000, 200000);
 

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -186,10 +186,15 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
             }
 
             if (windowType === WindowTypes.SLIDING) {
-              // zero start time indicates live point, relative time wise -1 will play almost from the live point,
-              // otherwise play from the given video start time relative to the window
-              startTime = (startTime === 0 ? -1 : startTime);
-              srcWithTime = src + '#r=' + parseInt(startTime);
+              srcWithTime = src; // No need for a relative time to play from live.
+
+              if (startTime !== undefined) {
+                // play from the given video start time relative to the window
+                // zero start time indicates live point to dashjs, but we use zero to mean start of the window
+                // so substituting -1 will play almost from the live point
+                startTime = (startTime === 0 ? -1 : startTime);
+                srcWithTime = src + '#r=' + parseInt(startTime);
+              }
             }
 
             setUpMediaElement(playbackElement);


### PR DESCRIPTION
As the startTime is undefined when attempting to play sliding window content from live, parseInt turns this into NaN and this is used as the relative time on the end of the url passed into dashjs' initialize, e.g.

`http://urltomanifest.mpd#r=NaN`

This small change avoids doing that, in much the same way as we avoid doing it for growing window content a few lines above.