### PR TITLE
add in debug tool enhancements. ABR levels, bitrates and buffer length.

### DIFF
--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -97,7 +97,6 @@ define('bigscreenplayer/bigscreenplayer',
             device
           );
 
-          DebugTool.keyValue({key: 'bitrate', value: bigscreenPlayerData.media.bitrate + ' kbps'});
           DebugTool.keyValue({key: 'cdn', value: bigscreenPlayerData.media.urls[0].cdn});
           DebugTool.keyValue({key: 'url', value: bigscreenPlayerData.media.urls[0].url});
         },

--- a/script/debugger/debugview.js
+++ b/script/debugger/debugview.js
@@ -18,7 +18,8 @@ define('bigscreenplayer/debugger/debugview',
      logBox.style.bottom = '25%';
      logBox.style.backgroundColor = '#1D1D1D';
      logBox.style.opacity = 0.9;
-     logBox.style.overflow = 'wrap';
+     logBox.style.overflow = 'hidden';
+     logBox.style.fontFamily = 'monospace';
 
      staticBox.id = 'staticBox';
      staticBox.style.position = 'absolute';
@@ -28,11 +29,12 @@ define('bigscreenplayer/debugger/debugview',
      staticBox.style.bottom = '25%';
      staticBox.style.backgroundColor = '#1D1D1D';
      staticBox.style.opacity = 0.9;
-     staticBox.style.overflow = 'wrap';
+     staticBox.style.overflow = 'hidden';
+     staticBox.style.fontFamily = 'monospace';
 
      logContainer.id = 'logContainer';
      logContainer.style.color = '#ffffff';
-     logContainer.style.fontSize = '13pt';
+     logContainer.style.fontSize = '11pt';
      logContainer.style.position = 'absolute';
      logContainer.style.bottom = '1%';
      logContainer.style.left = '1%';
@@ -40,7 +42,7 @@ define('bigscreenplayer/debugger/debugview',
 
      staticContainer.id = 'staticContainer';
      staticContainer.style.color = '#ffffff';
-     staticContainer.style.fontSize = '13pt';
+     staticContainer.style.fontSize = '11pt';
      staticContainer.style.wordWrap = 'break-word';
      staticContainer.style.left = '1%';
 

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -82,22 +82,21 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       }
 
       function onQualityChangeRendered (event) {
-        if (!bitrateInfoList) {
-          bitrateInfoList = mediaPlayer.getBitrateInfoListFor(event.mediaType);
-        }
-        if (bitrateInfoList && (event.newQuality !== undefined)) {
-          playerMetadata.playbackBitrate = bitrateInfoList[event.newQuality].bitrate / 1000;
+        if (event.mediaType === mediaKind) {
+          if (!bitrateInfoList) {
+            bitrateInfoList = mediaPlayer.getBitrateInfoListFor(event.mediaType);
+          }
+          if (bitrateInfoList && (event.newQuality !== undefined)) {
+            playerMetadata.playbackBitrate = bitrateInfoList[event.newQuality].bitrate / 1000;
 
-          var oldBitrate = isNaN(event.oldQuality) ? '--' : bitrateInfoList[event.oldQuality].bitrate / 1000;
-          var oldRepresentation = isNaN(event.oldQuality) ? 'Start' : event.oldQuality + ' (' + oldBitrate + ' kbps)';
-          var newRepresentation = event.newQuality + ' (' + playerMetadata.playbackBitrate + ' kbps)';
-          DebugTool.keyValue({key: event.mediaType + ' Representation', value: newRepresentation});
-
-          if (event.mediaType === 'video') {
+            var oldBitrate = isNaN(event.oldQuality) ? '--' : bitrateInfoList[event.oldQuality].bitrate / 1000;
+            var oldRepresentation = isNaN(event.oldQuality) ? 'Start' : event.oldQuality + ' (' + oldBitrate + ' kbps)';
+            var newRepresentation = event.newQuality + ' (' + playerMetadata.playbackBitrate + ' kbps)';
+            DebugTool.keyValue({key: event.mediaType + ' Representation', value: newRepresentation});
             DebugTool.info('ABR Change Rendered From Representation ' + oldRepresentation + ' To ' + newRepresentation);
           }
+          Plugins.interface.onPlayerInfoUpdated(playerMetadata);
         }
-        Plugins.interface.onPlayerInfoUpdated(playerMetadata);
       }
 
       function onMetricAdded (event) {
@@ -106,7 +105,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
             DebugTool.keyValue({key: 'Dropped Frames', value: event.value.droppedFrames});
           }
         }
-        if (event.metric === 'BufferLevel') {
+        if (event.mediaType === mediaKind && event.metric === 'BufferLevel') {
           mediaMetrics = mediaPlayer.getMetricsFor(event.mediaType);
           dashMetrics = mediaPlayer.getDashMetrics();
 

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -83,7 +83,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
             var oldRepresentation = isNaN(event.oldQuality) ? 'Initial' : event.oldQuality + ' (' + oldBitrate + ' Kbps)';
             var newRepresentation = event.newQuality + ' (' + newBitrate + ' Kbps)';
 
-            DebugTool.info('ABR Change from representation: ' + oldRepresentation + ' to: ' + newRepresentation);
+            DebugTool.info('ABR level change from: ' + oldRepresentation + ' - ' + newRepresentation);
             DebugTool.keyValue({key: 'bitrate', value: newBitrate + ' Kbps'});
           }
         }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -72,32 +72,11 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
 
       function onQualityChangeRendered (event) {
         if (event.mediaType === 'video') {
-          var metrics = mediaPlayer.getMetricsFor('video');
-          var dashMetrics = mediaPlayer.getDashMetrics();
-          var activeStreamInfo = mediaPlayer.getActiveStream().getStreamInfo();
-
-          if (metrics && dashMetrics && activeStreamInfo) {
-            var bitrateInfoList = mediaPlayer.getBitrateInfoListFor('video');
-            var oldBitrate = isNaN(event.oldQuality) ? '--' : bitrateInfoList[event.oldQuality].bitrate / 1000;
-            var newBitrate = bitrateInfoList[event.newQuality].bitrate / 1000;
-            var oldRepresentation = isNaN(event.oldQuality) ? 'Initial' : event.oldQuality + ' (' + oldBitrate + ' Kbps)';
-            var newRepresentation = event.newQuality + ' (' + newBitrate + ' Kbps)';
-
-            DebugTool.info('ABR level change from: ' + oldRepresentation + ' - ' + newRepresentation);
-            DebugTool.keyValue({key: 'bitrate', value: newBitrate + ' Kbps'});
-          }
+          DebugTool.info('ABR Change Rendered from: ' + event.oldQuality + ' to: ' + event.newQuality);
         }
       }
 
       function onMetricAdded (event) {
-        if (event.mediaType === 'video' && event.metric === 'BufferLevel') {
-          var metrics = mediaPlayer.getMetricsFor('video');
-          var dashMetrics = mediaPlayer.getDashMetrics();
-
-          if (metrics && dashMetrics) {
-            DebugTool.keyValue({key: 'Buffer Length', value: dashMetrics.getCurrentBufferLevel(metrics)});
-          }
-        }
         if (event.mediaType === 'video' && event.metric === 'DroppedFrames') {
           DebugTool.keyValue({key: 'Dropped Frames', value: event.value.droppedFrames});
         }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -91,10 +91,10 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           var oldBitrate = isNaN(event.oldQuality) ? '--' : bitrateInfoList[event.oldQuality].bitrate / 1000;
           var oldRepresentation = isNaN(event.oldQuality) ? 'Start' : event.oldQuality + ' (' + oldBitrate + ' kbps)';
           var newRepresentation = event.newQuality + ' (' + playerMetadata.playbackBitrate + ' kbps)';
-          DebugTool.keyValue({key: event.mediaType.toUpperCase() + ' Representation', value: newRepresentation});
+          DebugTool.keyValue({key: event.mediaType + ' Representation', value: newRepresentation});
 
           if (event.mediaType === 'video') {
-            DebugTool.info('ABR Change Rendered From ' + 'Representation' + oldRepresentation + ' To Representation ' + newRepresentation);
+            DebugTool.info('ABR Change Rendered From Representation ' + oldRepresentation + ' To ' + newRepresentation);
           }
         }
         Plugins.interface.onPlayerInfoUpdated(playerMetadata);

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -89,11 +89,13 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           playerMetadata.playbackBitrate = bitrateInfoList[event.newQuality].bitrate / 1000;
 
           var oldBitrate = isNaN(event.oldQuality) ? '--' : bitrateInfoList[event.oldQuality].bitrate / 1000;
-          var oldRepresentation = isNaN(event.oldQuality) ? 'Initial' : event.oldQuality + ' (' + oldBitrate + ' kbps)';
+          var oldRepresentation = isNaN(event.oldQuality) ? 'Start' : event.oldQuality + ' (' + oldBitrate + ' kbps)';
           var newRepresentation = event.newQuality + ' (' + playerMetadata.playbackBitrate + ' kbps)';
+          DebugTool.keyValue({key: event.mediaType.toUpperCase() + ' Representation', value: newRepresentation});
 
-          DebugTool.info('ABR Change Rendered from: ' + oldRepresentation + ' to: ' + newRepresentation);
-          DebugTool.keyValue({key: 'bitrate', value: newRepresentation});
+          if (event.mediaType === 'video') {
+            DebugTool.info('ABR Change Rendered From ' + 'Representation' + oldRepresentation + ' To Representation ' + newRepresentation);
+          }
         }
         Plugins.interface.onPlayerInfoUpdated(playerMetadata);
       }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -93,6 +93,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           var newRepresentation = event.newQuality + ' (' + playerMetadata.playbackBitrate + ' kbps)';
 
           DebugTool.info('ABR Change Rendered from: ' + oldRepresentation + ' to: ' + newRepresentation);
+          DebugTool.keyValue({key: 'bitrate', value: newRepresentation});
         }
         Plugins.interface.onPlayerInfoUpdated(playerMetadata);
       }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -72,11 +72,32 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
 
       function onQualityChangeRendered (event) {
         if (event.mediaType === 'video') {
-          DebugTool.info('ABR Change Rendered from: ' + event.oldQuality + ' to: ' + event.newQuality);
+          var metrics = mediaPlayer.getMetricsFor('video');
+          var dashMetrics = mediaPlayer.getDashMetrics();
+          var activeStreamInfo = mediaPlayer.getActiveStream().getStreamInfo();
+
+          if (metrics && dashMetrics && activeStreamInfo) {
+            var bitrateInfoList = mediaPlayer.getBitrateInfoListFor('video');
+            var oldBitrate = isNaN(event.oldQuality) ? '--' : bitrateInfoList[event.oldQuality].bitrate / 1000;
+            var newBitrate = bitrateInfoList[event.newQuality].bitrate / 1000;
+            var oldRepresentation = isNaN(event.oldQuality) ? 'Initial' : event.oldQuality + ' (' + oldBitrate + ' Kbps)';
+            var newRepresentation = event.newQuality + ' (' + newBitrate + ' Kbps)';
+
+            DebugTool.info('ABR Change from representation: ' + oldRepresentation + ' to: ' + newRepresentation);
+            DebugTool.keyValue({key: 'bitrate', value: newBitrate + ' Kbps'});
+          }
         }
       }
 
       function onMetricAdded (event) {
+        if (event.mediaType === 'video' && event.metric === 'BufferLevel') {
+          var metrics = mediaPlayer.getMetricsFor('video');
+          var dashMetrics = mediaPlayer.getDashMetrics();
+
+          if (metrics && dashMetrics) {
+            DebugTool.keyValue({key: 'Buffer Length', value: dashMetrics.getCurrentBufferLevel(metrics)});
+          }
+        }
         if (event.mediaType === 'video' && event.metric === 'DroppedFrames') {
           DebugTool.keyValue({key: 'Dropped Frames', value: event.value.droppedFrames});
         }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -85,7 +85,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         if (!bitrateInfoList) {
           bitrateInfoList = mediaPlayer.getBitrateInfoListFor(event.mediaType);
         }
-        if (bitrateInfoList && event.newQuality) {
+        if (bitrateInfoList && (event.newQuality !== undefined)) {
           playerMetadata.playbackBitrate = bitrateInfoList[event.newQuality].bitrate / 1000;
 
           var oldBitrate = isNaN(event.oldQuality) ? '--' : bitrateInfoList[event.oldQuality].bitrate / 1000;

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -82,15 +82,17 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       }
 
       function onQualityChangeRendered (event) {
-        if (event.mediaType === 'video') {
-          DebugTool.info('ABR Change Rendered from: ' + event.oldQuality + ' to: ' + event.newQuality);
-        }
-
         if (!bitrateInfoList) {
           bitrateInfoList = mediaPlayer.getBitrateInfoListFor(event.mediaType);
         }
         if (bitrateInfoList && event.newQuality) {
           playerMetadata.playbackBitrate = bitrateInfoList[event.newQuality].bitrate / 1000;
+
+          var oldBitrate = isNaN(event.oldQuality) ? '--' : bitrateInfoList[event.oldQuality].bitrate / 1000;
+          var oldRepresentation = isNaN(event.oldQuality) ? 'Initial' : event.oldQuality + ' (' + oldBitrate + ' kbps)';
+          var newRepresentation = event.newQuality + ' (' + playerMetadata.playbackBitrate + ' kbps)';
+
+          DebugTool.info('ABR Change Rendered from: ' + oldRepresentation + ' to: ' + newRepresentation);
         }
         Plugins.interface.onPlayerInfoUpdated(playerMetadata);
       }
@@ -107,6 +109,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
 
           if (mediaMetrics && dashMetrics) {
             playerMetadata.bufferLength = dashMetrics.getCurrentBufferLevel(mediaMetrics);
+            DebugTool.keyValue({key: 'Buffer Length', value: playerMetadata.bufferLength});
             Plugins.interface.onPlayerInfoUpdated(playerMetadata);
           }
         }


### PR DESCRIPTION
I've added in some extra hooks to the dash.js metric events with some interesting information for debugging playback.

ABR change debug messages have the bitrate in the message along with the current bitrate being shown on the key value pane (as the TAL strategy does it).

Buffer level has also been added to the key value pane.
