### PR TITLE
Unsupported dash codec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script-test/manifest/manifestmodifiertest.js
+++ b/script-test/manifest/manifestmodifiertest.js
@@ -13,22 +13,31 @@ require(
               AdaptationSet: [
                 {
                   contentType: 'video',
+                  mimeType: 'video/mp4',
                   Representation_asArray: [
                     {
                       bandwidth: 438000,
-                      frameRate: 25
+                      frameRate: 25,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
                     },
                     {
                       bandwidth: 827000,
-                      frameRate: 30
+                      frameRate: 30,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
                     },
                     {
                       bandwidth: 1570000,
-                      frameRate: 50
+                      frameRate: 50,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
                     },
                     {
                       bandwidth: 2812000,
-                      frameRate: 50
+                      frameRate: 50,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
                     }
                   ]
                 },
@@ -57,14 +66,19 @@ require(
               AdaptationSet: [
                 {
                   contentType: 'video',
+                  mimeType: 'video/mp4',
                   Representation_asArray: [
                     {
                       bandwidth: 438000,
-                      frameRate: 25
+                      frameRate: 25,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
                     },
                     {
                       bandwidth: 827000,
-                      frameRate: 30
+                      frameRate: 30,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
                     }
                   ]
                 },
@@ -90,14 +104,19 @@ require(
               AdaptationSet: [
                 {
                   contentType: 'video',
+                  mimeType: 'video/mp4',
                   Representation_asArray: [
                     {
                       bandwidth: 1570000,
-                      frameRate: 50
+                      frameRate: 50,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
                     },
                     {
                       bandwidth: 2812000,
-                      frameRate: 50
+                      frameRate: 50,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
                     }
                   ]
                 },
@@ -123,10 +142,13 @@ require(
               AdaptationSet: [
                 {
                   contentType: 'video',
+                  mimeType: 'video/mp4',
                   Representation_asArray: [
                     {
                       bandwidth: 827000,
-                      frameRate: 30
+                      frameRate: 30,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
                     }
                   ]
                 },
@@ -152,6 +174,7 @@ require(
               AdaptationSet: [
                 {
                   contentType: 'video',
+                  mimeType: 'video/mp4',
                   Representation_asArray: []
                 },
                 {
@@ -166,6 +189,108 @@ require(
             }
           };
           var actualManifest = ManifestModifier.filter(manifest, { maxFps: 10, constantFps: true });
+
+          expect(actualManifest).toEqual(expectedManifest);
+        });
+
+        it('should convert all avc3 codec representations to avc1 when the flag is enabled', function () {
+          var expectedManifest = {
+            Period: {
+              AdaptationSet: [
+                {
+                  contentType: 'video',
+                  mimeType: 'video/mp4',
+                  Representation_asArray: [
+                    {
+                      bandwidth: 438000,
+                      frameRate: 25,
+                      codecs: 'avc1.4D401E',
+                      mimeType: 'video/mp4'
+                    },
+                    {
+                      bandwidth: 827000,
+                      frameRate: 30,
+                      codecs: 'avc1.4D401E',
+                      mimeType: 'video/mp4'
+                    },
+                    {
+                      bandwidth: 1570000,
+                      frameRate: 50,
+                      codecs: 'avc1.4D401E',
+                      mimeType: 'video/mp4'
+                    },
+                    {
+                      bandwidth: 2812000,
+                      frameRate: 50,
+                      codecs: 'avc1.4D401E',
+                      mimeType: 'video/mp4'
+                    }
+                  ]
+                },
+                {
+                  contentType: 'audio',
+                  Representation_asArray: [
+                    {
+                      bandwidth: 128000
+                    }
+                  ]
+                }
+              ]
+            }
+          };
+
+          var actualManifest = ManifestModifier.filter(manifest, {}, true);
+
+          expect(actualManifest).toEqual(expectedManifest);
+        });
+
+        it('should not affect avc3 codec representations the old codec flag is not present', function () {
+          var expectedManifest = {
+            Period: {
+              AdaptationSet: [
+                {
+                  contentType: 'video',
+                  mimeType: 'video/mp4',
+                  Representation_asArray: [
+                    {
+                      bandwidth: 438000,
+                      frameRate: 25,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
+                    },
+                    {
+                      bandwidth: 827000,
+                      frameRate: 30,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
+                    },
+                    {
+                      bandwidth: 1570000,
+                      frameRate: 50,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
+                    },
+                    {
+                      bandwidth: 2812000,
+                      frameRate: 50,
+                      codecs: 'avc3.4D401E',
+                      mimeType: 'video/mp4'
+                    }
+                  ]
+                },
+                {
+                  contentType: 'audio',
+                  Representation_asArray: [
+                    {
+                      bandwidth: 128000
+                    }
+                  ]
+                }
+              ]
+            }
+          };
+
+          var actualManifest = ManifestModifier.filter(manifest, {}, undefined);
 
           expect(actualManifest).toEqual(expectedManifest);
         });

--- a/script/manifest/manifestmodifier.js
+++ b/script/manifest/manifestmodifier.js
@@ -60,13 +60,13 @@ define('bigscreenplayer/manifest/manifestmodifier',
     }
 
     function rewriteDashCodec (manifest) {
-      var periods = manifest.Period_asArray;
+      var periods = manifest.Period_asArray || [manifest.Period];
       if (periods) {
         for (var i = 0; i < periods.length; i++) {
-          var sets = periods[i].AdaptationSet_asArray;
+          var sets = periods[i].AdaptationSet_asArray || periods[i].AdaptationSet;
           if (sets) {
             for (var j = 0; j < sets.length; j++) {
-              var representations = sets[j].Representation_asArray;
+              var representations = sets[j].Representation_asArray || [sets[j].Representation];
               if (representations) {
                 for (var k = 0; k < representations.length; k++) {
                   var rep = representations[k];

--- a/script/manifest/manifestmodifier.js
+++ b/script/manifest/manifestmodifier.js
@@ -2,7 +2,7 @@ define('bigscreenplayer/manifest/manifestmodifier',
   function () {
     'use strict';
 
-    function filter (manifest, representationOptions) {
+    function filter (manifest, representationOptions, oldDashCodecRequired) {
       var constantFps = representationOptions.constantFps;
       var maxFps = representationOptions.maxFps;
 
@@ -23,6 +23,11 @@ define('bigscreenplayer/manifest/manifestmodifier',
           return adaptationSet;
         });
       }
+
+      if (oldDashCodecRequired) {
+        manifest = rewriteDashCodec(manifest);
+      }
+
       return manifest;
     }
 
@@ -46,6 +51,29 @@ define('bigscreenplayer/manifest/manifestmodifier',
       manifest.BaseURL_asArray = baseUrls;
       if (manifest && manifest.Period && manifest.Period.BaseURL) delete manifest.Period.BaseURL;
       if (manifest && manifest.Period && manifest.Period.BaseURL_asArray) delete manifest.Period.BaseURL_asArray;
+    }
+
+    function rewriteDashCodec (manifest) {
+      var periods = manifest.Period_asArray;
+      if (periods) {
+        for (var i = 0; i < periods.length; i++) {
+          var sets = periods[i].AdaptationSet_asArray;
+          if (sets) {
+            for (var j = 0; j < sets.length; j++) {
+              var representations = sets[j].Representation_asArray;
+              if (representations) {
+                for (var k = 0; k < representations.length; k++) {
+                  var rep = representations[k];
+                  if (rep.mimeType === 'video/mp4') {
+                    rep.codecs = rep.codecs.replace('avc3', 'avc1');
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      return manifest;
     }
 
     return {

--- a/script/manifest/manifestmodifier.js
+++ b/script/manifest/manifestmodifier.js
@@ -1,5 +1,8 @@
 define('bigscreenplayer/manifest/manifestmodifier',
-  function () {
+  [
+    'bigscreenplayer/debugger/debugtool'
+  ],
+  function (DebugTool) {
     'use strict';
 
     function filter (manifest, representationOptions, oldDashCodecRequired) {
@@ -25,7 +28,10 @@ define('bigscreenplayer/manifest/manifestmodifier',
       }
 
       if (oldDashCodecRequired) {
+        DebugTool.keyValue({ key: 'Video Container', value: 'avc1' });
         manifest = rewriteDashCodec(manifest);
+      } else {
+        DebugTool.keyValue({ key: 'Video Container', value: 'avc3' });
       }
 
       return manifest;

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -122,7 +122,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
 
         if (event.data) {
           var manifest = event.data;
-          ManifestModifier.filter(manifest, window.bigscreenPlayer.representationOptions || {});
+          ManifestModifier.filter(manifest, window.bigscreenPlayer.representationOptions || {}, window.bigscreenPlayer.oldDashCodecRequired);
           ManifestModifier.generateBaseUrls(manifest, mediaSources);
         }
       }


### PR DESCRIPTION
Added configurable option for reverting all `avc3` video container formats in the dash manifest to `avc1`. This can be set by the option `window.bigscreenPlayer.oldDashCodecRequired`. 