### PR TITLE
Revert "Set Smaller DashJS Buffer Defaults"

### DIFF
--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -67,8 +67,7 @@ require(
 
         mockDashInstance = jasmine.createSpyObj('mockDashInstance',
           ['initialize', 'getDebug', 'getSource', 'on', 'off', 'time', 'duration', 'attachSource',
-            'reset', 'isPaused', 'pause', 'play', 'seek', 'isReady', 'refreshManifest', 'getDashMetrics', 'getMetricsFor',
-            'setBufferToKeep', 'setBufferAheadToKeep', 'setBufferTimeAtTopQuality', 'setBufferTimeAtTopQualityLongForm']);
+            'reset', 'isPaused', 'pause', 'play', 'seek', 'isReady', 'refreshManifest', 'getDashMetrics', 'getMetricsFor']);
 
         mockDashInstance.duration.and.returnValue(101);
 

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -124,12 +124,6 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       function setUpMediaPlayer (src) {
         mediaPlayer = dashjs.MediaPlayer().create();
         mediaPlayer.getDebug().setLogToBrowserConsole(false);
-
-        mediaPlayer.setBufferToKeep(0);
-        mediaPlayer.setBufferAheadToKeep(20);
-        mediaPlayer.setBufferTimeAtTopQuality(20);
-        mediaPlayer.setBufferTimeAtTopQualityLongForm(20);
-
         mediaPlayer.initialize(mediaElement, src, true);
       }
 


### PR DESCRIPTION
Reverts bbc/bigscreen-player#7

Manual testing found that this change results in playback entering buffering and never recovering. We're investigating why this is the case.