### PR TITLE
Live cdn failover

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2654,7 +2654,7 @@
     "jasmine": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.2.0.tgz",
-      "integrity": "sha512-qv6TZ32r+slrQz8fbx2EhGbD9zlJo3NwPrpLK1nE8inILtZO9Fap52pyHk7mNTh4tG50a+1+tOiWVT3jO5I0Sg==",
+      "integrity": "sha1-s6AYRUeBgFZQ5GV4gD0I58/dez0=",
       "dev": true,
       "requires": {
         "glob": "^7.0.6",
@@ -2664,7 +2664,7 @@
     "jasmine-core": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.2.1.tgz",
-      "integrity": "sha512-pa9tbBWgU0EE4SWgc85T4sa886ufuQdsgruQANhECYjwqgV4z7Vw/499aCaP8ZH79JDS4vhm8doDG9HO4+e4sA==",
+      "integrity": "sha1-jk/1uGFgPugzQ/K0nu5qD/6WUM4=",
       "dev": true
     },
     "js-tokens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2654,7 +2654,7 @@
     "jasmine": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.2.0.tgz",
-      "integrity": "sha1-s6AYRUeBgFZQ5GV4gD0I58/dez0=",
+      "integrity": "sha512-qv6TZ32r+slrQz8fbx2EhGbD9zlJo3NwPrpLK1nE8inILtZO9Fap52pyHk7mNTh4tG50a+1+tOiWVT3jO5I0Sg==",
       "dev": true,
       "requires": {
         "glob": "^7.0.6",
@@ -2664,7 +2664,7 @@
     "jasmine-core": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.2.1.tgz",
-      "integrity": "sha1-jk/1uGFgPugzQ/K0nu5qD/6WUM4=",
+      "integrity": "sha512-pa9tbBWgU0EE4SWgc85T4sa886ufuQdsgruQANhECYjwqgV4z7Vw/499aCaP8ZH79JDS4vhm8doDG9HO4+e4sA==",
       "dev": true
     },
     "js-tokens": {

--- a/script-test/playbackstrategies/legacyplaybackadaptortest.js
+++ b/script-test/playbackstrategies/legacyplaybackadaptortest.js
@@ -392,12 +392,6 @@ require(
       });
 
       describe('getCurrentTime', function () {
-        // it('should be set to 0 on initialisation', function () {
-        //   setUpLegacyAdaptor();
-
-        //   expect(legacyAdaptor.getCurrentTime()).toEqual(0);
-        // });
-
         it('should be set when we get a playing event', function () {
           setUpLegacyAdaptor();
 

--- a/script-test/playbackstrategies/legacyplaybackadaptortest.js
+++ b/script-test/playbackstrategies/legacyplaybackadaptortest.js
@@ -392,11 +392,11 @@ require(
       });
 
       describe('getCurrentTime', function () {
-        it('should be set to 0 on initialisation', function () {
-          setUpLegacyAdaptor();
+        // it('should be set to 0 on initialisation', function () {
+        //   setUpLegacyAdaptor();
 
-          expect(legacyAdaptor.getCurrentTime()).toEqual(0);
-        });
+        //   expect(legacyAdaptor.getCurrentTime()).toEqual(0);
+        // });
 
         it('should be set when we get a playing event', function () {
           setUpLegacyAdaptor();

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -138,7 +138,7 @@ require(
         });
       });
 
-      describe('Load', function () {
+      describe('Load when there is no mediaPlayer', function () {
         it('should create a video element and add it to the media element', function () {
           setUpMSE(null, null, MediaKinds.VIDEO);
 
@@ -161,14 +161,6 @@ require(
           expect(playbackElement.childElementCount).toBe(1);
         });
 
-        it('should initialise MediaPlayer with the expected parameters', function () {
-          setUpMSE();
-          mseStrategy.load('src', null, 0);
-
-          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src', jasmine.any(Function));
-        });
-
         it('should initialise MediaPlayer with the expected parameters when no start time is present', function () {
           setUpMSE();
           mseStrategy.load('src', null, undefined);
@@ -177,12 +169,94 @@ require(
           expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src', jasmine.any(Function));
         });
 
-        it('should initialise MediaPlayer with the expected parameters when startTime is set', function () {
-          setUpMSE();
-          mseStrategy.load('src', null, 15);
+        describe('for STATIC window', function () {
+          it('should initialise MediaPlayer with the expected parameters when startTime is zero', function () {
+            setUpMSE();
+            mseStrategy.load('src', null, 0);
 
-          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src#t=15', jasmine.any(Function));
+            expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
+            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src', jasmine.any(Function));
+          });
+
+          it('should initialise MediaPlayer with the expected parameters when startTime is set', function () {
+            setUpMSE();
+            mseStrategy.load('src', null, 15);
+
+            expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
+            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src#t=15', jasmine.any(Function));
+          });
+        });
+
+        describe('for SLIDING window', function () {
+          it('should initialise MediaPlayer with the expected parameters when startTime is zero', function () {
+            setUpMSE(0, WindowTypes.SLIDING, MediaKinds.VIDEO);
+
+            mockDashInstance.getSource.and.returnValue('src');
+
+            mseStrategy.load('src', null, 0);
+
+            expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
+            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src', jasmine.any(Function));
+          });
+
+          it('should initialise MediaPlayer with the expected parameters when startTime is set to 0.1', function () {
+            setUpMSE(0, WindowTypes.SLIDING, MediaKinds.VIDEO);
+
+            mockDashInstance.getSource.and.returnValue('src');
+
+              // Somewhat live, playbackUtils forces 0.1 for TAL related reasons!
+            mseStrategy.load('src', null, 0.1);
+
+            expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
+            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src#r=0', jasmine.any(Function));
+          });
+
+          it('should initialise MediaPlayer with the expected parameters when startTime is set', function () {
+            setUpMSE(0, WindowTypes.SLIDING, MediaKinds.VIDEO);
+
+            mockDashInstance.getSource.and.returnValue('src');
+
+            mseStrategy.load('src', null, 100);
+
+            expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
+            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src#r=100', jasmine.any(Function));
+          });
+        });
+
+        describe('for GROWING window', function () {
+          it('should initialise MediaPlayer with the expected parameters when startTime is zero', function () {
+            setUpMSE(0, WindowTypes.GROWING, MediaKinds.VIDEO, 100000, 200000);
+
+            mockDashInstance.getSource.and.returnValue('src');
+
+            mseStrategy.load('src', null, 0);
+
+            expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
+            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src#t=101', jasmine.any(Function));
+          });
+
+          it('should initialise MediaPlayer with the expected parameters when startTime is set to 0.1', function () {
+            setUpMSE(0, WindowTypes.GROWING, MediaKinds.VIDEO, 100000, 200000);
+
+            mockDashInstance.getSource.and.returnValue('src');
+
+            // Somewhat live, playbackUtils forces 0.1 for TAL related reasons!
+            mseStrategy.load('src', null, 0.1);
+
+            expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
+            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src#t=101', jasmine.any(Function));
+          });
+
+          it('should initialise MediaPlayer with the expected parameters when startTime is set', function () {
+            setUpMSE(0, WindowTypes.GROWING, MediaKinds.VIDEO, 100000, 200000);
+
+            mockDashInstance.getSource.and.returnValue('src');
+
+            mseStrategy.load('src', null, 60);
+
+            expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
+            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src#t=160', jasmine.any(Function));
+          });
         });
 
         it('should set up bindings to MediaPlayer Events correctly', function () {
@@ -203,8 +277,10 @@ require(
           expect(mockDashInstance.on).toHaveBeenCalledWith(dashjsMediaPlayerEvents.QUALITY_CHANGE_RENDERED, jasmine.any(Function));
           expect(mockDashInstance.on).toHaveBeenCalledWith(dashjsMediaPlayerEvents.METRIC_ADDED, jasmine.any(Function));
         });
+      });
 
-        it('should attach a new source when CDN Failover occurs', function () {
+      describe('Load when there a mediaPlayer exists (e.g. CDN failover)', function () {
+        it('should attach a new source with the expected parameters', function () {
           setUpMSE();
 
           mockDashInstance.getSource.and.returnValue('src');
@@ -219,7 +295,7 @@ require(
           expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src2', jasmine.any(Function));
         });
 
-        it('should correctly continue playback from resume point when CDN failover occurs before we have a valid currentTime', function () {
+        it('should a new source with the expected parameters called before we have a valid currentTime', function () {
           setUpMSE();
 
           mockDashInstance.getSource.and.returnValue('src');
@@ -238,7 +314,7 @@ require(
           expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src3#t=45', jasmine.any(Function));
         });
 
-        it('should correctly continue playback from reached time when CDN failover occurs', function () {
+        it('should attach a new source with expected parameters at the current playback time', function () {
           setUpMSE();
 
           mockDashInstance.getSource.and.returnValue('src');
@@ -250,77 +326,9 @@ require(
 
           mockVideoElement.currentTime = 86;
           eventHandlers.timeupdate();
-          mseStrategy.load('src2', null, -1); // Start time is ignored by mse strategy one subsequent loads
+          mseStrategy.load('src2', null, 0);
 
           expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src2#t=86', jasmine.any(Function));
-        });
-
-        it('should playback from the live point of a simulcast', function () {
-          setUpMSE(0, WindowTypes.SLIDING, MediaKinds.VIDEO);
-
-          mockDashInstance.getSource.and.returnValue('src');
-
-          mseStrategy.load('src', null, undefined);
-
-          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src', jasmine.any(Function));
-        });
-
-        it('should playback from relative live start time for video simulcast', function () {
-          setUpMSE(0, WindowTypes.SLIDING, MediaKinds.VIDEO);
-
-          mockDashInstance.getSource.and.returnValue('src');
-
-            // Actual live point requested
-          mseStrategy.load('src', null, 0);
-
-          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src', jasmine.any(Function));
-        });
-
-        it('should playback from relative start time for video simulcast', function () {
-          setUpMSE(0, WindowTypes.SLIDING, MediaKinds.VIDEO);
-
-          mockDashInstance.getSource.and.returnValue('src');
-
-            // Somewhat live, playbackUtils forces 0.1 for TAL related reasons!
-          mseStrategy.load('src', null, 0.1);
-
-          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src#r=0', jasmine.any(Function));
-        });
-
-        it('should playback from derived start time for webcast', function () {
-          setUpMSE(0, WindowTypes.GROWING, MediaKinds.VIDEO, 100000, 200000);
-
-          mockDashInstance.getSource.and.returnValue('src');
-
-          mseStrategy.load('src', null, 0.1);
-
-          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src#t=101', jasmine.any(Function));
-        });
-
-        it('should playback from the provided time of a webcast', function () {
-          setUpMSE(0, WindowTypes.GROWING, MediaKinds.VIDEO, 100000, 200000);
-
-          mockDashInstance.getSource.and.returnValue('src');
-
-          mseStrategy.load('src', null, 60);
-
-          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src#t=160', jasmine.any(Function));
-        });
-
-        it('should playback from the live point of a webcast', function () {
-          setUpMSE(0, WindowTypes.GROWING, MediaKinds.VIDEO, 100000, 200000);
-
-          mockDashInstance.getSource.and.returnValue('src');
-
-          mseStrategy.load('src', null, undefined);
-
-          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src', jasmine.any(Function));
         });
       });
 

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -182,13 +182,6 @@ require(
           expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, 'src#t=15', true);
         });
 
-        it('should initialise MediaPlayer with the expected parameters when startTime is set and there is a time correction', function () {
-          setUpMSE(1922);
-          mseStrategy.load('src', null, 15);
-          // [ <video style="position: absolute; width: 100%; height: 100%;">, 'src#t=1937', true ]
-          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, 'src#t=1937', true);
-        });
-
         it('should set up bindings to MediaPlayer Events correctly', function () {
           setUpMSE();
           mseStrategy.load(null, null, 0);
@@ -253,6 +246,16 @@ require(
           mseStrategy.load('src2', null, 86);
 
           expect(mockDashInstance.attachSource).toHaveBeenCalledWith('src2#t=86');
+        });
+
+        it('should playback from the live point of a simulcast', function () {
+          setUpMSE(0, WindowTypes.SLIDING, MediaKinds.VIDEO);
+
+          mockDashInstance.getSource.and.returnValue('src');
+
+          mseStrategy.load('src', null, undefined);
+
+          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, 'src', true);
         });
 
         it('should playback from relative live start time for video simulcast', function () {

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -204,7 +204,6 @@ require(
 
             mockDashInstance.getSource.and.returnValue('src');
 
-              // Somewhat live, playbackUtils forces 0.1 for TAL related reasons!
             mseStrategy.load('src', null, 0.1);
 
             expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
@@ -240,7 +239,6 @@ require(
 
             mockDashInstance.getSource.and.returnValue('src');
 
-            // Somewhat live, playbackUtils forces 0.1 for TAL related reasons!
             mseStrategy.load('src', null, 0.1);
 
             expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -212,7 +212,7 @@ require(
 
           mseStrategy.load('src2', null, 0);
 
-          expect(mockDashInstance.attachSource).toHaveBeenCalledWith('src2#t=0');
+          expect(mockDashInstance.attachSource).toHaveBeenCalledWith('src2');
         });
 
         it('should correctly continue playback from resume point when CDN failover occurs before we have a valid currentTime', function () {
@@ -266,7 +266,7 @@ require(
             // Actual live point requested
           mseStrategy.load('src', null, 0);
 
-          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, 'src#r=-1', true);
+          expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, 'src', true);
         });
 
         it('should playback from relative start time for video simulcast', function () {

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -242,14 +242,15 @@ require(
           setUpMSE();
 
           mockDashInstance.getSource.and.returnValue('src');
-          mockVideoElement.currentTime = 86;
 
           mseStrategy.load('src', null, 45);
 
           expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
           expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src#t=45', jasmine.any(Function));
 
-          mseStrategy.load('src2', null, 86);
+          mockVideoElement.currentTime = 86;
+          eventHandlers.timeupdate();
+          mseStrategy.load('src2', null, -1); // Start time is ignored by mse strategy one subsequent loads
 
           expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith('src2#t=86', jasmine.any(Function));
         });

--- a/script-test/playercomponenttest.js
+++ b/script-test/playercomponenttest.js
@@ -951,23 +951,6 @@ require(
           expect(mockStateUpdateCallback.calls.mostRecent().args[0].data.state).toEqual(MediaState.FATAL_ERROR);
         });
 
-        // it('should fire a fatal error on the plugins if the playback type is live', function () {
-        //   spyOn(mockStrategy, 'getDuration').and.returnValue(100);
-        //   spyOn(mockStrategy, 'getCurrentTime').and.returnValue(94);
-        //   spyOn(mockStrategy, 'getSeekableRange').and.returnValue({start: 0, end: 100});
-        //   spyOn(mockStrategy, 'load');
-
-        //   setUpPlayerComponent({windowType: WindowTypes.SLIDING, multiCdn: true});
-
-        //   mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {}});
-
-        //   jasmine.clock().tick(5000);
-
-        //   expect(mockStrategy.load).toHaveBeenCalledTimes(1);
-
-        //   expect(mockPluginsInterface.onFatalError).toHaveBeenCalledWith(jasmine.objectContaining(pluginData));
-        // });
-
         it('should failover after buffering for 20 seconds on live dash playback', function () {
           var secondCdn = 'b';
           var currentTime = 94;
@@ -978,9 +961,7 @@ require(
           spyOn(mockStrategy, 'getSeekableRange').and.returnValue({start: 0, end: 100});
           spyOn(mockStrategy, 'load');
 
-          setUpPlayerComponent({windowType: WindowTypes.GROWING, multiCdn: true});
-
-          // mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {}});
+          setUpPlayerComponent({windowType: WindowTypes.SLIDING, multiCdn: true});
 
           // Set playback cause to normal
           mockStrategy.mockingHooks.fireEvent(MediaState.PLAYING);
@@ -997,22 +978,6 @@ require(
 
           expect(mockStrategy.load).toHaveBeenCalledWith(secondCdn, type, currentTime);
         });
-
-        // it('should publish a media state update of fatal if the playback type is live', function () {
-        //   spyOn(mockStrategy, 'getDuration').and.returnValue(100);
-        //   spyOn(mockStrategy, 'getCurrentTime').and.returnValue(94);
-        //   spyOn(mockStrategy, 'load');
-
-        //   setUpPlayerComponent({windowType: WindowTypes.SLIDING, multiCdn: true});
-
-        //   mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {}});
-
-        //   jasmine.clock().tick(5000);
-
-        //   expect(mockStrategy.load).toHaveBeenCalledTimes(1);
-
-        //   expect(mockStateUpdateCallback.calls.mostRecent().args[0].data.state).toEqual(MediaState.FATAL_ERROR);
-        // });
 
         it('should fire a fatal error on the plugins if we are in the last 5 seconds of playback', function () {
           errorProperties.current_time = 96;

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -126,11 +126,11 @@ define('bigscreenplayer/bigscreenplayer',
             device
           );
 
-          var availableCdns = bigscreenPlayerData.media.urls.reduce(function (acc, media) {
-            return acc.cdn.concat(', ', media.cdn);
+          var availableCdns = bigscreenPlayerData.media.urls.map(function (media) {
+            return media.cdn;
           });
 
-          DebugTool.keyValue({key: 'available cdns', value: availableCdns.cdn || availableCdns});
+          DebugTool.keyValue({key: 'available cdns', value: availableCdns});
           DebugTool.keyValue({key: 'current cdn', value: bigscreenPlayerData.media.urls[0].cdn});
           DebugTool.keyValue({key: 'url', value: bigscreenPlayerData.media.urls[0].url});
         },

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -186,7 +186,11 @@ define('bigscreenplayer/bigscreenplayer',
           }
         },
         getCurrentTime: function () {
-          return playerComponent ? playerComponent.getCurrentTime() : 0;
+          if (playerComponent) {
+            return playerComponent.getCurrentTime() || 0;
+          } else {
+            return 0;
+          }
         },
         getMediaKind: function () {
           return mediaKind;

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -186,11 +186,7 @@ define('bigscreenplayer/bigscreenplayer',
           }
         },
         getCurrentTime: function () {
-          if (playerComponent) {
-            return playerComponent.getCurrentTime() || 0;
-          } else {
-            return 0;
-          }
+          return playerComponent && playerComponent.getCurrentTime() || 0;
         },
         getMediaKind: function () {
           return mediaKind;

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -126,7 +126,12 @@ define('bigscreenplayer/bigscreenplayer',
             device
           );
 
-          DebugTool.keyValue({key: 'cdn', value: bigscreenPlayerData.media.urls[0].cdn});
+          var availableCdns = bigscreenPlayerData.media.urls.reduce(function (acc, media) {
+            return acc.cdn.concat(', ', media.cdn);
+          });
+
+          DebugTool.keyValue({key: 'available cdns', value: availableCdns.cdn || availableCdns});
+          DebugTool.keyValue({key: 'current cdn', value: bigscreenPlayerData.media.urls[0].cdn});
           DebugTool.keyValue({key: 'url', value: bigscreenPlayerData.media.urls[0].url});
         },
 

--- a/script/playbackstrategy/legacyplayeradapter.js
+++ b/script/playbackstrategy/legacyplayeradapter.js
@@ -246,10 +246,11 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
           isPaused = false;
 
           hasStartTime = startTime || startTime === 0;
-          var isLiveNonRestart = windowType !== WindowTypes.STATIC && !hasStartTime;
+          var isPlaybackFromLivePoint = windowType !== WindowTypes.STATIC && !hasStartTime;
 
           mediaPlayer.initialiseMedia('video', src, mimeType, playbackElement, setSourceOpts);
-          if (mediaPlayer.beginPlaybackFrom && !isLiveNonRestart) {
+          if (mediaPlayer.beginPlaybackFrom && !isPlaybackFromLivePoint) {
+            currentTime = startTime;
             mediaPlayer.beginPlaybackFrom(startTime + timeCorrection || 0);
           } else {
             mediaPlayer.beginPlayback();

--- a/script/playbackstrategy/legacyplayeradapter.js
+++ b/script/playbackstrategy/legacyplayeradapter.js
@@ -16,7 +16,7 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
       var eventCallback;
       var errorCallback;
       var timeUpdateCallback;
-      var currentTime = 0;
+      var currentTime;
       var timeCorrection = timeData && timeData.correction || 0;
       var duration = 0;
       var isPaused;

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -70,6 +70,10 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       }
 
       function onError (event) {
+        if (event.error && event.error.data) {
+          delete event.error.data;
+        }
+
         event.errorProperties = {error_mssg: event.error};
 
         if (event.error) {

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -18,7 +18,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       var timeUpdateCallback;
       var timeCorrection = timeData && timeData.correction || 0;
 
-      var initialStartTime;
+      var failoverTime;
       var isEnded = false;
       var mediaElement;
 
@@ -65,6 +65,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       }
 
       function onTimeUpdate () {
+        failoverTime = mediaElement.currentTime - timeCorrection;
         publishTimeUpdate();
       }
 
@@ -263,20 +264,12 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         },
         load: function (src, mimeType, playbackTime) {
           if (!mediaPlayer) {
-            initialStartTime = parseInt(playbackTime) + timeCorrection;
+            failoverTime = playbackTime;
             setUpMediaElement(playbackElement);
             setUpMediaPlayer(calculateSourceAnchor(src, playbackTime));
             setUpMediaListeners();
           } else {
-            var failoverSourceTime;
-
-            if (mediaElement.currentTime === 0) {
-              failoverSourceTime = calculateSourceAnchor(src, initialStartTime);
-            } else {
-              failoverSourceTime = calculateSourceAnchor(src, playbackTime);
-            }
-
-            modifySource(failoverSourceTime);
+            modifySource(calculateSourceAnchor(src, failoverTime));
           }
         },
         getSeekableRange: function () {
@@ -325,7 +318,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           errorCallback = undefined;
           timeUpdateCallback = undefined;
           isEnded = undefined;
-          initialStartTime = undefined;
+          failoverTime = undefined;
           timeCorrection = undefined;
           windowType = undefined;
         },

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -36,9 +36,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         MANIFEST_VALIDITY_CHANGED: 'manifestValidityChanged',
         QUALITY_CHANGE_RENDERED: 'qualityChangeRendered',
         METRIC_ADDED: 'metricAdded',
-        METRIC_CHANGED: 'metricChanged',
-        PLAYBACK_STALLED: 'playbackStalled',
-        BUFFER_STALLED: 'bufferStalled'
+        METRIC_CHANGED: 'metricChanged'
       };
 
       function onPlaying () {
@@ -84,14 +82,6 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           }
         }
         publishError(event);
-      }
-
-      function onBufferStalled (event) {
-        DebugTool.info('MSE Buffer Stalled');
-      }
-
-      function onPlaybackStalled (event) {
-        DebugTool.info('Playback Element Stalled');
       }
 
       function onManifestLoaded (event) {
@@ -204,8 +194,6 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         mediaPlayer.on(DashJSEvents.MANIFEST_VALIDITY_CHANGED, onManifestValidityChange);
         mediaPlayer.on(DashJSEvents.QUALITY_CHANGE_RENDERED, onQualityChangeRendered);
         mediaPlayer.on(DashJSEvents.METRIC_ADDED, onMetricAdded);
-        mediaPlayer.on(DashJSEvents.PLAYBACK_STALLED, onPlaybackStalled);
-        mediaPlayer.on(DashJSEvents.BUFFER_STALLED, onBufferStalled);
       }
 
       function cdnFailoverLoad (newSrc, currentSrcWithTime) {
@@ -305,8 +293,6 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           mediaPlayer.off(DashJSEvents.MANIFEST_VALIDITY_CHANGED, onManifestValidityChange);
           mediaPlayer.off(DashJSEvents.QUALITY_CHANGE_RENDERED, onQualityChangeRendered);
           mediaPlayer.off(DashJSEvents.METRIC_ADDED, onMetricAdded);
-          mediaPlayer.off(DashJSEvents.PLAYBACK_STALLED, onPlaybackStalled);
-          mediaPlayer.off(DashJSEvents.BUFFER_STALLED, onBufferStalled);
 
           mediaElement.parentElement.removeChild(mediaElement);
 

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -225,20 +225,16 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           return startTime === 0 ? source : source + '#t=' + parseInt(startTime);
         }
 
+        if (windowType === WindowTypes.SLIDING) {
+          return startTime === 0 ? source : source + '#r=' + parseInt(startTime);
+        }
+
         if (windowType === WindowTypes.GROWING) {
           var windowStartTimeSeconds = (timeData.windowStartTime / 1000);
           var srcWithTimeAnchor = source + '#t=';
 
           startTime = parseInt(startTime);
           return startTime === 0 ? srcWithTimeAnchor + (windowStartTimeSeconds + 1) : srcWithTimeAnchor + (windowStartTimeSeconds + startTime);
-        }
-
-        if (windowType === WindowTypes.SLIDING) {
-          if (startTime === 0) {
-            return source;
-          } else {
-            return source + '#r=' + parseInt(startTime);
-          }
         }
       }
 

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -231,7 +231,13 @@ define(
         mediaMetaData.urls.shift();
         var evt = new PluginData({status: PluginEnums.STATUS.FAILOVER, stateType: PluginEnums.TYPE.ERROR, properties: errorProperties, isBufferingTimeoutError: bufferingTimeoutError, cdn: mediaMetaData.urls[0].cdn});
         Plugins.interface.onErrorHandled(evt);
-        DebugTool.keyValue({key: 'cdn', value: mediaMetaData.urls[0].cdn});
+
+        var availableCdns = mediaMetaData.urls.reduce(function (acc, media) {
+          return acc.cdn.concat(', ', media.cdn);
+        });
+
+        DebugTool.keyValue({key: 'available cdns', value: availableCdns.cdn || availableCdns});
+        DebugTool.keyValue({key: 'current cdn', value: mediaMetaData.urls[0].cdn});
         DebugTool.keyValue({key: 'url', value: mediaMetaData.urls[0].url});
         loadMedia(mediaMetaData.urls[0].url, mediaMetaData.type, getCurrentTime(), thenPause);
       }

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -26,6 +26,7 @@ define(
       var mediaMetaData;
       var fatalErrorTimeout;
       var fatalError;
+      var transferFormat = bigscreenPlayerData.media.manifestType === 'mpd' ? 'dash' : 'hls';
 
       playbackStrategy = PlaybackStrategy(
         windowType,
@@ -210,8 +211,10 @@ define(
       }
 
       function attemptCdnFailover (errorProperties, bufferingTimeoutError) {
-        var aboutToEnd = getDuration() > 0 && (getDuration() - getCurrentTime()) <= 5;
-        if (mediaMetaData.urls.length > 1 && windowType === WindowTypes.STATIC && !aboutToEnd) {
+        var aboutToEndVod = getDuration() > 0 && (getDuration() - getCurrentTime()) <= 5;
+        if (mediaMetaData.urls.length > 1 && (windowType === WindowTypes.STATIC) && !aboutToEndVod) {
+          cdnFailover(errorProperties, bufferingTimeoutError);
+        } else if (windowType !== WindowTypes.STATIC && transferFormat === 'dash') {
           cdnFailover(errorProperties, bufferingTimeoutError);
         } else {
           var evt = new PluginData({status: PluginEnums.STATUS.FATAL, stateType: PluginEnums.TYPE.ERROR, properties: errorProperties, isBufferingTimeoutError: bufferingTimeoutError});

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -211,10 +211,12 @@ define(
       }
 
       function attemptCdnFailover (errorProperties, bufferingTimeoutError) {
+        var hasNextCDN = mediaMetaData.urls.length > 1;
         var aboutToEndVod = getDuration() > 0 && (getDuration() - getCurrentTime()) <= 5;
-        if (mediaMetaData.urls.length > 1 && (windowType === WindowTypes.STATIC) && !aboutToEndVod) {
-          cdnFailover(errorProperties, bufferingTimeoutError);
-        } else if (windowType !== WindowTypes.STATIC && transferFormat === 'dash') {
+        var canVodFailover = windowType === WindowTypes.STATIC && !aboutToEndVod;
+        var canLiveFailover = windowType !== WindowTypes.STATIC && transferFormat === 'dash';
+
+        if (hasNextCDN && (canVodFailover || canLiveFailover)) {
           cdnFailover(errorProperties, bufferingTimeoutError);
         } else {
           var evt = new PluginData({status: PluginEnums.STATUS.FATAL, stateType: PluginEnums.TYPE.ERROR, properties: errorProperties, isBufferingTimeoutError: bufferingTimeoutError});

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -232,11 +232,11 @@ define(
         var evt = new PluginData({status: PluginEnums.STATUS.FAILOVER, stateType: PluginEnums.TYPE.ERROR, properties: errorProperties, isBufferingTimeoutError: bufferingTimeoutError, cdn: mediaMetaData.urls[0].cdn});
         Plugins.interface.onErrorHandled(evt);
 
-        var availableCdns = mediaMetaData.urls.reduce(function (acc, media) {
-          return acc.cdn.concat(', ', media.cdn);
+        var availableCdns = mediaMetaData.urls.map(function (media) {
+          return media.cdn;
         });
 
-        DebugTool.keyValue({key: 'available cdns', value: availableCdns.cdn || availableCdns});
+        DebugTool.keyValue({key: 'available cdns', value: availableCdns});
         DebugTool.keyValue({key: 'current cdn', value: mediaMetaData.urls[0].cdn});
         DebugTool.keyValue({key: 'url', value: mediaMetaData.urls[0].url});
         loadMedia(mediaMetaData.urls[0].url, mediaMetaData.type, getCurrentTime(), thenPause);


### PR DESCRIPTION
Failover for LIVE playback - DASH only.

- Native Strategy - uses the `load` functions `startTime` argument as the time to failover to. This is passed in by `playerComponent` using `getCurrentTime`, which is the native strategy's internally stored current time.
- MSE Strategy - ignores the `load` functions `playbackTime` argument and instead uses the MSE strategy's internally stored `failoverTime`.

Refactoring unit tests.