### PR TITLE
Report new cdn to plugin when failing over

### DIFF
--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -374,16 +374,21 @@ require(
 
         it('should call plugin handler on dash baseUrl changed event', function () {
           setUpMSE();
+          cdnArray.push({url: 'testcdn2/test/', cdn: 'cdn2'});
 
           mseStrategy.load(cdnArray, WindowTypes.STATIC, 3);
 
           eventHandlers.baseUrlSelected({
             baseUrl: {
-              url: cdnArray[0].cdn
+              url: cdnArray[1].cdn,
+              serviceLocation: cdnArray[1].cdn
             }
           });
 
-          expect(mockPluginsInterface.onErrorHandled).toHaveBeenCalled();
+          expect(mockPluginsInterface.onErrorHandled).toHaveBeenCalledWith(jasmine.objectContaining({
+            cdn: 'cdn1',
+            newCdn: 'cdn2'
+          }));
         });
       });
 

--- a/script-test/playercomponenttest.js
+++ b/script-test/playercomponenttest.js
@@ -1111,6 +1111,7 @@ require(
             properties: errorProperties,
             isBufferingTimeoutError: false,
             cdn: 'cdn-a',
+            newCdn: 'cdn-b',
             isInitialPlay: undefined,
             timeStamp: jasmine.any(Object)
           };

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -162,7 +162,8 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           stateType: PluginEnums.TYPE.ERROR,
           properties: errorProperties,
           isBufferingTimeoutError: false,
-          cdn: mediaSources[0].cdn
+          cdn: mediaSources[0].cdn,
+          newCdn: mediaSources[1].cdn
         });
         // urls -> sources -> mediaSources (shift the cdns for correct behaviour with buffering timeout failover)
         // TODO: Remove this horrible mutation when failover is pushed down per strategy.

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -262,7 +262,14 @@ define(
       }
 
       function cdnFailover (failoverTime, thenPause, errorProperties, bufferingTimeoutError) {
-        var evt = new PluginData({ status: PluginEnums.STATUS.FAILOVER, stateType: PluginEnums.TYPE.ERROR, properties: errorProperties, isBufferingTimeoutError: bufferingTimeoutError, cdn: mediaMetaData.urls[0].cdn });
+        var evt = new PluginData({
+          status: PluginEnums.STATUS.FAILOVER,
+          stateType: PluginEnums.TYPE.ERROR,
+          properties: errorProperties,
+          isBufferingTimeoutError: bufferingTimeoutError,
+          cdn: mediaMetaData.urls[0].cdn,
+          newCdn: mediaMetaData.urls[1].cdn
+        });
         Plugins.interface.onErrorHandled(evt);
         mediaMetaData.urls.shift();
         cdnDebugOutput.update();

--- a/script/plugindata.js
+++ b/script/plugindata.js
@@ -10,6 +10,7 @@ define(
         this.isBufferingTimeoutError = args.isBufferingTimeoutError || false;
         this.isInitialPlay = args.isInitialPlay;
         this.cdn = args.cdn;
+        this.newCdn = args.newCdn;
         this.timeStamp = new Date();
       }
 


### PR DESCRIPTION
onErrorHandled plugin now passes both the CDN we are failing over _**from**_ and the CDN we are failing over _**to**_.

This will be useful to clients whose implementation wishes to know both pieces of information.

Failover may happen in either `playercomponent` or `msestrategy`, depending on the type of failover (standard buffering timeout or silent failover using dash manifest base urls).