### PR TITLE
Teardown seeking for restartable devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2696,7 +2696,7 @@
     "jasmine": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.2.0.tgz",
-      "integrity": "sha1-s6AYRUeBgFZQ5GV4gD0I58/dez0=",
+      "integrity": "sha512-qv6TZ32r+slrQz8fbx2EhGbD9zlJo3NwPrpLK1nE8inILtZO9Fap52pyHk7mNTh4tG50a+1+tOiWVT3jO5I0Sg==",
       "dev": true,
       "requires": {
         "glob": "^7.0.6",
@@ -2706,7 +2706,7 @@
     "jasmine-core": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.2.1.tgz",
-      "integrity": "sha1-jk/1uGFgPugzQ/K0nu5qD/6WUM4=",
+      "integrity": "sha512-pa9tbBWgU0EE4SWgc85T4sa886ufuQdsgruQANhECYjwqgV4z7Vw/499aCaP8ZH79JDS4vhm8doDG9HO4+e4sA==",
       "dev": true
     },
     "js-tokens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "2.4.0",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2696,7 +2696,7 @@
     "jasmine": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.2.0.tgz",
-      "integrity": "sha512-qv6TZ32r+slrQz8fbx2EhGbD9zlJo3NwPrpLK1nE8inILtZO9Fap52pyHk7mNTh4tG50a+1+tOiWVT3jO5I0Sg==",
+      "integrity": "sha1-s6AYRUeBgFZQ5GV4gD0I58/dez0=",
       "dev": true,
       "requires": {
         "glob": "^7.0.6",
@@ -2706,7 +2706,7 @@
     "jasmine-core": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.2.1.tgz",
-      "integrity": "sha512-pa9tbBWgU0EE4SWgc85T4sa886ufuQdsgruQANhECYjwqgV4z7Vw/499aCaP8ZH79JDS4vhm8doDG9HO4+e4sA==",
+      "integrity": "sha1-jk/1uGFgPugzQ/K0nu5qD/6WUM4=",
       "dev": true
     },
     "js-tokens": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "2.4.0",
+  "version": "2.7.0",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -712,7 +712,7 @@ require(
             it('should return false when device does not support seeking', function () {
               mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 60});
 
-              liveSupport = LiveSupport.RESTARTABLE;
+              liveSupport = LiveSupport.PLAYABLE;
 
               initialiseBigscreenPlayer({
                 windowType: WindowTypes.SLIDING

--- a/script-test/playbackstrategies/modifiers/live/playabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/playabletest.js
@@ -7,9 +7,9 @@
 require(
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
-    'squire'
+    'bigscreenplayer/playbackstrategy/modifiers/live/playable'
   ],
-    function (MediaPlayerBase, Squire) {
+    function (MediaPlayerBase, PlayableMediaPlayer) {
       var sourceContainer = document.createElement('div');
       var player;
       var playableMediaPlayer;
@@ -31,23 +31,12 @@ require(
       }
 
       describe('Playable HMTL5 Live Player', function () {
-        beforeEach(function (done) {
-          var injector = new Squire();
-
+        beforeEach(function () {
           player = jasmine.createSpyObj('player',
             ['beginPlayback', 'initialiseMedia', 'stop', 'reset', 'getState', 'getSource', 'getMimeType',
               'addEventCallback', 'removeEventCallback', 'removeAllEventCallbacks', 'getPlayerElement']);
 
-          function mockMediaPlayer () {
-            return player;
-          }
-
-          injector.mock({'bigscreenplayer/playbackstrategy/modifiers/html5': mockMediaPlayer});
-
-          injector.require(['bigscreenplayer/playbackstrategy/modifiers/live/playable'], function (PlayableMediaPlayer) {
-            playableMediaPlayer = PlayableMediaPlayer();
-            done();
-          });
+          playableMediaPlayer = PlayableMediaPlayer(player);
         });
 
         it('calls beginPlayback on the media player', function () {

--- a/script-test/playbackstrategies/modifiers/live/restartabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/restartabletest.js
@@ -104,6 +104,8 @@ require(
             });
 
             it('calls pause on the media player', function () {
+              player.getSeekableRange.and.returnValue({start: 0});
+
               wrapperTests('pause');
             });
 
@@ -184,6 +186,7 @@ require(
             var mockCallback = [];
 
             function startPlaybackAndPause (startTime, disableAutoResume) {
+              player.getCurrentTime.and.returnValue(startTime);
               restartableMediaPlayer.beginPlaybackFrom(startTime);
               restartableMediaPlayer.pause({disableAutoResume: disableAutoResume});
             }
@@ -195,6 +198,7 @@ require(
               player.addEventCallback.and.callFake(function (self, callback) {
                 mockCallback.push(callback);
               });
+              player.getSeekableRange.and.returnValue({start: 0});
 
               initialiseRestartableMediaPlayer();
             });
@@ -267,6 +271,7 @@ require(
               startPlaybackAndPause(20, false);
 
               jasmine.clock().tick(12 * 1000);
+              player.getSeekableRange.and.returnValue({start: 12});
 
               restartableMediaPlayer.pause();
 

--- a/script-test/playbackstrategies/modifiers/live/restartabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/restartabletest.js
@@ -32,7 +32,7 @@ require(
             player = jasmine.createSpyObj('player',
               ['beginPlayback', 'initialiseMedia', 'stop', 'reset', 'getState', 'getSource', 'getMimeType',
                 'addEventCallback', 'removeEventCallback', 'removeAllEventCallbacks', 'getPlayerElement', 'pause',
-                'resume', 'beginPlaybackFrom', 'getCurrentTime']);
+                'resume', 'beginPlaybackFrom', 'getCurrentTime', 'getSeekableRange']);
 
             function mockMediaPlayer () {
               return player;
@@ -106,6 +106,14 @@ require(
             it('calls pause on the media player', function () {
               wrapperTests('pause');
             });
+
+            it('getCurrentTime', function () {
+              wrapperTests('getCurrentTime');
+            });
+
+            it('getSeekableRange', function () {
+              wrapperTests('getSeekableRange');
+            });
           });
 
           describe('should not have methods for', function () {
@@ -119,14 +127,6 @@ require(
 
             it('playFrom', function () {
               isUndefined('playFrom');
-            });
-
-            it('getCurrentTime', function () {
-              isUndefined('getCurrentTime');
-            });
-
-            it('getSeekableRange', function () {
-              isUndefined('getSeekableRange');
             });
           });
 

--- a/script-test/playbackstrategies/modifiers/live/restartabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/restartabletest.js
@@ -1,16 +1,15 @@
 require(
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
-    'squire'
+    'bigscreenplayer/playbackstrategy/modifiers/live/restartable'
   ],
-      function (MediaPlayerBase, Squire) {
+      function (MediaPlayerBase, RestartableMediaPlayer) {
         var sourceContainer = document.createElement('div');
         var player;
-        var restartableMediaConstructor;
         var restartableMediaPlayer;
 
-        function initialiseRestartableMediaPlayer (config, logger) {
-          restartableMediaPlayer = restartableMediaConstructor(config, logger);
+        function initialiseRestartableMediaPlayer (config) {
+          restartableMediaPlayer = RestartableMediaPlayer(player, config);
         }
 
         describe('restartable HMTL5 Live Player', function () {
@@ -26,24 +25,11 @@ require(
             }
           }
 
-          beforeEach(function (done) {
-            var injector = new Squire();
-
+          beforeEach(function () {
             player = jasmine.createSpyObj('player',
               ['beginPlayback', 'initialiseMedia', 'stop', 'reset', 'getState', 'getSource', 'getMimeType',
                 'addEventCallback', 'removeEventCallback', 'removeAllEventCallbacks', 'getPlayerElement', 'pause',
                 'resume', 'beginPlaybackFrom', 'getCurrentTime', 'getSeekableRange']);
-
-            function mockMediaPlayer () {
-              return player;
-            }
-
-            injector.mock({'bigscreenplayer/playbackstrategy/modifiers/html5': mockMediaPlayer});
-
-            injector.require(['bigscreenplayer/playbackstrategy/modifiers/live/restartable'], function (mediaPlayer) {
-              restartableMediaConstructor = mediaPlayer;
-              done();
-            });
           });
 
           describe('methods call the appropriate media player methods', function () {

--- a/script-test/playbackstrategies/modifiers/live/restartabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/restartabletest.js
@@ -178,7 +178,7 @@ require(
                 expect(restartableMediaPlayer.getSeekableRange()).toEqual({ start: 0, end: 100 });
               });
 
-              it('should increase with time', function () {
+              it('should increase start and end for a sliding window', function () {
                 restartableMediaPlayer.beginPlaybackFrom(0);
 
                 timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
@@ -188,7 +188,7 @@ require(
                 expect(restartableMediaPlayer.getSeekableRange()).toEqual({ start: 1, end: 101 });
               });
 
-              it('should not increase start for growing', function () {
+              it('should only increase end for growing window', function () {
                 initialiseRestartableMediaPlayer({}, WindowTypes.GROWING);
                 restartableMediaPlayer.beginPlaybackFrom(0);
                 timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });

--- a/script-test/playbackstrategies/modifiers/live/restartabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/restartabletest.js
@@ -122,9 +122,9 @@ require(
                 timeUpdate = callback;
               });
 
-              initialiseRestartableMediaPlayer();
               restartableMediaPlayer.addEventCallback(this, function () {});
               player.getSeekableRange.and.returnValue({start: 0, end: 100});
+              initialiseRestartableMediaPlayer();
             });
 
             afterEach(function () {

--- a/script-test/playbackstrategies/modifiers/live/restartabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/restartabletest.js
@@ -188,7 +188,7 @@ require(
                 expect(restartableMediaPlayer.getSeekableRange()).toEqual({ start: 1, end: 101 });
               });
 
-              it('should only increase end for growing window', function () {
+              it('should only increase end for a growing window', function () {
                 initialiseRestartableMediaPlayer({}, WindowTypes.GROWING);
                 restartableMediaPlayer.beginPlaybackFrom(0);
                 timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });

--- a/script-test/playbackstrategies/modifiers/live/seekabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/seekabletest.js
@@ -1,12 +1,11 @@
 require(
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
-    'squire'
+    'bigscreenplayer/playbackstrategy/modifiers/live/seekable'
   ],
-    function (MediaPlayerBase, Squire) {
+    function (MediaPlayerBase, SeekableMediaPlayer) {
       var sourceContainer = document.createElement('div');
       var player;
-      var seekableMediaConstructor;
       var seekableMediaPlayer;
 
       function wrapperTests (action, expectedReturn) {
@@ -21,30 +20,17 @@ require(
         }
       }
 
-      function initialiseSeekableMediaPlayer (config, logger) {
-        seekableMediaPlayer = seekableMediaConstructor(config, logger);
+      function initialiseSeekableMediaPlayer (config) {
+        seekableMediaPlayer = SeekableMediaPlayer(player, config);
       }
 
       describe('Seekable HMTL5 Live Player', function () {
-        beforeEach(function (done) {
-          var injector = new Squire();
-
+        beforeEach(function () {
           player = jasmine.createSpyObj('player',
             ['beginPlayback', 'initialiseMedia', 'stop', 'reset', 'getState', 'getSource', 'getMimeType',
               'addEventCallback', 'removeEventCallback', 'removeAllEventCallbacks', 'getPlayerElement', 'pause',
               'resume', 'beginPlaybackFrom', 'playFrom', 'getCurrentTime', 'getSeekableRange', 'toPaused',
               'toPlaying']);
-
-          function mockMediaPlayer () {
-            return player;
-          }
-
-          injector.mock({'bigscreenplayer/playbackstrategy/modifiers/html5': mockMediaPlayer});
-
-          injector.require(['bigscreenplayer/playbackstrategy/modifiers/live/seekable'], function (seekableMediaPlayer) {
-            seekableMediaConstructor = seekableMediaPlayer;
-            done();
-          });
         });
 
         describe('methods call the appropriate media player methods', function () {

--- a/script-test/playbackstrategies/nativestrategytest.js
+++ b/script-test/playbackstrategies/nativestrategytest.js
@@ -27,6 +27,7 @@ require(
           mockDevice = jasmine.createSpyObj('mockDevice', ['getConfig', 'getLogger']);
 
           mockLegacyAdapter = jasmine.createSpy('LegacyAdapter');
+          mediaPlayer = jasmine.createSpy('MediaPlayer');
           html5player = jasmine.createSpy('Html5Player');
           livePlayer = jasmine.createSpy('LivePlayer');
 
@@ -70,8 +71,8 @@ require(
           var windowType = WindowTypes.GROWING;
           nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
 
-          expect(html5player).toHaveBeenCalledWith(mockLogger, false, WindowTypes.GROWING, 'timeData');
-          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig);
+          expect(html5player).toHaveBeenCalledWith(mockLogger);
+          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.GROWING, 'timeData');
 
           expect(mockLegacyAdapter).toHaveBeenCalledWith(windowType, mediaKind, timeData, playbackElement, isUHD, mockConfig, mediaPlayer);
         });
@@ -80,19 +81,8 @@ require(
           var windowType = WindowTypes.SLIDING;
           nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
 
-          expect(html5player).toHaveBeenCalledWith(mockLogger, false, WindowTypes.SLIDING, 'timeData');
-          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig);
-
-          expect(mockLegacyAdapter).toHaveBeenCalledWith(windowType, mediaKind, timeData, playbackElement, isUHD, mockConfig, mediaPlayer);
-        });
-
-        it('calls LegacyAdapter with useFakeTime if live support is RESTARTABLE', function () {
-          var windowType = WindowTypes.SLIDING;
-          window.bigscreenPlayer.liveSupport = LiveSupport.RESTARTABLE;
-          nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
-
-          expect(html5player).toHaveBeenCalledWith(mockLogger, true, WindowTypes.SLIDING, 'timeData');
-          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig);
+          expect(html5player).toHaveBeenCalledWith(mockLogger);
+          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.SLIDING, 'timeData');
 
           expect(mockLegacyAdapter).toHaveBeenCalledWith(windowType, mediaKind, timeData, playbackElement, isUHD, mockConfig, mediaPlayer);
         });

--- a/script-test/playbackstrategies/nativestrategytest.js
+++ b/script-test/playbackstrategies/nativestrategytest.js
@@ -65,7 +65,7 @@ require(
           var windowType = WindowTypes.GROWING;
           nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
 
-          expect(livePlayer).toHaveBeenCalledWith(mockConfig, mockLogger);
+          expect(livePlayer).toHaveBeenCalledWith(mockConfig, mockLogger, WindowTypes.GROWING, 'timeData');
 
           expect(mockLegacyAdapter).toHaveBeenCalledWith(windowType, mediaKind, timeData, playbackElement, isUHD, mockConfig, mediaPlayer);
         });
@@ -74,7 +74,7 @@ require(
           var windowType = WindowTypes.SLIDING;
           nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
 
-          expect(livePlayer).toHaveBeenCalledWith(mockConfig, mockLogger);
+          expect(livePlayer).toHaveBeenCalledWith(mockConfig, mockLogger, WindowTypes.SLIDING, 'timeData');
 
           expect(mockLegacyAdapter).toHaveBeenCalledWith(windowType, mediaKind, timeData, playbackElement, isUHD, mockConfig, mediaPlayer);
         });

--- a/script-test/playbackstrategies/nativestrategytest.js
+++ b/script-test/playbackstrategies/nativestrategytest.js
@@ -72,7 +72,7 @@ require(
           nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
 
           expect(html5player).toHaveBeenCalledWith(mockLogger);
-          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.GROWING);
+          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.GROWING, timeData);
 
           expect(mockLegacyAdapter).toHaveBeenCalledWith(windowType, mediaKind, timeData, playbackElement, isUHD, mockConfig, mediaPlayer);
         });
@@ -82,7 +82,7 @@ require(
           nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
 
           expect(html5player).toHaveBeenCalledWith(mockLogger);
-          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.SLIDING);
+          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.SLIDING, timeData);
 
           expect(mockLegacyAdapter).toHaveBeenCalledWith(windowType, mediaKind, timeData, playbackElement, isUHD, mockConfig, mediaPlayer);
         });

--- a/script-test/playbackstrategies/nativestrategytest.js
+++ b/script-test/playbackstrategies/nativestrategytest.js
@@ -1,9 +1,10 @@
 require(
   [
     'bigscreenplayer/models/windowtypes',
+    'bigscreenplayer/models/livesupport',
     'squire'
   ],
-    function (WindowTypes, Squire) {
+    function (WindowTypes, LiveSupport, Squire) {
       describe('Native Strategy', function () {
         var nativeStrategy;
         var html5player;
@@ -52,6 +53,10 @@ require(
           });
         });
 
+        afterEach(function () {
+          window.bigscreenPlayer.liveSupport = LiveSupport.PLAYABLE;
+        });
+
         it('calls LegacyAdapter with a static media player when called for STATIC window', function () {
           var windowType = WindowTypes.STATIC;
           nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
@@ -65,7 +70,8 @@ require(
           var windowType = WindowTypes.GROWING;
           nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
 
-          expect(livePlayer).toHaveBeenCalledWith(mockConfig, mockLogger, WindowTypes.GROWING, 'timeData');
+          expect(html5player).toHaveBeenCalledWith(mockLogger, false, WindowTypes.GROWING, 'timeData');
+          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig);
 
           expect(mockLegacyAdapter).toHaveBeenCalledWith(windowType, mediaKind, timeData, playbackElement, isUHD, mockConfig, mediaPlayer);
         });
@@ -74,10 +80,21 @@ require(
           var windowType = WindowTypes.SLIDING;
           nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
 
-          expect(livePlayer).toHaveBeenCalledWith(mockConfig, mockLogger, WindowTypes.SLIDING, 'timeData');
+          expect(html5player).toHaveBeenCalledWith(mockLogger, false, WindowTypes.SLIDING, 'timeData');
+          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig);
+
+          expect(mockLegacyAdapter).toHaveBeenCalledWith(windowType, mediaKind, timeData, playbackElement, isUHD, mockConfig, mediaPlayer);
+        });
+
+        it('calls LegacyAdapter with useFakeTime if live support is RESTARTABLE', function () {
+          var windowType = WindowTypes.SLIDING;
+          window.bigscreenPlayer.liveSupport = LiveSupport.RESTARTABLE;
+          nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
+
+          expect(html5player).toHaveBeenCalledWith(mockLogger, true, WindowTypes.SLIDING, 'timeData');
+          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig);
 
           expect(mockLegacyAdapter).toHaveBeenCalledWith(windowType, mediaKind, timeData, playbackElement, isUHD, mockConfig, mediaPlayer);
         });
       });
     });
-

--- a/script-test/playbackstrategies/nativestrategytest.js
+++ b/script-test/playbackstrategies/nativestrategytest.js
@@ -72,7 +72,7 @@ require(
           nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
 
           expect(html5player).toHaveBeenCalledWith(mockLogger);
-          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.GROWING, 'timeData');
+          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.GROWING);
 
           expect(mockLegacyAdapter).toHaveBeenCalledWith(windowType, mediaKind, timeData, playbackElement, isUHD, mockConfig, mediaPlayer);
         });
@@ -82,7 +82,7 @@ require(
           nativeStrategy(windowType, mediaKind, timeData, playbackElement, isUHD, mockDevice);
 
           expect(html5player).toHaveBeenCalledWith(mockLogger);
-          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.SLIDING, 'timeData');
+          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.SLIDING);
 
           expect(mockLegacyAdapter).toHaveBeenCalledWith(windowType, mediaKind, timeData, playbackElement, isUHD, mockConfig, mediaPlayer);
         });

--- a/script-test/playercomponenttest.js
+++ b/script-test/playercomponenttest.js
@@ -294,6 +294,15 @@ require(
       });
 
       describe('setCurrentTime', function () {
+        var currentStrategy;
+        beforeEach(function () {
+          currentStrategy = window.bigscreenPlayer.playbackStrategy;
+        });
+
+        afterEach(function () {
+          window.bigscreenPlayer.playbackStrategy = currentStrategy;
+        });
+
         it('should setCurrentTime on the strategy when in a seekable state', function () {
           setUpPlayerComponent();
 
@@ -305,10 +314,12 @@ require(
         });
 
         it('should reload the element if restartable', function () {
+          window.bigscreenPlayer.playbackStrategy = 'nativestrategy';
           liveSupport = LiveSupport.RESTARTABLE;
           setUpPlayerComponent({ windowType: WindowTypes.SLIDING });
 
           spyOn(mockStrategy, 'load');
+          spyOn(mockStrategy, 'getSeekableRange').and.returnValue({start: 0, end: 100});
           playerComponent.setCurrentTime(10);
 
           expect(mockStrategy.load).toHaveBeenCalledWith([{ url: 'a', cdn: 'cdn-a' }], 'application/dash+xml', 10);

--- a/script-test/playercomponenttest.js
+++ b/script-test/playercomponenttest.js
@@ -303,6 +303,16 @@ require(
 
           expect(mockStrategy.setCurrentTime).toHaveBeenCalledWith(10);
         });
+
+        it('should reload the element if restartable', function () {
+          liveSupport = LiveSupport.RESTARTABLE;
+          setUpPlayerComponent({ windowType: WindowTypes.SLIDING });
+
+          spyOn(mockStrategy, 'load');
+          playerComponent.setCurrentTime(10);
+
+          expect(mockStrategy.load).toHaveBeenCalledWith([{ url: 'a', cdn: 'cdn-a' }], 'application/dash+xml', 10);
+        });
       });
 
       describe('events', function () {

--- a/script/dynamicwindowutils.js
+++ b/script/dynamicwindowutils.js
@@ -42,7 +42,7 @@ define(
     }
 
     function supportsSeeking (liveSupport) {
-      return liveSupport === LiveSupport.SEEKABLE;
+      return liveSupport === LiveSupport.SEEKABLE || LiveSupport.RESTARTABLE;
     }
 
     return {

--- a/script/dynamicwindowutils.js
+++ b/script/dynamicwindowutils.js
@@ -42,7 +42,9 @@ define(
     }
 
     function supportsSeeking (liveSupport) {
-      return liveSupport === LiveSupport.SEEKABLE || liveSupport === LiveSupport.RESTARTABLE;
+      return liveSupport === LiveSupport.SEEKABLE ||
+        (liveSupport === LiveSupport.RESTARTABLE &&
+        window.bigscreenPlayer.playbackStrategy === 'nativestrategy');
     }
 
     return {

--- a/script/dynamicwindowutils.js
+++ b/script/dynamicwindowutils.js
@@ -1,10 +1,12 @@
 define(
   'bigscreenplayer/dynamicwindowutils', [
-    'bigscreenplayer/models/livesupport'
+    'bigscreenplayer/models/livesupport',
+    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
   ],
-  function (LiveSupport) {
+  function (LiveSupport, MediaPlayerBase) {
     'use strict';
 
+    var AUTO_RESUME_WINDOW_START_CUSHION_SECONDS = 8;
     var FOUR_MINUTES = 4 * 60;
 
     function convertMilliSecondsToSeconds (timeInMilis) {
@@ -47,7 +49,25 @@ define(
         window.bigscreenPlayer.playbackStrategy === 'nativestrategy');
     }
 
+    function autoResumeAtStartOfRange (currentTime, seekableRange, addEventCallback, removeEventCallback, resume) {
+      var resumeTimeOut = Math.max(0, currentTime - seekableRange.start - AUTO_RESUME_WINDOW_START_CUSHION_SECONDS);
+      var autoResumeTimer = setTimeout(function () {
+        removeEventCallback(undefined, detectIfUnpaused);
+        resume();
+      }, resumeTimeOut * 1000);
+
+      addEventCallback(undefined, detectIfUnpaused);
+
+      function detectIfUnpaused (event) {
+        if (event.state !== MediaPlayerBase.STATE.PAUSED) {
+          removeEventCallback(undefined, detectIfUnpaused);
+          clearTimeout(autoResumeTimer);
+        }
+      }
+    }
+
     return {
+      autoResumeAtStartOfRange: autoResumeAtStartOfRange,
       canPause: canPause,
       canSeek: canSeek
     };

--- a/script/dynamicwindowutils.js
+++ b/script/dynamicwindowutils.js
@@ -42,7 +42,7 @@ define(
     }
 
     function supportsSeeking (liveSupport) {
-      return liveSupport === LiveSupport.SEEKABLE || LiveSupport.RESTARTABLE;
+      return liveSupport === LiveSupport.SEEKABLE || liveSupport === LiveSupport.RESTARTABLE;
     }
 
     return {

--- a/script/playbackstrategy/modifiers/html5.js
+++ b/script/playbackstrategy/modifiers/html5.js
@@ -465,7 +465,9 @@ define(
       }
 
       function getFakeCurrentTimeAndIncrement () {
-        if (!fakeTimer.runningTime) fakeTimer.runningTime = Date.now();
+        if (!fakeTimer.runningTime) {
+          fakeTimer.runningTime = Date.now();
+        }
         var deltaTime = (Date.now() - fakeTimer.runningTime) / 1000;
         fakeTimer.currentTime += deltaTime;
         fakeTimer.runningTime = Date.now();

--- a/script/playbackstrategy/modifiers/html5.js
+++ b/script/playbackstrategy/modifiers/html5.js
@@ -63,6 +63,7 @@ define(
 
       function emitEvent (eventType, eventLabels, useFakeTime) {
         DebugTool.keyValue({key: 'Date.now', value: Date.now()});
+        DebugTool.keyValue({key: 'Date.now iso', value: new Date().toISOString()});
         var event = {
           type: eventType,
           currentTime: useFakeTime ? getFakeCurrentTimeAndIncrement() : getCurrentTime(),
@@ -409,7 +410,6 @@ define(
       }
 
       function onStatus () {
-        console.log('html5::onStatus >>> ', new Date().toISOString());
         if (getState() === MediaPlayerBase.STATE.PLAYING) {
           emitEvent(MediaPlayerBase.EVENT.STATUS, null, true);
         }
@@ -466,13 +466,9 @@ define(
 
       function getFakeCurrentTimeAndIncrement () {
         if (!fakeTimer.runningTime) fakeTimer.runningTime = Date.now();
-        // if (fakeTimer.currentTime === undefined) {
-        //   fakeTimer.currentTime = fakeTimer.cachedStartTime ? fakeTimer.cachedStartTime : 0.1;
-        // }
         var deltaTime = (Date.now() - fakeTimer.runningTime) / 1000;
         fakeTimer.currentTime += deltaTime;
         fakeTimer.runningTime = Date.now();
-        console.log('FakeTime: ', fakeTimer.currentTime, 'Media Element Time: ', mediaElement.currentTime);
 
         if (windowType !== WindowTypes.STATIC) {
           if (windowType === WindowTypes.SLIDING) {
@@ -491,8 +487,6 @@ define(
             break;
 
           default:
-            // if (mediaElement) return mediaElement.currentTime;
-            // if (mediaElement && !useFakeTime) return mediaElement.currentTime;
             return mediaElement && !useFakeTime ? mediaElement.currentTime : fakeTimer.currentTime;
             break;
         }

--- a/script/playbackstrategy/modifiers/html5.js
+++ b/script/playbackstrategy/modifiers/html5.js
@@ -219,7 +219,7 @@ define(
         var currentTime = getCurrentTime();
         var sentinelActionTaken = false;
 
-        if (currentTime === undefined || isNaN(currentTime) || Math.abs(currentTime - sentinelSeekTime) > seekSentinelTolerance) {
+        if (Math.abs(currentTime - sentinelSeekTime) > seekSentinelTolerance) {
           sentinelActionTaken = nextSentinelAttempt(sentinelLimits.seek, function () {
             mediaElement.currentTime = sentinelSeekTime;
             fakeTimer.currentTime = sentinelSeekTime;
@@ -716,6 +716,11 @@ define(
         beginPlayback: function () {
           postBufferingState = MediaPlayerBase.STATE.PLAYING;
           sentinelSeekTime = undefined;
+
+          fakeTimer.window.start = 0;
+          fakeTimer.window.end = (timeData.windowEndTime - timeData.windowStartTime) / 1000;
+          fakeTimer.currentTime = fakeTimer.window.end;
+
           switch (getState()) {
             case MediaPlayerBase.STATE.STOPPED:
               trustZeroes = true;
@@ -736,6 +741,7 @@ define(
 
           fakeTimer.window.start = 0;
           fakeTimer.window.end = (timeData.windowEndTime - timeData.windowStartTime) / 1000;
+          fakeTimer.currentTime = fakeTimer.window.end;
 
           switch (this.getState()) {
             case MediaPlayerBase.STATE.STOPPED:

--- a/script/playbackstrategy/modifiers/html5.js
+++ b/script/playbackstrategy/modifiers/html5.js
@@ -36,15 +36,7 @@ define(
       var sentinelIntervalNumber;
       var lastSentinelTime;
 
-      var fakeTimer = {
-        currentTime: undefined,
-        runningTime: undefined,
-        window: {
-          start: undefined,
-          end: undefined
-        },
-        wasPlaying: false
-      };
+      var fakeTimer = {};
 
       var sentinelLimits = {
         pause: {
@@ -355,7 +347,7 @@ define(
 
       function getSeekableRange () {
         if (useFakeTime) {
-          return fakeTimer.window;
+          return fakeTimer.seekableRange;
         }
         if (mediaElement) {
           if (isReadyToPlayFrom() && mediaElement.seekable && mediaElement.seekable.length > 0) {
@@ -605,7 +597,7 @@ define(
         fakeTimer = {
           currentTime: windowLength,
           runningTime: Date.now(),
-          window: {
+          seekableRange: {
             start: 0,
             end: windowLength
           },
@@ -625,11 +617,11 @@ define(
         }
         fakeTimer.wasPlaying = getState() === MediaPlayerBase.STATE.PLAYING;
 
-        if (windowType !== WindowTypes.STATIC) {
+        if (fakeTimer.seekableRange && windowType !== WindowTypes.STATIC) {
           if (windowType === WindowTypes.SLIDING) {
-            fakeTimer.window.start += deltaTime;
+            fakeTimer.seekableRange.start += deltaTime;
           }
-          fakeTimer.window.end += deltaTime;
+          fakeTimer.seekableRange.end += deltaTime;
         }
       }
 

--- a/script/playbackstrategy/modifiers/html5.js
+++ b/script/playbackstrategy/modifiers/html5.js
@@ -2,9 +2,10 @@ define(
   'bigscreenplayer/playbackstrategy/modifiers/html5',
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
-    'bigscreenplayer/models/windowtypes'
+    'bigscreenplayer/models/windowtypes',
+    'bigscreenplayer/debugger/debugtool'
   ],
-  function (MediaPlayerBase, WindowTypes) {
+  function (MediaPlayerBase, WindowTypes, DebugTool) {
     'use strict';
 
     function Player (logger, useFakeTime, windowType, timeData) {
@@ -61,6 +62,7 @@ define(
       };
 
       function emitEvent (eventType, eventLabels, useFakeTime) {
+        DebugTool.keyValue({key: 'Date.now', value: Date.now()});
         var event = {
           type: eventType,
           currentTime: useFakeTime ? getFakeCurrentTimeAndIncrement() : getCurrentTime(),

--- a/script/playbackstrategy/modifiers/html5.js
+++ b/script/playbackstrategy/modifiers/html5.js
@@ -219,7 +219,7 @@ define(
         var currentTime = getCurrentTime();
         var sentinelActionTaken = false;
 
-        if (currentTime === undefined || Math.abs(currentTime - sentinelSeekTime) > seekSentinelTolerance) {
+        if (currentTime === undefined || isNaN(currentTime) || Math.abs(currentTime - sentinelSeekTime) > seekSentinelTolerance) {
           sentinelActionTaken = nextSentinelAttempt(sentinelLimits.seek, function () {
             mediaElement.currentTime = sentinelSeekTime;
             fakeTimer.currentTime = sentinelSeekTime;
@@ -486,13 +486,10 @@ define(
         switch (getState()) {
           case MediaPlayerBase.STATE.STOPPED:
           case MediaPlayerBase.STATE.ERROR:
-            break;
-
+            return;
           default:
             return mediaElement && !useFakeTime ? mediaElement.currentTime : fakeTimer.currentTime;
-            break;
         }
-        return undefined;
       }
 
       /**

--- a/script/playbackstrategy/modifiers/live/playable.js
+++ b/script/playbackstrategy/modifiers/live/playable.js
@@ -1,13 +1,11 @@
 define(
     'bigscreenplayer/playbackstrategy/modifiers/live/playable',
   [
-    'bigscreenplayer/playbackstrategy/modifiers/html5',
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
   ],
-    function (Html5Player, MediaPlayerBase) {
+    function (MediaPlayerBase) {
       'use strict';
-      function PlayableLivePlayer (deviceConfig, logger) {
-        var mediaPlayer = Html5Player(logger);
+      function PlayableLivePlayer (mediaPlayer) {
         return {
           beginPlayback: function beginPlayback () {
             mediaPlayer.beginPlayback();

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -110,7 +110,7 @@ define(
             var config = deviceConfig;
 
             startTime = Date.now();
-            // fakeTimer.currentTime = (timeData.windowEndTime - timeData.windowStartTime) / 1000;
+            fakeTimer.currentTime = undefined;
 
             addEventCallback(this, updateFakeTimer);
 

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -3,9 +3,10 @@ define(
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
     'bigscreenplayer/models/windowtypes',
-    'bigscreenplayer/dynamicwindowutils'
+    'bigscreenplayer/dynamicwindowutils',
+    'bigscreenplayer/debugger/debugtool'
   ],
-    function (MediaPlayerBase, WindowTypes, DynamicWindowUtils) {
+    function (MediaPlayerBase, WindowTypes, DynamicWindowUtils, DebugTool) {
       'use strict';
 
       function RestartableLivePlayer (mediaPlayer, deviceConfig, windowType) {
@@ -18,11 +19,14 @@ define(
         function updateFakeTimer (event) {
           var seekableRange = mediaPlayer.getSeekableRange();
           if (seekableRange && seekableRange.end) {
+            DebugTool.info('Seekable range start: ' + seekableRange.start + ' |||||| Seekable range end: ' + seekableRange.end);
             if (fakeTimer.currentTime === undefined) {
               fakeTimer.currentTime = seekableRange.end - seekableRange.start;
             }
             if (windowLength === undefined) {
+              DebugTool.info('windowLength start: ' + seekableRange.start + ' |||||| windowLength end: ' + seekableRange.end);
               windowLength = seekableRange.end - seekableRange.start;
+              DebugTool.keyValue({key: 'windowLength', value: windowLength});
             }
           }
 

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -1,15 +1,13 @@
 define(
     'bigscreenplayer/playbackstrategy/modifiers/live/restartable',
   [
-    'bigscreenplayer/playbackstrategy/modifiers/html5',
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
   ],
-    function (Html5Player, MediaPlayerBase) {
+    function (MediaPlayerBase) {
       'use strict';
       var AUTO_RESUME_WINDOW_START_CUSHION_SECONDS = 8;
 
-      function RestartableLivePlayer (deviceConfig, logger, windowType, timeData) {
-        var mediaPlayer = Html5Player(logger, true, windowType, timeData);
+      function RestartableLivePlayer (mediaPlayer, deviceConfig) {
         var self = this;
 
         function autoResumeAtStartOfRange () {

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -1,14 +1,27 @@
 define(
     'bigscreenplayer/playbackstrategy/modifiers/live/restartable',
   [
-    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
+    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
+    'bigscreenplayer/models/windowtypes'
   ],
-    function (MediaPlayerBase) {
+    function (MediaPlayerBase, WindowTypes) {
       'use strict';
       var AUTO_RESUME_WINDOW_START_CUSHION_SECONDS = 8;
 
-      function RestartableLivePlayer (mediaPlayer, deviceConfig) {
+      function RestartableLivePlayer (mediaPlayer, deviceConfig, windowType, timeData) {
         var self = this;
+
+        var callbacksMap = [];
+        var startTime = Date.now();
+        var fakeTimer = {};
+
+        function updateFakeTimer (state) {
+          if (fakeTimer.wasPlaying && fakeTimer.runningTime) {
+            fakeTimer.currentTime += (Date.now() - fakeTimer.runningTime) / 1000;
+          }
+          fakeTimer.runningTime = Date.now();
+          fakeTimer.wasPlaying = state === MediaPlayerBase.STATE.PLAYING;
+        }
 
         function autoResumeAtStartOfRange () {
           var resumeTimeOut = Math.max(0, getCurrentTime() - getSeekableRange().start - AUTO_RESUME_WINDOW_START_CUSHION_SECONDS);
@@ -28,11 +41,27 @@ define(
         }
 
         function addEventCallback (thisArg, callback) {
-          mediaPlayer.addEventCallback(thisArg, callback);
+          function newCallback (event) {
+            updateFakeTimer(event.state);
+
+            event.currentTime = getCurrentTime();
+            event.seekableRange = getSeekableRange();
+            callback(event);
+          }
+          callbacksMap.push({ from: callback, to: newCallback });
+          mediaPlayer.addEventCallback(thisArg, newCallback);
         }
 
         function removeEventCallback (thisArg, callback) {
-          mediaPlayer.removeEventCallback(thisArg, callback);
+          var filteredCallbacks = callbacksMap.filter(function (cb) {
+            return cb.from === callback;
+          });
+
+          if (filteredCallbacks.length > 0) {
+            callbacksMap = callbacksMap.splice(callbacksMap.indexOf(filteredCallbacks[0]));
+
+            mediaPlayer.removeEventCallback(thisArg, filteredCallbacks[0].to);
+          }
         }
 
         function removeAllEventCallbacks () {
@@ -52,16 +81,23 @@ define(
         }
 
         function getCurrentTime () {
-          return mediaPlayer.getCurrentTime();
+          return fakeTimer.currentTime;
         }
 
         function getSeekableRange () {
-          return mediaPlayer.getSeekableRange();
+          var windowLength = (timeData.windowEndTime - timeData.windowStartTime) / 1000;
+          var delta = (Date.now() - startTime) / 1000;
+          return {
+            start: windowType === WindowTypes.SLIDING ? delta : 0,
+            end: windowLength + delta
+          };
         }
 
         return {
           beginPlayback: function () {
             var config = deviceConfig;
+
+            fakeTimer.currentTime = (timeData.windowEndTime - timeData.windowStartTime) / 1000;
 
             if (config && config.streaming && config.streaming.overrides && config.streaming.overrides.forceBeginPlaybackToEndOfWindow) {
               mediaPlayer.beginPlaybackFrom(Infinity);
@@ -71,6 +107,7 @@ define(
           },
 
           beginPlaybackFrom: function (offset) {
+            fakeTimer.currentTime = offset;
             mediaPlayer.beginPlaybackFrom(offset);
           },
 

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -97,6 +97,7 @@ define(
           beginPlayback: function () {
             var config = deviceConfig;
 
+            startTime = Date.now();
             fakeTimer.currentTime = (timeData.windowEndTime - timeData.windowStartTime) / 1000;
 
             if (config && config.streaming && config.streaming.overrides && config.streaming.overrides.forceBeginPlaybackToEndOfWindow) {
@@ -107,6 +108,7 @@ define(
           },
 
           beginPlaybackFrom: function (offset) {
+            startTime = Date.now();
             fakeTimer.currentTime = offset;
             mediaPlayer.beginPlaybackFrom(offset);
           },

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -13,6 +13,7 @@ define(
         var startTime;
         var fakeTimer = {};
         var windowLength;
+        addEventCallback(this, updateFakeTimer);
 
         function updateFakeTimer (event) {
           var seekableRange = mediaPlayer.getSeekableRange();
@@ -93,8 +94,6 @@ define(
             startTime = Date.now();
             fakeTimer.currentTime = undefined;
 
-            addEventCallback(this, updateFakeTimer);
-
             if (config && config.streaming && config.streaming.overrides && config.streaming.overrides.forceBeginPlaybackToEndOfWindow) {
               mediaPlayer.beginPlaybackFrom(Infinity);
             } else {
@@ -105,7 +104,6 @@ define(
           beginPlaybackFrom: function (offset) {
             startTime = Date.now();
             fakeTimer.currentTime = offset;
-            addEventCallback(this, updateFakeTimer);
             mediaPlayer.beginPlaybackFrom(offset);
           },
 

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -2,15 +2,13 @@ define(
     'bigscreenplayer/playbackstrategy/modifiers/live/restartable',
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
-    'bigscreenplayer/models/windowtypes'
+    'bigscreenplayer/models/windowtypes',
+    'bigscreenplayer/dynamicwindowutils'
   ],
-    function (MediaPlayerBase, WindowTypes) {
+    function (MediaPlayerBase, WindowTypes, DynamicWindowUtils) {
       'use strict';
-      var AUTO_RESUME_WINDOW_START_CUSHION_SECONDS = 8;
 
       function RestartableLivePlayer (mediaPlayer, deviceConfig, windowType) {
-        var self = this;
-
         var callbacksMap = [];
         var startTime;
         var fakeTimer = {};
@@ -33,23 +31,6 @@ define(
 
           fakeTimer.runningTime = Date.now();
           fakeTimer.wasPlaying = event.state === MediaPlayerBase.STATE.PLAYING;
-        }
-
-        function autoResumeAtStartOfRange () {
-          var resumeTimeOut = Math.max(0, getCurrentTime() - getSeekableRange().start - AUTO_RESUME_WINDOW_START_CUSHION_SECONDS);
-          var autoResumeTimer = setTimeout(function () {
-            removeEventCallback(self, detectIfUnpaused);
-            resume();
-          }, resumeTimeOut * 1000);
-
-          addEventCallback(self, detectIfUnpaused);
-
-          function detectIfUnpaused (event) {
-            if (event.state !== MediaPlayerBase.STATE.PAUSED) {
-              removeEventCallback(self, detectIfUnpaused);
-              clearTimeout(autoResumeTimer);
-            }
-          }
         }
 
         function addEventCallback (thisArg, callback) {
@@ -86,7 +67,7 @@ define(
           mediaPlayer.pause();
           opts = opts || {};
           if (opts.disableAutoResume !== true) {
-            autoResumeAtStartOfRange();
+            DynamicWindowUtils.autoResumeAtStartOfRange(getCurrentTime(), getSeekableRange(), addEventCallback, removeEventCallback, resume);
           }
         }
 

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -2,14 +2,15 @@ define(
     'bigscreenplayer/playbackstrategy/modifiers/live/restartable',
   [
     'bigscreenplayer/playbackstrategy/modifiers/html5',
-    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
+    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
+    'bigscreenplayer/models/windowtypes'
   ],
-    function (Html5Player, MediaPlayerBase) {
+    function (Html5Player, MediaPlayerBase, WindowTypes) {
       'use strict';
       var AUTO_RESUME_WINDOW_START_CUSHION_MILLISECONDS = 8000;
 
-      function RestartableLivePlayer (deviceConfig, logger) {
-        var mediaPlayer = Html5Player(logger);
+      function RestartableLivePlayer (deviceConfig, logger, timeData) {
+        var mediaPlayer = Html5Player(logger, true, WindowTypes.SLIDING, timeData);
         var millisecondsUntilStartOfWindow;
         var bufferingStarted;
         var self = this;
@@ -159,6 +160,10 @@ define(
 
           getPlayerElement: function () {
             return mediaPlayer.getPlayerElement();
+          },
+
+          getSeekableRange: function getSeekableRange () {
+            return mediaPlayer.getSeekableRange();
           }
 
         };

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -2,15 +2,14 @@ define(
     'bigscreenplayer/playbackstrategy/modifiers/live/restartable',
   [
     'bigscreenplayer/playbackstrategy/modifiers/html5',
-    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
-    'bigscreenplayer/models/windowtypes'
+    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
   ],
-    function (Html5Player, MediaPlayerBase, WindowTypes) {
+    function (Html5Player, MediaPlayerBase) {
       'use strict';
       var AUTO_RESUME_WINDOW_START_CUSHION_MILLISECONDS = 8000;
 
-      function RestartableLivePlayer (deviceConfig, logger, timeData) {
-        var mediaPlayer = Html5Player(logger, true, WindowTypes.SLIDING, timeData);
+      function RestartableLivePlayer (deviceConfig, logger, windowType, timeData) {
+        var mediaPlayer = Html5Player(logger, true, windowType, timeData);
         var millisecondsUntilStartOfWindow;
         var bufferingStarted;
         var self = this;
@@ -160,6 +159,10 @@ define(
 
           getPlayerElement: function () {
             return mediaPlayer.getPlayerElement();
+          },
+
+          getCurrentTime: function getCurrentTime () {
+            return mediaPlayer.getCurrentTime();
           },
 
           getSeekableRange: function getSeekableRange () {

--- a/script/playbackstrategy/modifiers/live/seekable.js
+++ b/script/playbackstrategy/modifiers/live/seekable.js
@@ -1,16 +1,13 @@
 define(
     'bigscreenplayer/playbackstrategy/modifiers/live/seekable',
   [
-    'bigscreenplayer/playbackstrategy/modifiers/html5',
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
   ],
-    function (Html5Player, MediaPlayerBase) {
+    function (MediaPlayerBase) {
       'use strict';
 
-      function SeekableLivePlayer (deviceConfig, logger) {
+      function SeekableLivePlayer (mediaPlayer, deviceConfig) {
         var AUTO_RESUME_WINDOW_START_CUSHION_SECONDS = 8;
-
-        var mediaPlayer = Html5Player(logger);
 
         function addEventCallback (thisArg, callback) {
           mediaPlayer.addEventCallback(thisArg, callback);

--- a/script/playbackstrategy/modifiers/live/seekable.js
+++ b/script/playbackstrategy/modifiers/live/seekable.js
@@ -1,9 +1,10 @@
 define(
     'bigscreenplayer/playbackstrategy/modifiers/live/seekable',
   [
-    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
+    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
+    'bigscreenplayer/dynamicwindowutils'
   ],
-    function (MediaPlayerBase) {
+    function (MediaPlayerBase, DynamicWindowUtils) {
       'use strict';
 
       function SeekableLivePlayer (mediaPlayer, deviceConfig) {
@@ -19,23 +20,6 @@ define(
 
         function removeAllEventCallbacks () {
           mediaPlayer.removeAllEventCallbacks();
-        }
-
-        function autoResumeAtStartOfRange () {
-          var secondsUntilAutoResume = Math.max(0, mediaPlayer.getCurrentTime() - mediaPlayer.getSeekableRange().start - AUTO_RESUME_WINDOW_START_CUSHION_SECONDS);
-          var self = this;
-          var autoResumeTimer = setTimeout(function () {
-            removeEventCallback(self, detectIfUnpaused);
-            resume();
-          }, secondsUntilAutoResume * 1000);
-
-          addEventCallback(self, detectIfUnpaused);
-          function detectIfUnpaused (event) {
-            if (event.state !== MediaPlayerBase.STATE.PAUSED) {
-              removeEventCallback(self, detectIfUnpaused);
-              clearTimeout(autoResumeTimer);
-            }
-          }
         }
 
         function resume () {
@@ -81,7 +65,7 @@ define(
               mediaPlayer.toPlaying();
             } else {
               mediaPlayer.pause();
-              autoResumeAtStartOfRange();
+              DynamicWindowUtils.autoResumeAtStartOfRange(mediaPlayer.getCurrentTime(), mediaPlayer.getSeekableRange(), addEventCallback, removeEventCallback, resume);
             }
           },
           resume: resume,
@@ -126,9 +110,7 @@ define(
 
           getLiveSupport: function getLiveSupport () {
             return MediaPlayerBase.LIVE_SUPPORT.SEEKABLE;
-          },
-
-          autoResumeAtStartOfRange: autoResumeAtStartOfRange
+          }
 
         });
       }

--- a/script/playbackstrategy/nativestrategy.js
+++ b/script/playbackstrategy/nativestrategy.js
@@ -12,7 +12,7 @@ define('bigscreenplayer/playbackstrategy/nativestrategy',
       var tempConfig = device.getConfig();
 
       if (windowType !== WindowTypes.STATIC) {
-        mediaPlayer = LivePlayer(tempConfig, logger);
+        mediaPlayer = LivePlayer(tempConfig, logger, timeData);
       } else {
         mediaPlayer = Html5Player(logger);
       }

--- a/script/playbackstrategy/nativestrategy.js
+++ b/script/playbackstrategy/nativestrategy.js
@@ -13,7 +13,7 @@ define('bigscreenplayer/playbackstrategy/nativestrategy',
 
       mediaPlayer = Html5Player(logger);
       if (windowType !== WindowTypes.STATIC) {
-        mediaPlayer = LivePlayer(mediaPlayer, tempConfig, windowType, timeData);
+        mediaPlayer = LivePlayer(mediaPlayer, tempConfig, windowType);
       }
 
       return LegacyAdapter(windowType, mediaKind, timeData, playbackElement, isUHD, device.getConfig(), mediaPlayer);

--- a/script/playbackstrategy/nativestrategy.js
+++ b/script/playbackstrategy/nativestrategy.js
@@ -3,21 +3,17 @@ define('bigscreenplayer/playbackstrategy/nativestrategy',
     'bigscreenplayer/playbackstrategy/legacyplayeradapter',
     'bigscreenplayer/models/windowtypes',
     'bigscreenplayer/playbackstrategy/modifiers/html5',
-    'bigscreenplayer/playbackstrategy/modifiers/live/' + (window.bigscreenPlayer.liveSupport || 'playable'),
-    'bigscreenplayer/models/livesupport'
+    'bigscreenplayer/playbackstrategy/modifiers/live/' + (window.bigscreenPlayer.liveSupport || 'playable')
   ],
-  function (LegacyAdapter, WindowTypes, Html5Player, LivePlayer, LiveSupport) {
+  function (LegacyAdapter, WindowTypes, Html5Player, LivePlayer) {
     var NativeStrategy = function (windowType, mediaKind, timeData, playbackElement, isUHD, device) {
       var mediaPlayer;
       var logger = device.getLogger();
       var tempConfig = device.getConfig();
 
+      mediaPlayer = Html5Player(logger);
       if (windowType !== WindowTypes.STATIC) {
-        var useFakeTime = window.bigscreenPlayer.liveSupport === LiveSupport.RESTARTABLE;
-        var html5Player = Html5Player(logger, useFakeTime, windowType, timeData);
-        mediaPlayer = LivePlayer(html5Player, tempConfig);
-      } else {
-        mediaPlayer = Html5Player(logger);
+        mediaPlayer = LivePlayer(mediaPlayer, tempConfig, windowType, timeData);
       }
 
       return LegacyAdapter(windowType, mediaKind, timeData, playbackElement, isUHD, device.getConfig(), mediaPlayer);

--- a/script/playbackstrategy/nativestrategy.js
+++ b/script/playbackstrategy/nativestrategy.js
@@ -13,7 +13,7 @@ define('bigscreenplayer/playbackstrategy/nativestrategy',
 
       mediaPlayer = Html5Player(logger);
       if (windowType !== WindowTypes.STATIC) {
-        mediaPlayer = LivePlayer(mediaPlayer, tempConfig, windowType);
+        mediaPlayer = LivePlayer(mediaPlayer, tempConfig, windowType, timeData);
       }
 
       return LegacyAdapter(windowType, mediaKind, timeData, playbackElement, isUHD, device.getConfig(), mediaPlayer);

--- a/script/playbackstrategy/nativestrategy.js
+++ b/script/playbackstrategy/nativestrategy.js
@@ -12,7 +12,7 @@ define('bigscreenplayer/playbackstrategy/nativestrategy',
       var tempConfig = device.getConfig();
 
       if (windowType !== WindowTypes.STATIC) {
-        mediaPlayer = LivePlayer(tempConfig, logger, timeData);
+        mediaPlayer = LivePlayer(tempConfig, logger, windowType, timeData);
       } else {
         mediaPlayer = Html5Player(logger);
       }

--- a/script/playbackstrategy/nativestrategy.js
+++ b/script/playbackstrategy/nativestrategy.js
@@ -3,16 +3,19 @@ define('bigscreenplayer/playbackstrategy/nativestrategy',
     'bigscreenplayer/playbackstrategy/legacyplayeradapter',
     'bigscreenplayer/models/windowtypes',
     'bigscreenplayer/playbackstrategy/modifiers/html5',
-    'bigscreenplayer/playbackstrategy/modifiers/live/' + (window.bigscreenPlayer.liveSupport || 'playable')
+    'bigscreenplayer/playbackstrategy/modifiers/live/' + (window.bigscreenPlayer.liveSupport || 'playable'),
+    'bigscreenplayer/models/livesupport'
   ],
-  function (LegacyAdapter, WindowTypes, Html5Player, LivePlayer) {
+  function (LegacyAdapter, WindowTypes, Html5Player, LivePlayer, LiveSupport) {
     var NativeStrategy = function (windowType, mediaKind, timeData, playbackElement, isUHD, device) {
       var mediaPlayer;
       var logger = device.getLogger();
       var tempConfig = device.getConfig();
 
       if (windowType !== WindowTypes.STATIC) {
-        mediaPlayer = LivePlayer(tempConfig, logger, windowType, timeData);
+        var useFakeTime = window.bigscreenPlayer.liveSupport === LiveSupport.RESTARTABLE;
+        var html5Player = Html5Player(logger, useFakeTime, windowType, timeData);
+        mediaPlayer = LivePlayer(html5Player, tempConfig);
       } else {
         mediaPlayer = Html5Player(logger);
       }

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -127,7 +127,7 @@ define(
       function setCurrentTime (time) {
         userInteracted = true;
         if (transitions().canBeginSeek()) {
-          if (windowType !== WindowTypes.STATIC && getLiveSupport(device) === LiveSupport.RESTARTABLE) {
+          if (windowType !== WindowTypes.STATIC && getLiveSupport(device) === LiveSupport.RESTARTABLE && window.bigscreenPlayer.playbackStrategy === 'nativestrategy') {
             reloadMediaElement(time);
           } else {
             playbackStrategy.setCurrentTime(time);
@@ -138,8 +138,9 @@ define(
       function reloadMediaElement (time) {
         function doSeek (time) {
           var thenPause = playbackStrategy.isPaused();
+          var seekableRange = playbackStrategy.getSeekableRange();
           tearDownMediaElement();
-          if (time > (bigscreenPlayerData.time.windowEndTime - bigscreenPlayerData.time.windowStartTime) / 1000 - 30) {
+          if (time > seekableRange.end - seekableRange.start) {
             time = undefined;
           }
           loadMedia(mediaMetaData.urls, mediaMetaData.type, time, thenPause);

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -139,7 +139,7 @@ define(
         function doSeek (time) {
           var thenPause = playbackStrategy.isPaused();
           tearDownMediaElement();
-          if (time > (bigscreenPlayerData.time.windowEndTime - bigscreenPlayerData.time.windowStartTime) / 1000 - 10) {
+          if (time > (bigscreenPlayerData.time.windowEndTime - bigscreenPlayerData.time.windowStartTime) / 1000 - 30) {
             time = undefined;
           }
           loadMedia(mediaMetaData.urls, mediaMetaData.type, time, thenPause);

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -13,9 +13,10 @@ define(
     'bigscreenplayer/manifest/manifestloader',
     'bigscreenplayer/utils/livesupportutils',
     'bigscreenplayer/mediaresilience',
-    'bigscreenplayer/debugger/cdndebugoutput'
+    'bigscreenplayer/debugger/cdndebugoutput',
+    'bigscreenplayer/models/livesupport'
   ],
-  function (MediaState, CaptionsContainer, PlaybackStrategy, WindowTypes, PlaybackUtils, PluginData, PluginEnums, Plugins, DebugTool, TransferFormats, ManifestLoader, LiveSupportUtils, MediaResilience, CdnDebugOutput) {
+  function (MediaState, CaptionsContainer, PlaybackStrategy, WindowTypes, PlaybackUtils, PluginData, PluginEnums, Plugins, DebugTool, TransferFormats, ManifestLoader, LiveSupportUtils, MediaResilience, CdnDebugOutput, LiveSupport) {
     'use strict';
 
     var PlayerComponent = function (playbackElement, bigscreenPlayerData, windowType, enableSubtitles, callback, device) {
@@ -126,7 +127,39 @@ define(
       function setCurrentTime (time) {
         userInteracted = true;
         if (transitions().canBeginSeek()) {
-          playbackStrategy.setCurrentTime(time);
+          if (windowType !== WindowTypes.STATIC && getLiveSupport(device) === LiveSupport.RESTARTABLE) {
+            failoverStyleSeek(time);
+          } else {
+            playbackStrategy.setCurrentTime(time);
+          }
+        }
+      }
+
+      function failoverStyleSeek (time) {
+        function doSeek (time) {
+          var thenPause = playbackStrategy.isPaused();
+          tearDownMediaElement();
+          loadMedia(mediaMetaData.urls, mediaMetaData.type, time, thenPause);
+        }
+
+        if (transferFormat === TransferFormats.HLS && LiveSupportUtils.needToGetManifest(windowType, getLiveSupport(device))) {
+          ManifestLoader.load(
+            bigscreenPlayerData.media.urls,
+            bigscreenPlayerData.serverDate,
+            {
+              onSuccess: function (manifestData) {
+                var windowOffset = manifestData.time.windowStartTime - getWindowStartTime();
+                bigscreenPlayerData.time = manifestData.time;
+                time -= windowOffset / 1000;
+                doSeek(time);
+              },
+              onError: function (e) {
+                // handle error; 04002?
+              }
+            }
+          );
+        } else {
+          doSeek(time);
         }
       }
 

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -128,20 +128,20 @@ define(
         userInteracted = true;
         if (transitions().canBeginSeek()) {
           if (windowType !== WindowTypes.STATIC && getLiveSupport(device) === LiveSupport.RESTARTABLE) {
-            failoverStyleSeek(time);
+            reloadMediaElement(time);
           } else {
             playbackStrategy.setCurrentTime(time);
           }
         }
       }
 
-      function failoverStyleSeek (time) {
+      function reloadMediaElement (time) {
         function doSeek (time) {
-          var thenPause = playbackStrategy.isPaused();
-          tearDownMediaElement();
           loadMedia(mediaMetaData.urls, mediaMetaData.type, time, thenPause);
         }
 
+        var thenPause = playbackStrategy.isPaused();
+        tearDownMediaElement();
         if (transferFormat === TransferFormats.HLS && LiveSupportUtils.needToGetManifest(windowType, getLiveSupport(device))) {
           ManifestLoader.load(
             bigscreenPlayerData.media.urls,
@@ -153,8 +153,8 @@ define(
                 time -= windowOffset / 1000;
                 doSeek(time);
               },
-              onError: function (e) {
-                // handle error; 04002?
+              onError: function (event) {
+                bubbleFatalError(createPlaybackErrorProperties(event), false);
               }
             }
           );

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -139,7 +139,7 @@ define(
         function doSeek (time) {
           var thenPause = playbackStrategy.isPaused();
           tearDownMediaElement();
-          if (time > (bigscreenPlayerData.time.windowEndTime - bigscreenPlayerData.time.windowStartTime) / 1000) {
+          if (time > (bigscreenPlayerData.time.windowEndTime - bigscreenPlayerData.time.windowStartTime) / 1000 - 10) {
             time = undefined;
           }
           loadMedia(mediaMetaData.urls, mediaMetaData.type, time, thenPause);

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -139,6 +139,9 @@ define(
         function doSeek (time) {
           var thenPause = playbackStrategy.isPaused();
           tearDownMediaElement();
+          if (time > (bigscreenPlayerData.time.windowEndTime - bigscreenPlayerData.time.windowStartTime) / 1000) {
+            time = undefined;
+          }
           loadMedia(mediaMetaData.urls, mediaMetaData.type, time, thenPause);
         }
         var errorCallback = function () {

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -136,13 +136,13 @@ define(
       }
 
       function reloadMediaElement (time) {
-        var thenPause = playbackStrategy.isPaused();
-        tearDownMediaElement();
-
         function doSeek (time) {
+          var thenPause = playbackStrategy.isPaused();
+          tearDownMediaElement();
           loadMedia(mediaMetaData.urls, mediaMetaData.type, time, thenPause);
         }
         var errorCallback = function () {
+          tearDownMediaElement();
           bubbleFatalError(createPlaybackErrorProperties(event), false);
         };
 

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -140,7 +140,7 @@ define(
           var thenPause = playbackStrategy.isPaused();
           var seekableRange = playbackStrategy.getSeekableRange();
           tearDownMediaElement();
-          if (time > seekableRange.end - seekableRange.start) {
+          if (time > seekableRange.end - seekableRange.start - 30) {
             time = undefined;
           }
           loadMedia(mediaMetaData.urls, mediaMetaData.type, time, thenPause);

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -142,6 +142,7 @@ define(
           tearDownMediaElement();
           if (time > seekableRange.end - seekableRange.start - 30) {
             time = undefined;
+            thenPause = false;
           }
           loadMedia(mediaMetaData.urls, mediaMetaData.type, time, thenPause);
         }

--- a/spec/support/boot.js
+++ b/spec/support/boot.js
@@ -74,7 +74,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   var filterSpecs = !!queryString.getParam('spec');
 
   // Overrides
-  env.stopOnSpecFailure(true);
+  // env.stopOnSpecFailure(true);
   env.throwOnExpectationFailure(true);
 
   var hideDisabled = queryString.getParam('hideDisabled');


### PR DESCRIPTION
We can simulate seeking by creating a fake version of the current time (and seekable range), and then restarting (complete teardown) the media player to begin playback from the user's input seeking time. This will enable `restartable` devices with unreliable `mediaElement.currentTime` to now have seeking capabilities.