### PR TITLE
Live CDN failover time fix

### DIFF
--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -65,7 +65,14 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       }
 
       function onTimeUpdate () {
-        failoverTime = mediaElement.currentTime - timeCorrection;
+        var IN_STREAM_BUFFERING_SECONDS = 20;
+        var dvrInfo = mediaPlayer.getDashMetrics().getCurrentDVRInfo(mediaPlayer.getMetricsFor('video'));
+        failoverTime = mediaElement.currentTime;
+
+        if (dvrInfo && windowType === WindowTypes.SLIDING) {
+          failoverTime = parseInt(dvrInfo.time - dvrInfo.range.start) - IN_STREAM_BUFFERING_SECONDS;
+        }
+
         publishTimeUpdate();
       }
 

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -70,7 +70,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         failoverTime = mediaElement.currentTime;
 
         if (dvrInfo && windowType === WindowTypes.SLIDING) {
-          failoverTime = parseInt(dvrInfo.time - dvrInfo.range.start) - IN_STREAM_BUFFERING_SECONDS;
+          failoverTime = Math.max(0, parseInt(dvrInfo.time - dvrInfo.range.start) - IN_STREAM_BUFFERING_SECONDS);
         }
 
         publishTimeUpdate();

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -67,10 +67,11 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       function onTimeUpdate () {
         var IN_STREAM_BUFFERING_SECONDS = 20;
         var dvrInfo = mediaPlayer.getDashMetrics().getCurrentDVRInfo(mediaPlayer.getMetricsFor('video'));
-        failoverTime = mediaElement.currentTime;
 
         if (dvrInfo && windowType === WindowTypes.SLIDING) {
           failoverTime = Math.max(0, parseInt(dvrInfo.time - dvrInfo.range.start) - IN_STREAM_BUFFERING_SECONDS);
+        } else {
+          failoverTime = mediaElement.currentTime;
         }
 
         publishTimeUpdate();


### PR DESCRIPTION
## Impact

Sliding window CDN failover using dash.js was previously using the time correction based on the initial stream start time to determine the time to restart. 

This causes the time that CDN failover occurs to drift by the amount of time you have been watching a live stream.

It was also possible to failover to just behind the live point when watching from the start of a window, so this has been clamped to 0 for this case. This was due to #r= using negative numbers, IN_STREAM_BUFFERING being 20 seconds and the `failoverTime` being < 20.
