### PR TITLE
Failover on Native-Restartable devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script-test/mediaresiliencetest.js
+++ b/script-test/mediaresiliencetest.js
@@ -42,7 +42,7 @@ require(
           describe('and transfer format is HLS', function () {
             it('should return correct value for live support', function () {
               expect(MediaResilience.shouldFailover(2, 100, 10, LiveSupport.SEEKABLE, WindowTypes.GROWING, TransferFormats.HLS)).toBe(true);
-              expect(MediaResilience.shouldFailover(2, 100, 10, LiveSupport.RESTARTABLE, WindowTypes.GROWING, TransferFormats.HLS)).toBe(false);
+              expect(MediaResilience.shouldFailover(2, 100, 10, LiveSupport.RESTARTABLE, WindowTypes.GROWING, TransferFormats.HLS)).toBe(true);
               expect(MediaResilience.shouldFailover(2, 100, 10, LiveSupport.PLAYABLE, WindowTypes.GROWING, TransferFormats.HLS)).toBe(true);
             });
           });
@@ -60,7 +60,7 @@ require(
           describe('and transfer format is HLS', function () {
             it('should return correct value for live support', function () {
               expect(MediaResilience.shouldFailover(2, 100, 10, LiveSupport.SEEKABLE, WindowTypes.SLIDING, TransferFormats.HLS)).toBe(true);
-              expect(MediaResilience.shouldFailover(2, 100, 10, LiveSupport.RESTARTABLE, WindowTypes.SLIDING, TransferFormats.HLS)).toBe(false);
+              expect(MediaResilience.shouldFailover(2, 100, 10, LiveSupport.RESTARTABLE, WindowTypes.SLIDING, TransferFormats.HLS)).toBe(true);
               expect(MediaResilience.shouldFailover(2, 100, 10, LiveSupport.PLAYABLE, WindowTypes.SLIDING, TransferFormats.HLS)).toBe(true);
             });
           });

--- a/script-test/playbackstrategies/strategypickertest.js
+++ b/script-test/playbackstrategies/strategypickertest.js
@@ -22,56 +22,56 @@ require(
       });
 
       it('Causes MSE Strategy to be picked if there are no configured exceptions', function () {
-        expect(StrategyPicker(WindowTypes.STATIC, !isUHD)).toBe('mseStrategy');
+        expect(StrategyPicker(WindowTypes.STATIC, !isUHD)).toBe('msestrategy');
       });
 
       it('Causes TAL Strategy to be picked if uhd is an exception', function () {
         setWindowBigscreenPlayerConfig({mseExceptions: ['uhd']});
 
-        expect(StrategyPicker(WindowTypes.STATIC, isUHD)).toBe('talStrategy');
+        expect(StrategyPicker(WindowTypes.STATIC, isUHD)).toBe('nativestrategy');
       });
 
       it('Causes MSE Strategy to be picked if uhd is an exception but asset is not UHD', function () {
         setWindowBigscreenPlayerConfig({mseExceptions: ['uhd']});
 
-        expect(StrategyPicker(WindowTypes.STATIC, !isUHD)).toBe('mseStrategy');
+        expect(StrategyPicker(WindowTypes.STATIC, !isUHD)).toBe('msestrategy');
       });
 
       describe('WindowTypes', function () {
         it('Causes MSE Strategy to be picked if asset is STATIC window and there is no exception for staticWindow', function () {
           setWindowBigscreenPlayerConfig({mseExceptions: ['testException']});
 
-          expect(StrategyPicker(WindowTypes.STATIC, !isUHD)).toBe('mseStrategy');
+          expect(StrategyPicker(WindowTypes.STATIC, !isUHD)).toBe('msestrategy');
         });
 
         it('Causes TAL Strategy to be picked if asset is STATIC window and there is an exception for staticWindow', function () {
           setWindowBigscreenPlayerConfig({mseExceptions: ['staticWindow']});
 
-          expect(StrategyPicker(WindowTypes.STATIC, !isUHD)).toBe('talStrategy');
+          expect(StrategyPicker(WindowTypes.STATIC, !isUHD)).toBe('nativestrategy');
         });
 
         it('Causes MSE Strategy to be picked if asset is SLIDING window and there is no exception for slidingWindow', function () {
           setWindowBigscreenPlayerConfig({mseExceptions: ['testException']});
 
-          expect(StrategyPicker(WindowTypes.SLIDING, !isUHD)).toBe('mseStrategy');
+          expect(StrategyPicker(WindowTypes.SLIDING, !isUHD)).toBe('msestrategy');
         });
 
         it('Causes TAL Strategy to be picked if asset is SLIDING window and there is an exception for slidingWindow', function () {
           setWindowBigscreenPlayerConfig({mseExceptions: ['slidingWindow']});
 
-          expect(StrategyPicker(WindowTypes.SLIDING, !isUHD)).toBe('talStrategy');
+          expect(StrategyPicker(WindowTypes.SLIDING, !isUHD)).toBe('nativestrategy');
         });
 
         it('Causes MSE Strategy to be picked if asset is GROWING window and there is no exception for growingWindow', function () {
           setWindowBigscreenPlayerConfig({mseExceptions: ['testException']});
 
-          expect(StrategyPicker(WindowTypes.GROWING, !isUHD)).toBe('mseStrategy');
+          expect(StrategyPicker(WindowTypes.GROWING, !isUHD)).toBe('msestrategy');
         });
 
         it('Causes TAL Strategy to be picked if asset is GROWING and there is an exception for growingWindow', function () {
           setWindowBigscreenPlayerConfig({mseExceptions: ['growingWindow']});
 
-          expect(StrategyPicker(WindowTypes.GROWING, !isUHD)).toBe('talStrategy');
+          expect(StrategyPicker(WindowTypes.GROWING, !isUHD)).toBe('nativestrategy');
         });
       });
     });

--- a/script-test/playercomponenttest.js
+++ b/script-test/playercomponenttest.js
@@ -885,6 +885,7 @@ require(
         var currentTime;
         var type;
         var currentTimeSpy;
+        var currentStrategy;
 
         beforeEach(function () {
           jasmine.clock().install();
@@ -912,9 +913,11 @@ require(
           currentTimeSpy.and.returnValue(currentTime);
           spyOn(mockStrategy, 'getDuration').and.returnValue(100);
           spyOn(mockStrategy, 'getSeekableRange').and.returnValue({start: 0, end: 100});
+          currentStrategy = window.bigscreenPlayer.playbackStrategy;
         });
 
         afterEach(function () {
+          window.bigscreenPlayer.playbackStrategy = currentStrategy;
           jasmine.clock().uninstall();
         });
 
@@ -1007,6 +1010,7 @@ require(
         });
 
         it('should publish a media state update of fatal when failover is disabled', function () {
+          window.bigscreenPlayer.playbackStrategy = 'talstrategy';
           liveSupport = LiveSupport.RESTARTABLE;
           setUpPlayerComponent({multiCdn: true, transferFormat: TransferFormats.HLS, windowType: WindowTypes.GROWING});
 

--- a/script/mediaresilience.js
+++ b/script/mediaresilience.js
@@ -1,17 +1,15 @@
 define(
   'bigscreenplayer/mediaresilience', [
     'bigscreenplayer/models/windowtypes',
-    'bigscreenplayer/models/playbackstrategy',
-    'bigscreenplayer/models/livesupport',
-    'bigscreenplayer/models/transferformats'
+    'bigscreenplayer/models/playbackstrategy'
   ],
-  function (WindowTypes, PlaybackStrategy, LiveSupport, TransferFormats) {
+  function (WindowTypes, PlaybackStrategy) {
     'use strict';
 
     function shouldFailover (remainingUrls, duration, currentTime, liveSupport, windowType, transferFormat) {
       var aboutToEnd = duration && currentTime > duration - 5;
       var shouldStaticFailover = windowType === WindowTypes.STATIC && !aboutToEnd;
-      var shouldLiveFailover = windowType !== WindowTypes.STATIC && window.bigscreenPlayer.playbackStrategy !== PlaybackStrategy.TAL;
+      var shouldLiveFailover = windowType !== WindowTypes.STATIC && window.bigscreenPlayer.playbackStrategy !== PlaybackStrategy.TAL && !window.bigscreenPlayer.disableLiveFailover;
       return remainingUrls > 1 && (shouldStaticFailover || shouldLiveFailover);
     }
 

--- a/script/mediaresilience.js
+++ b/script/mediaresilience.js
@@ -1,16 +1,17 @@
 define(
   'bigscreenplayer/mediaresilience', [
     'bigscreenplayer/models/windowtypes',
+    'bigscreenplayer/models/playbackstrategy',
     'bigscreenplayer/models/livesupport',
     'bigscreenplayer/models/transferformats'
   ],
-  function (WindowTypes, LiveSupport, TransferFormats) {
+  function (WindowTypes, PlaybackStrategy, LiveSupport, TransferFormats) {
     'use strict';
 
     function shouldFailover (remainingUrls, duration, currentTime, liveSupport, windowType, transferFormat) {
       var aboutToEnd = duration && currentTime > duration - 5;
       var shouldStaticFailover = windowType === WindowTypes.STATIC && !aboutToEnd;
-      var shouldLiveFailover = windowType !== WindowTypes.STATIC && (transferFormat === TransferFormats.DASH || liveSupport !== LiveSupport.RESTARTABLE);
+      var shouldLiveFailover = windowType !== WindowTypes.STATIC && window.bigscreenPlayer.playbackStrategy !== PlaybackStrategy.TAL;
       return remainingUrls > 1 && (shouldStaticFailover || shouldLiveFailover);
     }
 

--- a/script/models/playbackstrategy.js
+++ b/script/models/playbackstrategy.js
@@ -1,0 +1,12 @@
+define(
+    'bigscreenplayer/models/playbackstrategy', [],
+    function () {
+      'use strict';
+      return {
+        MSE: 'msestrategy',
+        HYBRID: 'hybridstrategy',
+        NATIVE: 'nativestrategy',
+        TAL: 'talstrategy'
+      };
+    });
+

--- a/script/playbackstrategy/hybridstrategy.js
+++ b/script/playbackstrategy/hybridstrategy.js
@@ -3,13 +3,14 @@ define('bigscreenplayer/playbackstrategy/hybridstrategy',
     'bigscreenplayer/playbackstrategy/nativestrategy',
     'bigscreenplayer/playbackstrategy/msestrategy',
     'bigscreenplayer/playbackstrategy/strategypicker',
-    'bigscreenplayer/models/livesupport'
+    'bigscreenplayer/models/livesupport',
+    'bigscreenplayer/models/playbackstrategy'
   ],
-  function (Native, MSE, StrategyPicker, LiveSupport) {
+  function (Native, MSE, StrategyPicker, LiveSupport, PlaybackStrategy) {
     var HybridStrategy = function (windowType, mediaKind, timeCorrection, videoElement, isUHD, device, cdnDebugOutput) {
       var strategy = StrategyPicker(windowType, isUHD);
 
-      if (strategy === 'mseStrategy') {
+      if (strategy === PlaybackStrategy.MSE) {
         return MSE(windowType, mediaKind, timeCorrection, videoElement, isUHD, device, cdnDebugOutput);
       }
 

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -13,6 +13,7 @@ define(
         var callbacksMap = [];
         var startTime;
         var fakeTimer = {};
+        var timeCorrection = timeData.correction || 0;
         addEventCallback(this, updateFakeTimer);
 
         function updateFakeTimer (event) {
@@ -63,15 +64,15 @@ define(
         }
 
         function getCurrentTime () {
-          return fakeTimer.currentTime;
+          return fakeTimer.currentTime + timeCorrection;
         }
 
         function getSeekableRange () {
           var windowLength = (timeData.windowEndTime - timeData.windowStartTime) / 1000;
           var delta = (Date.now() - startTime) / 1000;
           return {
-            start: windowType === WindowTypes.SLIDING ? delta : 0,
-            end: windowLength + delta
+            start: (windowType === WindowTypes.SLIDING ? delta : 0) + timeCorrection,
+            end: windowLength + delta + timeCorrection
           };
         }
 

--- a/script/playbackstrategy/strategypicker.js
+++ b/script/playbackstrategy/strategypicker.js
@@ -1,19 +1,20 @@
 define('bigscreenplayer/playbackstrategy/strategypicker',
-  function () {
+  [
+    'bigscreenplayer/models/playbackstrategy'
+  ],
+  function (PlaybackStrategy) {
     return function (windowType, isUHD) {
-      var strategy = 'mseStrategy';
-
       var mseExceptions = window.bigscreenPlayer.mseExceptions || [];
 
       if (mseExceptions.indexOf(windowType) !== -1) {
-        strategy = 'talStrategy';
+        return PlaybackStrategy.NATIVE;
       }
 
       if (isUHD && mseExceptions.indexOf('uhd') !== -1) {
-        strategy = 'talStrategy';
+        return PlaybackStrategy.NATIVE;
       }
 
-      return strategy;
+      return PlaybackStrategy.MSE;
     };
   }
 );


### PR DESCRIPTION
Using the `restartable` fake time functionality, we can now allow live CDN failover on `nativestrategy`, `restartable` devices. As part of this work, a configurable window flag (`window.bigscreenPlayer.disableLiveFailover`) can be set to disable live failover for any specific conditions.