### PR TITLE
DASH MSE Webcast Enhancement

### DIFF
--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -629,17 +629,6 @@ require(
           expect(mockDashInstance.seek).toHaveBeenCalledWith(99.9);
         });
 
-        it('should refresh the DASH manifest before seeking within a growing window asset', function () {
-          setUpMSE(0, WindowTypes.GROWING, MediaKinds.VIDEO);
-          mseStrategy.load(cdnArray, null, 0);
-
-          mseStrategy.setCurrentTime(102);
-          dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {});
-
-          expect(mockDashInstance.refreshManifest).toHaveBeenCalled();
-          expect(mockDashInstance.seek).toHaveBeenCalledWith(99.9);
-        });
-
         describe('sliding window', function () {
           beforeEach(function () {
             setUpMSE(0, WindowTypes.SLIDING, MediaKinds.VIDEO);

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -800,6 +800,48 @@ require(
 
           expect(mockPluginsInterface.onErrorHandled).toHaveBeenCalledWith(jasmine.objectContaining(pluginData));
         });
+
+        it('should not fire CDN failover event on content download error', function () {
+          var mockEvent = {
+            error: 'download',
+            event: {
+              id: 'content'
+            }
+          };
+
+          setUpMSE();
+
+          var mockErrorCallback = jasmine.createSpy();
+          mseStrategy.addErrorCallback(null, mockErrorCallback);
+
+          cdnArray.push({url: 'testcdn2/test/', cdn: 'cdn2'});
+          mseStrategy.load(cdnArray, null, 0);
+
+          dashEventCallback(dashjsMediaPlayerEvents.ERROR, mockEvent);
+
+          expect(mockErrorCallback).not.toHaveBeenCalled();
+        });
+
+        it('should fire CDN failover event on manifest download error', function () {
+          var mockEvent = {
+            error: 'download',
+            event: {
+              id: 'manifest'
+            }
+          };
+
+          setUpMSE();
+
+          var mockErrorCallback = jasmine.createSpy();
+          mseStrategy.addErrorCallback(null, mockErrorCallback);
+
+          cdnArray.push({url: 'testcdn2/test/', cdn: 'cdn2'});
+          mseStrategy.load(cdnArray, null, 0);
+
+          dashEventCallback(dashjsMediaPlayerEvents.ERROR, mockEvent);
+
+          expect(mockErrorCallback).toHaveBeenCalledWith(jasmine.objectContaining(mockEvent));
+        });
       });
     });
   });

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -42,13 +42,18 @@ require(
         interface: mockPluginsInterface
       };
 
+      var mockManifestFilter = {
+        filter: function () {}
+      };
+
       beforeEach(function (done) {
         cdnArray = [];
         cdnArray.push({url: 'testcdn1/test/', cdn: 'cdn1'});
 
         injector.mock({
           'dashjs': mockDashjs,
-          'bigscreenplayer/plugins': mockPlugins
+          'bigscreenplayer/plugins': mockPlugins,
+          'bigscreenplayer/manifest/manifestfilter': mockManifestFilter
         });
 
         injector.require(['bigscreenplayer/playbackstrategy/msestrategy'], function (SquiredMSEStrategy) {
@@ -182,7 +187,35 @@ require(
           mseStrategy.load(cdnArray, null, undefined);
 
           expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url, jasmine.any(Function));
+          expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url);
+        });
+
+        it('should modify the manifest when dashjs fires a manifest loaded event', function () {
+          setUpMSE();
+          cdnArray.push({url: 'testcdn2/test/', cdn: 'cdn2'});
+          mseStrategy.load(cdnArray, null, 0);
+
+          var testManifestObject = {
+            type: 'manifestLoaded',
+            data: {}
+          };
+
+          dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, testManifestObject);
+
+          var baseUrlArray = [
+            {
+              __text: cdnArray[0].url + 'dash/',
+              'dvb:priority': 0,
+              serviceLocation: cdnArray[0].cdn
+            },
+            {
+              __text: cdnArray[1].url + 'dash/',
+              'dvb:priority': 1,
+              serviceLocation: cdnArray[1].cdn
+            }
+          ];
+
+          expect(testManifestObject.data.BaseURL_asArray).toEqual(baseUrlArray);
         });
 
         describe('for STATIC window', function () {
@@ -191,7 +224,7 @@ require(
             mseStrategy.load(cdnArray, null, 0);
 
             expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url, jasmine.any(Function));
+            expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url);
           });
 
           it('should initialise MediaPlayer with the expected parameters when startTime is set', function () {
@@ -199,7 +232,7 @@ require(
             mseStrategy.load(cdnArray, null, 15);
 
             expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url + '#t=15', jasmine.any(Function));
+            expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url + '#t=15');
           });
         });
 
@@ -212,7 +245,7 @@ require(
             mseStrategy.load(cdnArray, null, 0);
 
             expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url, jasmine.any(Function));
+            expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url);
           });
 
           it('should initialise MediaPlayer with the expected parameters when startTime is set to 0.1', function () {
@@ -223,7 +256,7 @@ require(
             mseStrategy.load(cdnArray, null, 0.1);
 
             expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url + '#r=0', jasmine.any(Function));
+            expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url + '#r=0');
           });
 
           it('should initialise MediaPlayer with the expected parameters when startTime is set', function () {
@@ -234,7 +267,7 @@ require(
             mseStrategy.load(cdnArray, null, 100);
 
             expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url + '#r=100', jasmine.any(Function));
+            expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url + '#r=100');
           });
         });
 
@@ -247,7 +280,7 @@ require(
             mseStrategy.load(cdnArray, null, 0);
 
             expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url + '#t=101', jasmine.any(Function));
+            expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url + '#t=101');
           });
 
           it('should initialise MediaPlayer with the expected parameters when startTime is set to 0.1', function () {
@@ -258,7 +291,7 @@ require(
             mseStrategy.load(cdnArray, null, 0.1);
 
             expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url + '#t=101', jasmine.any(Function));
+            expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url + '#t=101');
           });
 
           it('should initialise MediaPlayer with the expected parameters when startTime is set', function () {
@@ -269,7 +302,7 @@ require(
             mseStrategy.load(cdnArray, null, 60);
 
             expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-            expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url + '#t=160', jasmine.any(Function));
+            expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url + '#t=160');
           });
         });
 
@@ -304,13 +337,13 @@ require(
           mseStrategy.load(cdnArray, null, 0);
 
           expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url, jasmine.any(Function));
+          expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url);
 
           cdnArray.shift();
 
           mseStrategy.load(cdnArray, null, 0);
 
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url, jasmine.any(Function));
+          expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url);
         });
 
         it('should a new source with the expected parameters called before we have a valid currentTime', function () {
@@ -324,19 +357,19 @@ require(
           mseStrategy.load(cdnArray, null, 45);
 
           expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url + '#t=45', jasmine.any(Function));
+          expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url + '#t=45');
 
           cdnArray.shift();
 
           mseStrategy.load(cdnArray, null, 0);
 
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url + '#t=45', jasmine.any(Function));
+          expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url + '#t=45');
 
           cdnArray.shift();
 
           mseStrategy.load(cdnArray, null, 0);
 
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url + '#t=45', jasmine.any(Function));
+          expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url + '#t=45');
         });
 
         it('should attach a new source with expected parameters at the current playback time', function () {
@@ -349,7 +382,7 @@ require(
           mseStrategy.load(cdnArray, null, 45);
 
           expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true);
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url + '#t=45', jasmine.any(Function));
+          expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url + '#t=45');
 
           cdnArray.shift();
 
@@ -357,7 +390,7 @@ require(
           eventHandlers.timeupdate();
           mseStrategy.load(cdnArray, null, 0);
 
-          expect(mockDashInstance.retrieveManifest).toHaveBeenCalledWith(cdnArray[0].url + '#t=86', jasmine.any(Function));
+          expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url + '#t=86');
         });
 
         it('should fire download error event when in growing window', function () {
@@ -596,11 +629,12 @@ require(
           expect(mockDashInstance.seek).toHaveBeenCalledWith(99.9);
         });
 
-        it('should refresh the DASH manifest before seeking  within a growing window asset', function () {
+        it('should refresh the DASH manifest before seeking within a growing window asset', function () {
           setUpMSE(0, WindowTypes.GROWING, MediaKinds.VIDEO);
           mseStrategy.load(cdnArray, null, 0);
 
           mseStrategy.setCurrentTime(102);
+          dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {});
 
           expect(mockDashInstance.refreshManifest).toHaveBeenCalled();
           expect(mockDashInstance.seek).toHaveBeenCalledWith(99.9);

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -332,22 +332,6 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         }
       }
 
-      function refreshManifest (onComplete, timeout) {
-        var callback = function () {
-          onComplete();
-          mediaPlayer.off(DashJSEvents.MANIFEST_LOADED, callback);
-          clearTimeout(errorId);
-        };
-
-        var errorId = setTimeout(function () {
-          onComplete(); // so the manifest load failed, but look on the bright side, we might not have seeked past the available segments, so let's have a go anyway.
-          mediaPlayer.off(DashJSEvents.MANIFEST_LOADED, callback);
-        }, timeout || 2000);
-
-        mediaPlayer.on(DashJSEvents.MANIFEST_LOADED, callback);
-        mediaPlayer.refreshManifest();
-      }
-
       function getSeekableRange () {
         if (mediaPlayer && mediaPlayer.isReady() && windowType !== WindowTypes.STATIC) {
           var dvrInfo = mediaPlayer.getDashMetrics().getCurrentDVRInfo(mediaPlayer.getMetricsFor(mediaKind));
@@ -454,21 +438,11 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           mediaPlayer.play();
         },
         setCurrentTime: function (time) {
-          if (windowType === WindowTypes.GROWING) {
-            DebugTool.info('Seeking and refreshing the manifest');
-
-            refreshManifest(function () {
-              var seekToTime = getClampedTime(time, getSeekableRange());
-              mediaPlayer.seek(seekToTime);
-            });
+          var seekToTime = getClampedTime(time, getSeekableRange());
+          if (windowType === WindowTypes.SLIDING) {
+            mediaElement.currentTime = (seekToTime + timeCorrection);
           } else {
-            var seekToTime = getClampedTime(time, getSeekableRange());
-
-            if (windowType === WindowTypes.SLIDING) {
-              mediaElement.currentTime = (seekToTime + timeCorrection);
-            } else {
-              mediaPlayer.seek(seekToTime);
-            }
+            mediaPlayer.seek(seekToTime);
           }
         }
       };

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -109,8 +109,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           } else {
             DebugTool.info('MSE Error: ' + event.error);
 
-            // Don't raise an error on fragment download error unless we want to do a standard failover for growing windows
-            if (event.error === DashJSEvents.DOWNLOAD_ERROR_MESSAGE && windowType !== WindowTypes.GROWING) {
+            if (event.error === DashJSEvents.DOWNLOAD_ERROR_MESSAGE) {
               return;
             }
           }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -109,7 +109,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           } else {
             DebugTool.info('MSE Error: ' + event.error);
 
-            if (event.error === DashJSEvents.DOWNLOAD_ERROR_MESSAGE) {
+            if (event.error === DashJSEvents.DOWNLOAD_ERROR_MESSAGE && event.event.id === 'content') {
               return;
             }
           }
@@ -181,8 +181,6 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       }
 
       function onCdnFailover (event) {
-        if (windowType === WindowTypes.GROWING) return;
-
         var pluginEvent = {
           errorProperties: {
             error_mssg: 'download'

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -336,15 +336,15 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         }
       }
 
-      function refreshManifest (onSuccess, onError, timeout) {
+      function refreshManifest (onComplete, timeout) {
         var callback = function () {
-          onSuccess();
+          onComplete();
           mediaPlayer.off(DashJSEvents.MANIFEST_LOADED, callback);
           clearTimeout(errorId);
         };
 
         var errorId = setTimeout(function () {
-          onError();
+          onComplete(); // so the manifest load failed, but look on the bright side, we might not have seeked past the available segments, so let's have a go anyway.
           mediaPlayer.off(DashJSEvents.MANIFEST_LOADED, callback);
         }, timeout || 2000);
 
@@ -461,19 +461,10 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           if (windowType === WindowTypes.GROWING) {
             DebugTool.info('Seeking and refreshing the manifest');
 
-            var refreshSuccess = function () {
+            refreshManifest(function () {
               var seekToTime = getClampedTime(time, getSeekableRange());
               mediaPlayer.seek(seekToTime);
-            };
-
-            var refreshError = function () {
-              publishError({
-                errorProperties: 'manifestLoad',
-                error: 'manifestLoad'
-              });
-            };
-
-            refreshManifest(refreshSuccess, refreshError);
+            });
           } else {
             var seekToTime = getClampedTime(time, getSeekableRange());
 


### PR DESCRIPTION
Changed when we modify the manifest. Now done on dashjs `manifestLoaded` event (which returns the manifest object), rather than manually retrieving it and attaching the object on startup. 

**Note:** Since `refreshManifest` was asynchronous and not effectively updating the `DVRInfo.range.end` in time for seeking, it was placed in the same code path as `WindowTypes.STATIC`.