### PR TITLE
Set Smaller DashJS Buffer Defaults

### DIFF
--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -67,7 +67,8 @@ require(
 
         mockDashInstance = jasmine.createSpyObj('mockDashInstance',
           ['initialize', 'getDebug', 'getSource', 'on', 'off', 'time', 'duration', 'attachSource',
-            'reset', 'isPaused', 'pause', 'play', 'seek', 'isReady', 'refreshManifest', 'getDashMetrics', 'getMetricsFor']);
+            'reset', 'isPaused', 'pause', 'play', 'seek', 'isReady', 'refreshManifest', 'getDashMetrics', 'getMetricsFor',
+            'setBufferToKeep', 'setBufferAheadToKeep', 'setBufferTimeAtTopQuality', 'setBufferTimeAtTopQualityLongForm']);
 
         mockDashInstance.duration.and.returnValue(101);
 

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -126,9 +126,9 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         mediaPlayer.getDebug().setLogToBrowserConsole(false);
 
         mediaPlayer.setBufferToKeep(0);
-        mediaPlayer.setBufferAheadToKeep(30);
-        mediaPlayer.setBufferTimeAtTopQuality(30);
-        mediaPlayer.setBufferTimeAtTopQualityLongForm(30);
+        mediaPlayer.setBufferAheadToKeep(20);
+        mediaPlayer.setBufferTimeAtTopQuality(20);
+        mediaPlayer.setBufferTimeAtTopQualityLongForm(20);
 
         mediaPlayer.initialize(mediaElement, src, true);
       }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -124,6 +124,12 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       function setUpMediaPlayer (src) {
         mediaPlayer = dashjs.MediaPlayer().create();
         mediaPlayer.getDebug().setLogToBrowserConsole(false);
+
+        mediaPlayer.setBufferToKeep(0);
+        mediaPlayer.setBufferAheadToKeep(30);
+        mediaPlayer.setBufferTimeAtTopQuality(30);
+        mediaPlayer.setBufferTimeAtTopQualityLongForm(30);
+
         mediaPlayer.initialize(mediaElement, src, true);
       }
 


### PR DESCRIPTION
This adds in some smaller defaults to the buffer size used by DashJS. These are noticeably smaller than those defined by the library. See documentation [here](http://cdn.dashjs.org/latest/jsdoc/module-MediaPlayer.html#setBufferAheadToKeep__anchor).