### PR TITLE
Add cehtml player to native strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2696,7 +2696,7 @@
     "jasmine": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.2.0.tgz",
-      "integrity": "sha1-s6AYRUeBgFZQ5GV4gD0I58/dez0=",
+      "integrity": "sha512-qv6TZ32r+slrQz8fbx2EhGbD9zlJo3NwPrpLK1nE8inILtZO9Fap52pyHk7mNTh4tG50a+1+tOiWVT3jO5I0Sg==",
       "dev": true,
       "requires": {
         "glob": "^7.0.6",
@@ -2706,7 +2706,7 @@
     "jasmine-core": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.2.1.tgz",
-      "integrity": "sha1-jk/1uGFgPugzQ/K0nu5qD/6WUM4=",
+      "integrity": "sha512-pa9tbBWgU0EE4SWgc85T4sa886ufuQdsgruQANhECYjwqgV4z7Vw/499aCaP8ZH79JDS4vhm8doDG9HO4+e4sA==",
       "dev": true
     },
     "js-tokens": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script-test/playbackstrategies/modifiers/cehtmltests.js
+++ b/script-test/playbackstrategies/modifiers/cehtmltests.js
@@ -1,0 +1,285 @@
+require(
+  [
+    'bigscreenplayer/playbackstrategy/modifiers/cehtml',
+    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
+  ],
+    function (CehtmlMediaPlayer, MediaPlayerBase) {
+      describe('cehtml Base', function () {
+        var player;
+        var mockMediaElement;
+        var sourceContainer;
+
+        beforeEach(function () {
+          jasmine.clock().install();
+          jasmine.clock().mockDate();
+
+          mockMediaElement = jasmine.createSpyObj('mediaElement', ['play', 'seek', 'remove', 'stop']);
+          mockMediaElement.style = {};
+          spyOn(document, 'createElement').and.returnValue(mockMediaElement);
+          spyOn(document, 'getElementsByTagName').and.returnValue([jasmine.createSpyObj('body', ['insertBefore'])]);
+
+          sourceContainer = document.createElement('div');
+
+          player = CehtmlMediaPlayer();
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+        });
+
+        afterEach(function () {
+          jasmine.clock().uninstall();
+        });
+
+        describe('addEventCallback', function () {
+          it('should call the callback on update', function () {
+            var spy = jasmine.createSpy('callback');
+
+            player.addEventCallback(this, spy);
+            player.beginPlayback();
+
+            expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ type: 'buffering' }));
+          });
+        });
+
+        describe('removeEventCallback', function () {
+          it('should remove the callback', function () {
+            var spy = jasmine.createSpy('callback');
+
+            player.addEventCallback(this, spy);
+            player.removeEventCallback(this, spy);
+            player.beginPlayback();
+
+            expect(spy).not.toHaveBeenCalled();
+          });
+        });
+
+        describe('removeAllEventCallbacks', function () {
+          it('should remove all the callbacks', function () {
+            var spy = jasmine.createSpy('callback');
+
+            player.addEventCallback(this, spy);
+            player.removeAllEventCallbacks();
+            player.beginPlayback();
+
+            expect(spy).not.toHaveBeenCalled();
+          });
+        });
+
+        describe('resume', function () {
+          it('should call through to play if paused', function () {
+            player.beginPlayback();
+            mockMediaElement.playState = 1;
+            mockMediaElement.onPlayStateChange();
+            player.pause();
+
+            mockMediaElement.play.calls.reset();
+
+            expect(mockMediaElement.play).not.toHaveBeenCalled();
+
+            player.resume();
+
+            expect(mockMediaElement.play).toHaveBeenCalledWith(1);
+          });
+
+          it('should do nothing if playing', function () {
+            player.beginPlayback();
+            mockMediaElement.playState = 1;
+            mockMediaElement.onPlayStateChange();
+
+            mockMediaElement.play.calls.reset();
+
+            player.resume();
+
+            expect(mockMediaElement.play).not.toHaveBeenCalled();
+          });
+        });
+
+        describe('playFrom', function () {
+          it('should seek to the required time', function () {
+            player.beginPlayback();
+            mockMediaElement.playState = 1;
+            mockMediaElement.onPlayStateChange();
+
+            player.playFrom(10);
+
+            expect(mockMediaElement.seek).toHaveBeenCalledWith(10000);
+          });
+
+          it('should clamp to within the seekable range', function () {
+            player.beginPlayback();
+            mockMediaElement.playState = 1;
+            mockMediaElement.playTime = 10000;
+            mockMediaElement.onPlayStateChange();
+
+            player.playFrom(1000000000);
+
+            expect(mockMediaElement.seek).toHaveBeenCalledWith(8900);
+          });
+        });
+
+        describe('beginPlayback', function () {
+          it('should call play on the media element', function () {
+            player.beginPlayback();
+
+            expect(mockMediaElement.play).toHaveBeenCalledWith(1);
+          });
+
+          it('should not call play if playing', function () {
+            player.beginPlayback();
+
+            mockMediaElement.play.calls.reset();
+
+            player.beginPlayback();
+
+            expect(mockMediaElement.play).not.toHaveBeenCalled();
+          });
+        });
+
+        describe('beginPlaybackFrom', function () {
+          it('should call play and then seek on the media element', function () {
+            player.beginPlaybackFrom(10);
+            mockMediaElement.playState = 1;
+            mockMediaElement.onPlayStateChange();
+
+            expect(mockMediaElement.play).toHaveBeenCalledWith(1);
+            expect(mockMediaElement.seek).toHaveBeenCalledWith(10000);
+          });
+
+          it('should call play or seek if playing', function () {
+            player.beginPlaybackFrom(10);
+            mockMediaElement.playState = 1;
+            mockMediaElement.onPlayStateChange();
+
+            mockMediaElement.play.calls.reset();
+            mockMediaElement.seek.calls.reset();
+
+            player.beginPlaybackFrom(10);
+
+            expect(mockMediaElement.play).not.toHaveBeenCalledWith();
+            expect(mockMediaElement.seek).not.toHaveBeenCalledWith();
+          });
+        });
+
+        describe('pause', function () {
+          it('should call pause on the media element', function () {
+            player.beginPlayback();
+            mockMediaElement.playState = 1;
+            mockMediaElement.onPlayStateChange();
+
+            mockMediaElement.play.calls.reset();
+            player.pause();
+
+            expect(mockMediaElement.play).toHaveBeenCalledWith(0);
+          });
+
+          it('should not call pause if paused', function () {
+            player.beginPlayback();
+            mockMediaElement.playState = 1;
+            mockMediaElement.onPlayStateChange();
+
+            player.pause();
+
+            mockMediaElement.play.calls.reset();
+            player.pause();
+
+            expect(mockMediaElement.play).not.toHaveBeenCalled();
+          });
+        });
+
+        describe('stop', function () {
+          it('should call stop on the media element', function () {
+            player.beginPlayback();
+            player.stop();
+
+            expect(mockMediaElement.stop).toHaveBeenCalledWith();
+          });
+
+          it('should not call stop if playback has not started', function () {
+            player.stop();
+
+            expect(mockMediaElement.stop).not.toHaveBeenCalled();
+          });
+
+          it('should not call stop if already stopped', function () {
+            player.beginPlayback();
+            player.stop();
+
+            mockMediaElement.stop.calls.reset();
+            player.stop();
+
+            expect(mockMediaElement.stop).not.toHaveBeenCalled();
+          });
+        });
+
+        describe('getSource', function () {
+          it('should return the source', function () {
+            expect(player.getSource()).toBe('testUrl');
+          });
+        });
+
+        describe('getMimeType', function () {
+          it('should return the mimeType', function () {
+            expect(player.getMimeType()).toBe('testMimeType');
+          });
+        });
+
+        describe('getSeekableRange', function () {
+          it('should return the seekable range', function () {
+            player.beginPlayback();
+            mockMediaElement.playState = 1;
+            mockMediaElement.playTime = 10000;
+            mockMediaElement.onPlayStateChange();
+
+            expect(player.getSeekableRange()).toEqual({start: 0, end: 10});
+          });
+        });
+
+        describe('getMediaDuration', function () {
+          it('should return the media duration', function () {
+            player.beginPlayback();
+            mockMediaElement.playState = 1;
+            mockMediaElement.playTime = 10000;
+            mockMediaElement.onPlayStateChange();
+
+            expect(player.getMediaDuration()).toEqual(10);
+          });
+        });
+
+        describe('getState', function () {
+          it('should return the state', function () {
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
+            player.beginPlayback();
+            mockMediaElement.playState = 1;
+            mockMediaElement.onPlayStateChange();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+          });
+        });
+
+        describe('getPlayerElement', function () {
+          it('should return the media element', function () {
+            expect(player.getPlayerElement()).toBe(mockMediaElement);
+          });
+        });
+
+        describe('getDuration', function () {
+          it('should retrun the media duration for vod', function () {
+            player.beginPlayback();
+            mockMediaElement.playState = 1;
+            mockMediaElement.playTime = 10000;
+            mockMediaElement.onPlayStateChange();
+
+            expect(player.getDuration()).toBe(10);
+          });
+
+          it('should retrun the inifinty for live', function () {
+            player.reset();
+            player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+            player.beginPlayback();
+            mockMediaElement.playState = 1;
+            mockMediaElement.playTime = 10000;
+            mockMediaElement.onPlayStateChange();
+
+            expect(player.getDuration()).toBe(Infinity);
+          });
+        });
+      });
+    });

--- a/script/playbackstrategy/legacyplayeradapter.js
+++ b/script/playbackstrategy/legacyplayeradapter.js
@@ -243,6 +243,7 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
           };
         },
         load: function (cdns, mimeType, startTime) {
+          DebugTool.info('mediaPlayer = ' + window.bigscreenPlayer.mediaPlayer);
           var source = cdns[0].url;
           setupExitSeekWorkarounds(mimeType);
           isPaused = false;

--- a/script/playbackstrategy/legacyplayeradapter.js
+++ b/script/playbackstrategy/legacyplayeradapter.js
@@ -243,7 +243,6 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
           };
         },
         load: function (cdns, mimeType, startTime) {
-          DebugTool.info('mediaPlayer = ' + window.bigscreenPlayer.mediaPlayer);
           var source = cdns[0].url;
           setupExitSeekWorkarounds(mimeType);
           isPaused = false;

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -1,0 +1,771 @@
+/**
+ * @fileOverview Requirejs module containing device modifier for CEHTML media playback
+ * @preserve Copyright (c) 2013-present British Broadcasting Corporation. All rights reserved.
+ * @license See https://github.com/bbc/tal/blob/master/LICENSE for full licence
+ */
+
+define(
+    'bigscreenplayer/playbackstrategy/modifiers/cehtml',
+  [
+    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
+  ],
+    function (MediaPlayerBase) {
+      'use strict';
+
+      var CURRENT_TIME_TOLERANCE = 1;
+      var CLAMP_OFFSET_FROM_END_OF_RANGE = 1.1;
+
+      var eventCallback;
+      var eventCallbacks = [];
+      var state = MediaPlayerBase.STATE.EMPTY;
+
+      var mediaElement;
+      var sourceElement;
+
+      var trustZeroes = false;
+      var ignoreNextPauseEvent = false;
+      var nearEndOfMedia;
+      var readyToPlayFrom;
+
+      var updateInterval;
+
+      var mediaType;
+      var source;
+      var mimeType;
+
+      var deferSeekingTo;
+      var range;
+
+      var postBufferingState;
+      var targetSeekTime;
+      var seekFinished;
+
+      var count;
+      var timeoutHappened;
+
+      var disableSentinels;
+      var disableSeekSentinel;
+      var hasSentinelTimeChangedWithinTolerance;
+      var enterBufferingSentinelAttemptCount;
+      var sentinelSeekTime;
+      var seekSentinelTolerance;
+      var sentinelInterval;
+      var sentinelIntervalNumber;
+      var lastSentinelTime;
+
+      var timeAtLastSentinelInterval;
+
+      var sentinelLimits = {
+        pause: {
+          maximumAttempts: 2,
+          successEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE,
+          failureEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE,
+          currentAttemptCount: 0
+        },
+        seek: {
+          maximumAttempts: 2,
+          successEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK,
+          failureEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE,
+          currentAttemptCount: 0
+        }
+      };
+
+      function init () {
+        // noop
+      }
+
+      function addEventCallback (thisArg, newCallback) {
+        eventCallback = function (event) {
+          newCallback.call(thisArg, event);
+        };
+        eventCallbacks.push(eventCallback);
+      }
+
+      function removeEventCallback (callback) {
+        var index = eventCallbacks.indexOf(callback);
+        if (index !== -1) {
+          eventCallbacks.splice(index, 1);
+        }
+      }
+
+      function removeAllEventCallbacks () {
+        eventCallbacks = undefined;
+      }
+
+      function emitEvent (eventType, eventLabels) {
+        var event = {
+          type: eventType,
+          currentTime: getCurrentTime(),
+          seekableRange: getSeekableRange(),
+          duration: getDuration(),
+          url: getSource(),
+          mimeType: getMimeType(),
+          state: getState()
+        };
+
+        if (eventLabels) {
+          for (var key in eventLabels) {
+            if (eventLabels.hasOwnProperty(key)) {
+              event[key] = eventLabels[key];
+            }
+          }
+        }
+
+        for (var index = 0; index < eventCallbacks.length; index++) {
+          eventCallbacks[index](event);
+        }
+      }
+
+      function getClampedTime (seconds) {
+        var range = getSeekableRange();
+        var offsetFromEnd = getClampOffsetFromConfig();
+        var nearToEnd = Math.max(range.end - offsetFromEnd, range.start);
+        if (seconds < range.start) {
+          return range.start;
+        } else if (seconds > nearToEnd) {
+          return nearToEnd;
+        } else {
+          return seconds;
+        }
+      }
+
+      function isLiveMedia () {
+        return (mediaType === MediaPlayerBase.TYPE.LIVE_VIDEO) || (mediaType === MediaPlayerBase.TYPE.LIVE_AUDIO);
+      }
+
+      function getSource () {
+        return source;
+      }
+
+      function getMimeType () {
+        return mimeType;
+      }
+
+      function getState () {
+        return state;
+      }
+
+      function generateSourceElement (url, mimeType) {
+        var sourceElement = document.createElement('source');
+        sourceElement.src = url;
+        sourceElement.type = mimeType;
+        return sourceElement;
+      }
+
+      function appendChildElement (to, el) {
+        to.appendChild(el);
+      }
+
+      function prependChildElement (to, el) {
+        if (to.childNodes.length > 0) {
+          to.insertBefore(el, to.childNodes[0]);
+        } else {
+          to.appendChild(el);
+        }
+      }
+
+      function removeElement (el) {
+        if (el.parentNode) {
+          el.parentNode.removeChild(el);
+        }
+      }
+
+      function setSeekSentinelTolerance () {
+        var ON_DEMAND_SEEK_SENTINEL_TOLERANCE = 15;
+        var LIVE_SEEK_SENTINEL_TOLERANCE = 30;
+
+        seekSentinelTolerance = ON_DEMAND_SEEK_SENTINEL_TOLERANCE;
+        if (this._isLiveMedia()) {
+          seekSentinelTolerance = LIVE_SEEK_SENTINEL_TOLERANCE;
+        }
+      }
+
+      function initialiseMedia (type, url, mediaMimeType, sourceContainer, opts) {
+        disableSentinels = opts.disableSentinels;
+        disableSeekSentinel = opts.disableSeekSentinel;
+        mediaType = type;
+        source = url;
+        mimeType = mediaMimeType;
+        opts = opts || {};
+
+        if (getState() === MediaPlayerBase.STATE.EMPTY) {
+          timeAtLastSentinelInterval = 0;
+          setSeekSentinelTolerance();
+          createElement();
+          addElementToDOM();
+          mediaElement.data = source;
+          registerEventHandlers();
+          toStopped();
+        } else {
+          toError('Cannot set source unless in the \'' + MediaPlayerBase.STATE.EMPTY + '\' state');
+        }
+      }
+
+      function resume () {
+        postBufferingState = MediaPlayerBase.STATE.PLAYING;
+        switch (this.getState()) {
+          case MediaPlayerBase.STATE.PLAYING:
+          case MediaPlayerBase.STATE.BUFFERING:
+            break;
+
+          case MediaPlayerBase.STATE.PAUSED:
+            mediaElement.play(1);
+            toPlaying();
+            break;
+
+          default:
+            toError('Cannot resume while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function playFrom (seconds) {
+        postBufferingState = MediaPlayerBase.STATE.PLAYING;
+        sentinelLimits.seek.currentAttemptCount = 0;
+        switch (getState()) {
+          case MediaPlayerBase.STATE.BUFFERING:
+            deferSeekingTo = seconds;
+            break;
+
+          case MediaPlayerBase.STATE.COMPLETE:
+            toBuffering();
+            mediaElement.stop();
+            playAndSetDeferredSeek(seconds);
+            break;
+
+          case MediaPlayerBase.STATE.PLAYING:
+            toBuffering();
+            var seekResult = seekTo(seconds);
+            if (seekResult === false) {
+              toPlaying();
+            }
+            break;
+
+          case MediaPlayerBase.STATE.PAUSED:
+            toBuffering();
+            seekTo(seconds);
+            mediaElement.play(1);
+            break;
+
+          default:
+            toError('Cannot playFrom while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function getDuration () {
+        switch (getState()) {
+          case MediaPlayerBase.STATE.STOPPED:
+          case MediaPlayerBase.STATE.ERROR:
+            return undefined;
+          default:
+            if (isLiveMedia()) {
+              return Infinity;
+            }
+            return getMediaDuration();
+        }
+      }
+
+      function beginPlayback () {
+        postBufferingState = MediaPlayerBase.STATE.PLAYING;
+        switch (getState()) {
+          case MediaPlayerBase.STATE.STOPPED:
+            toBuffering();
+            mediaElement.play(1);
+            break;
+
+          default:
+            toError('Cannot beginPlayback while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function beginPlaybackFrom (seconds) {
+        postBufferingState = MediaPlayerBase.STATE.PLAYING;
+        sentinelLimits.seek.currentAttemptCount = 0;
+
+        switch (this.getState()) {
+          case MediaPlayerBase.STATE.STOPPED:
+                    // Seeking past 0 requires calling play first when media has not been loaded
+            toBuffering();
+            playAndSetDeferredSeek(seconds);
+            break;
+
+          default:
+            toError('Cannot beginPlayback while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function pause () {
+        postBufferingState = MediaPlayerBase.STATE.PAUSED;
+        switch (getState()) {
+          case MediaPlayerBase.STATE.BUFFERING:
+          case MediaPlayerBase.STATE.PAUSED:
+            break;
+
+          case MediaPlayerBase.STATE.PLAYING:
+            mediaElement.play(0);
+            toPaused();
+            break;
+
+          default:
+            toError('Cannot pause while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function stop () {
+        switch (getState()) {
+          case MediaPlayerBase.STATE.STOPPED:
+            break;
+
+          case MediaPlayerBase.STATE.BUFFERING:
+          case MediaPlayerBase.STATE.PLAYING:
+          case MediaPlayerBase.STATE.PAUSED:
+          case MediaPlayerBase.STATE.COMPLETE:
+            sentinelSeekTime = undefined;
+            mediaElement.stop();
+            toStopped();
+            break;
+
+          default:
+            toError('Cannot stop while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function reset () {
+        switch (getState()) {
+          case MediaPlayerBase.STATE.EMPTY:
+            break;
+
+          case MediaPlayerBase.STATE.STOPPED:
+          case MediaPlayerBase.STATE.ERROR:
+            toEmpty();
+            break;
+
+          default:
+            toError('Cannot reset while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function getCurrentTime () {
+        switch (getState()) {
+          case MediaPlayerBase.STATE.STOPPED:
+          case MediaPlayerBase.STATE.ERROR:
+            break;
+
+          case MediaPlayerBase.STATE.COMPLETE:
+            if (range) {
+              return range.end;
+            }
+            break;
+
+          default:
+            if (mediaElement) {
+              return mediaElement.playPosition / 1000;
+            }
+            break;
+        }
+        return undefined;
+      }
+
+      function getSeekableRange () {
+        switch (getState()) {
+          case MediaPlayerBase.STATE.STOPPED:
+          case MediaPlayerBase.STATE.ERROR:
+            break;
+
+          default:
+            return range;
+        }
+        return undefined;
+      }
+
+      function getMediaDuration () {
+        if (range) {
+          return range.end;
+        }
+        return undefined;
+      }
+
+      function getPlayerElement () {
+        return mediaElement;
+      }
+
+      function onFinishedBuffering () {
+        cacheRange();
+
+        if (getState() !== MediaPlayerBase.STATE.BUFFERING) {
+          return;
+        }
+
+        if (waitingToSeek()) {
+          toBuffering();
+          performDeferredSeek();
+        } else if (waitingToPause()) {
+          toPaused();
+          mediaElement.play(0);
+        } else {
+          toPlaying();
+        }
+      }
+
+      function onDeviceError () {
+        reportError('Media element error code: ' + mediaElement.error);
+      }
+
+      function onDeviceBuffering () {
+        if (getState() === MediaPlayerBase.STATE.PLAYING) {
+          toBuffering();
+        }
+      }
+
+      function onEndOfMedia () {
+        if (getState() !== MediaPlayerBase.STATE.COMPLETE) {
+          toComplete();
+        }
+      }
+
+      function onStatus () {
+        if (getState() === MediaPlayerBase.STATE.PLAYING) {
+          emitEvent(MediaPlayerBase.EVENT.STATUS);
+        }
+      }
+
+      function createElement () {
+        var device = RuntimeContext.getDevice();
+        this._mediaElement = device._createElement('object', 'mediaPlayer');
+        this._mediaElement.type = this._mimeType;
+        this._mediaElement.style.position = 'absolute';
+        this._mediaElement.style.top = '0px';
+        this._mediaElement.style.left = '0px';
+        this._mediaElement.style.width = '100%';
+        this._mediaElement.style.height = '100%';
+      }
+
+      function registerEventHandlers () {
+        var DEVICE_UPDATE_PERIOD_MS = 500;
+
+        mediaElement.onPlayStateChange = function () {
+          switch (mediaElement.playState) {
+            case Player.PLAY_STATE_STOPPED:
+              break;
+            case Player.PLAY_STATE_PLAYING:
+              onFinishedBuffering();
+              break;
+            case Player.PLAY_STATE_PAUSED:
+              break;
+            case Player.PLAY_STATE_CONNECTING:
+              break;
+            case Player.PLAY_STATE_BUFFERING:
+              onDeviceBuffering();
+              break;
+            case Player.PLAY_STATE_FINISHED:
+              onEndOfMedia();
+              break;
+            case Player.PLAY_STATE_ERROR:
+              onDeviceError();
+              break;
+            default:
+                      // do nothing
+              break;
+          }
+        };
+
+        this._updateInterval = setInterval(function () {
+          onStatus();
+        }, DEVICE_UPDATE_PERIOD_MS);
+      }
+
+      function addElementToDOM () {
+        var device = RuntimeContext.getDevice();
+        var body = document.getElementsByTagName('body')[0];
+        device.prependChildElement(body, mediaElement);
+      }
+
+      function cacheRange () {
+        if (mediaElement) {
+          range = {
+            start: 0,
+            end: this._mediaElement.playTime / 1000
+          };
+        }
+      }
+
+      function playAndSetDeferredSeek (seconds) {
+        mediaElement.play(1);
+        if (seconds > 0) {
+          deferSeekingTo = seconds;
+        }
+      }
+
+      function waitingToSeek () {
+        return (deferSeekingTo !== undefined);
+      }
+
+      function performDeferredSeek () {
+        seekTo(deferSeekingTo);
+        deferSeekingTo = undefined;
+      }
+
+      function seekTo (seconds) {
+        var clampedTime = getClampedTime(seconds);
+        if (clampedTime !== seconds) {
+          RuntimeContext.getDevice().getLogger().debug('playFrom ' + seconds + ' clamped to ' + clampedTime + ' - seekable range is { start: ' + this._range.start + ', end: ' + this._range.end + ' }');
+        }
+        sentinelSeekTime = clampedTime;
+        return mediaElement.seek(clampedTime * 1000);
+      }
+
+      function waitingToPause () {
+        return (postBufferingState === MediaPlayerBase.STATE.PAUSED);
+      }
+
+      function wipe () {
+        type = undefined;
+        source = undefined;
+        mimeType = undefined;
+        sentinelSeekTime = undefined;
+        range = undefined;
+        if (mediaElement) {
+          clearInterval(updateInterval);
+          clearSentinels();
+          destroyMediaElement();
+        }
+      }
+
+      function destroyMediaElement () {
+        var device = RuntimeContext.getDevice();
+        delete mediaElement.onPlayStateChange;
+        device.removeElement(mediaElement);
+        mediaElement = undefined;
+      }
+
+      function reportError (errorMessage) {
+        RuntimeContext.getDevice().getLogger().error(errorMessage);
+        this._emitEvent(MediaPlayerBase.EVENT.ERROR, {'errorMessage': errorMessage});
+      }
+
+      function toStopped () {
+        state = MediaPlayerBase.STATE.STOPPED;
+        emitEvent(MediaPlayerBase.EVENT.STOPPED);
+        if (sentinelInterval) {
+          clearSentinels();
+        }
+      }
+
+      function toBuffering () {
+        state = MediaPlayerBase.STATE.BUFFERING;
+        emitEvent(MediaPlayerBase.EVENT.BUFFERING);
+        setSentinels([exitBufferingSentinel]);
+      }
+
+      function toPlaying () {
+        state = MediaPlayerBase.STATE.PLAYING;
+        emitEvent(MediaPlayerBase.EVENT.PLAYING);
+        setSentinels([
+          shouldBeSeekedSentinel,
+          enterCompleteSentinel,
+          enterBufferingSentinel
+        ]);
+      }
+
+      function toPaused () {
+        state = MediaPlayerBase.STATE.PAUSED;
+        emitEvent(MediaPlayerBase.EVENT.PAUSED);
+        setSentinels([
+          shouldBePausedSentinel,
+          shouldBeSeekedSentinel
+        ]);
+      }
+
+      function toComplete () {
+        state = MediaPlayerBase.STATE.COMPLETE;
+        emitEvent(MediaPlayerBase.EVENT.COMPLETE);
+        clearSentinels();
+      }
+
+      function toEmpty () {
+        wipe();
+        state = MediaPlayerBase.STATE.EMPTY;
+      }
+
+      function toError (errorMessage) {
+        wipe();
+        state = MediaPlayerBase.STATE.ERROR;
+        reportError(errorMessage);
+      }
+
+      function isNearToEnd (seconds) {
+        return (getDuration() - seconds <= 1);
+      }
+
+      function setSentinels (sentinels) {
+        if (disableSentinels) {
+          return;
+        }
+
+        sentinelLimits.pause.currentAttemptCount = 0;
+        var self = this;
+        timeAtLastSenintelInterval = getCurrentTime();
+        clearSentinels();
+        sentinelIntervalNumber = 0;
+        sentinelInterval = setInterval(function () {
+          var newTime = setCurrentTime();
+          self._sentinelIntervalNumber++;
+
+          timeHasAdvanced = newTime ? (newTime > (timeAtLastSenintelInterval + 0.2)) : false;
+          sentinelTimeIsNearEnd = isNearToEnd(newTime || timeAtLastSenintelInterval);
+
+          for (var i = 0; i < sentinels.length; i++) {
+            var sentinelActionPerformed = sentinels[i].call(self);
+            if (sentinelActionPerformed) {
+              break;
+            }
+          }
+
+          timeAtLastSenintelInterval = newTime;
+        }, 1100);
+      }
+
+      function setSentinelLimits () {
+        sentinelLimits = {
+          pause: {
+            maximumAttempts: 2,
+            successEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE,
+            failureEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE,
+            currentAttemptCount: 0
+          },
+          seek: {
+            maximumAttempts: 2,
+            successEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK,
+            failureEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE,
+            currentAttemptCount: 0
+          }
+        };
+      }
+
+      function clearSentinels () {
+        clearInterval(sentinelInterval);
+      }
+
+      function enterBufferingSentinel () {
+        var sentinelBufferingRequired = !timeHasAdvanced && !sentinelTimeIsNearEnd && (sentinelIntervalNumber > 1);
+        if (sentinelBufferingRequired) {
+          emitEvent(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
+          toBuffering();
+        }
+        return sentinelBufferingRequired;
+      }
+
+      function exitBufferingSentinel () {
+        var sentinelExitBufferingRequired = timeHasAdvanced;
+        if (sentinelExitBufferingRequired) {
+          emitEvent(MediaPlayerBase.EVENT.SENTINEL_EXIT_BUFFERING);
+          onFinishedBuffering();
+        }
+        return sentinelExitBufferingRequired;
+      }
+
+      function shouldBeSeekedSentinel () {
+        if (sentinelSeekTime === undefined) {
+          return false;
+        }
+
+        var currentTime = getCurrentTime();
+
+        var clampedSentinelSeekTime = getClampedTime(sentinelSeekTime);
+
+        var sentinelSeekRequired = Math.abs(clampedSentinelSeekTime - currentTime) > seekSentinelTolerance;
+        var sentinelActionTaken = false;
+
+        if (sentinelSeekRequired) {
+          var mediaElement = mediaElement;
+          sentinelActionTaken = nextSentinelAttempt(sentinelLimits.seek, function () {
+            mediaElement.seek(clampedSentinelSeekTime * 1000);
+          });
+        } else if (sentinelIntervalNumber < 3) {
+          sentinelSeekTime = currentTime;
+        } else {
+          sentinelSeekTime = undefined;
+        }
+        return sentinelActionTaken;
+      }
+
+      function shouldBePausedSentinel () {
+        var sentinelPauseRequired = timeHasAdvanced;
+        var sentinelActionTaken = false;
+        if (sentinelPauseRequired) {
+          var mediaElement = mediaElement;
+          sentinelActionTaken = nextSentinelAttempt(sentinelLimits.pause, function () {
+            mediaElement.play(0);
+          });
+        }
+        return sentinelActionTaken;
+      }
+
+      function enterCompleteSentinel () {
+        var sentinelCompleteRequired = !timeHasAdvanced && sentinelTimeIsNearEnd;
+        if (sentinelCompleteRequired) {
+          emitEvent(MediaPlayerBase.EVENT.SENTINEL_COMPLETE);
+          onEndOfMedia();
+        }
+        return sentinelCompleteRequired;
+      }
+
+      function nextSentinelAttempt (sentinelInfo, attemptFn) {
+        var currentAttemptCount, maxAttemptCount;
+
+        sentinelInfo.currentAttemptCount += 1;
+        currentAttemptCount = sentinelInfo.currentAttemptCount;
+        maxAttemptCount = sentinelInfo.maximumAttempts;
+
+        if (currentAttemptCount === maxAttemptCount + 1) {
+          emitEvent(sentinelInfo.failureEvent);
+        }
+
+        if (currentAttemptCount <= maxAttemptCount) {
+          attemptFn();
+          this._emitEvent(sentinelInfo.successEvent);
+          return true;
+        }
+
+        return false;
+      }
+
+      /**
+       * Main MediaPlayer implementation for CEHTML devices.
+       * Use this device modifier if a device implements the CEHTML media playback standard.
+       * It must support creation of &lt;object&gt; elements for media mime types, and those objects must expose an
+       * API in accordance with the CEHTML specification.
+       * @name antie.devices.mediaplayer.CEHTML
+       * @class
+       * @extends antie.devices.mediaplayer.MediaPlayer
+       */
+      var Player = {
+        init: init,
+        addEventCallback: addEventCallback,
+        removeEventCallback: removeEventCallback,
+        removeAllEventCallbacks: removeAllEventCallbacks,
+        initialiseMedia: initialiseMedia,
+        resume: resume,
+        playFrom: playFrom,
+        beginPlayback: beginPlayback,
+        beginPlaybackFrom: beginPlaybackFrom,
+        pause: pause,
+        stop: stop,
+        reset: resizeTo,
+        getSource: getSource,
+        getMimeType: getMimeType,
+        getSeekableRange: getSeekableRange,
+        getMediaDuration: getMediaDuration,
+        getState: getState,
+        getPlayerElement: getPlayerElement,
+        getDuration: getDuration
+      };
+
+      return Player;
+    });

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -7,9 +7,10 @@
 define(
     'bigscreenplayer/playbackstrategy/modifiers/cehtml',
   [
-    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
+    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
+    'bigscreenplayer/debugger/debugtool'
   ],
-    function (MediaPlayerBase) {
+    function (MediaPlayerBase, DebugTool) {
       'use strict';
       /**
        * Main MediaPlayer implementation for CEHTML devices.
@@ -20,7 +21,7 @@ define(
        * @class
        * @extends antie.devices.mediaplayer.MediaPlayer
        */
-      return function (device) {
+      return function () {
         var CLAMP_OFFSET_FROM_END_OF_RANGE = 1.1;
 
         var eventCallback;
@@ -441,7 +442,7 @@ define(
         }
 
         function createElement () {
-          mediaElement = device._createElement('object', 'mediaPlayer');
+          mediaElement = document.createElement('object', 'mediaPlayer');
           mediaElement.type = mimeType;
           mediaElement.style.position = 'absolute';
           mediaElement.style.top = '0px';
@@ -496,7 +497,7 @@ define(
 
         function addElementToDOM () {
           var body = document.getElementsByTagName('body')[0];
-          device.prependChildElement(body, mediaElement);
+          body.insertBefore(mediaElement, body.firstChild);
         }
 
         function cacheRange () {
@@ -527,7 +528,7 @@ define(
         function seekTo (seconds) {
           var clampedTime = getClampedTime(seconds);
           if (clampedTime !== seconds) {
-            device.getLogger().debug('playFrom ' + seconds + ' clamped to ' + clampedTime + ' - seekable range is { start: ' + range.start + ', end: ' + range.end + ' }');
+            DebugTool.info('playFrom ' + seconds + ' clamped to ' + clampedTime + ' - seekable range is { start: ' + range.start + ', end: ' + range.end + ' }');
           }
           sentinelSeekTime = clampedTime;
           return mediaElement.seek(clampedTime * 1000);
@@ -552,12 +553,12 @@ define(
 
         function destroyMediaElement () {
           delete mediaElement.onPlayStateChange;
-          device.removeElement(mediaElement);
+          mediaElement.remove();
           mediaElement = undefined;
         }
 
         function reportError (errorMessage) {
-          device.getLogger().error(errorMessage);
+          DebugTool.info(errorMessage);
           emitEvent(MediaPlayerBase.EVENT.ERROR, {'errorMessage': errorMessage});
         }
 
@@ -765,7 +766,8 @@ define(
           getMediaDuration: getMediaDuration,
           getState: getState,
           getPlayerElement: getPlayerElement,
-          getDuration: getDuration
+          getDuration: getDuration,
+          toPaused: toPaused
         };
       };
     });

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -187,6 +187,7 @@ define(
         }
 
         function initialiseMedia (type, url, mediaMimeType, sourceContainer, opts) {
+          DebugTool.info('Starting...');
           disableSentinels = opts.disableSentinels;
           mediaType = type;
           source = url;
@@ -538,6 +539,7 @@ define(
         }
 
         function wipe () {
+          DebugTool.info('wipe()');
           mediaType = undefined;
           source = undefined;
           mimeType = undefined;
@@ -546,7 +548,9 @@ define(
           if (mediaElement) {
             clearInterval(updateInterval);
             clearSentinels();
+            DebugTool.info('destroying media element');
             destroyMediaElement();
+            DebugTool.info('destroyed media element');
           }
         }
 

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -6,10 +6,19 @@ define(
   ],
     function (MediaPlayerBase, DebugTool) {
       'use strict';
+      var CLAMP_OFFSET_FROM_END_OF_RANGE = 1.1;
+
+      var STATE = {
+        STOPPED: 0,
+        PLAYING: 1,
+        PAUSED: 2,
+        CONNECTING: 3,
+        BUFFERING: 4,
+        FINISHED: 5,
+        ERROR: 6
+      };
 
       return function () {
-        var CLAMP_OFFSET_FROM_END_OF_RANGE = 1.1;
-
         var eventCallbacks = [];
         var state = MediaPlayerBase.STATE.EMPTY;
 
@@ -415,37 +424,27 @@ define(
           mediaElement.style.height = '100%';
         }
 
-        var states = {
-          PLAY_STATE_STOPPED: 0,
-          PLAY_STATE_PLAYING: 1,
-          PLAY_STATE_PAUSED: 2,
-          PLAY_STATE_CONNECTING: 3,
-          PLAY_STATE_BUFFERING: 4,
-          PLAY_STATE_FINISHED: 5,
-          PLAY_STATE_ERROR: 6
-        };
-
         function registerEventHandlers () {
           var DEVICE_UPDATE_PERIOD_MS = 500;
 
           mediaElement.onPlayStateChange = function () {
             switch (mediaElement.playState) {
-              case states.PLAY_STATE_STOPPED:
+              case STATE.STOPPED:
                 break;
-              case states.PLAY_STATE_PLAYING:
+              case STATE.PLAYING:
                 onFinishedBuffering();
                 break;
-              case states.PLAY_STATE_PAUSED:
+              case STATE.PAUSED:
                 break;
-              case states.PLAY_STATE_CONNECTING:
+              case STATE.CONNECTING:
                 break;
-              case states.PLAY_STATE_BUFFERING:
+              case STATE.BUFFERING:
                 onDeviceBuffering();
                 break;
-              case states.PLAY_STATE_FINISHED:
+              case STATE.FINISHED:
                 onEndOfMedia();
                 break;
-              case states.PLAY_STATE_ERROR:
+              case STATE.ERROR:
                 onDeviceError();
                 break;
               default:

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -1,9 +1,3 @@
-/**
- * @fileOverview Requirejs module containing device modifier for CEHTML media playback
- * @preserve Copyright (c) 2013-present British Broadcasting Corporation. All rights reserved.
- * @license See https://github.com/bbc/tal/blob/master/LICENSE for full licence
- */
-
 define(
     'bigscreenplayer/playbackstrategy/modifiers/cehtml',
   [
@@ -12,15 +6,7 @@ define(
   ],
     function (MediaPlayerBase, DebugTool) {
       'use strict';
-      /**
-       * Main MediaPlayer implementation for CEHTML devices.
-       * Use this device modifier if a device implements the CEHTML media playback standard.
-       * It must support creation of &lt;object&gt; elements for media mime types, and those objects must expose an
-       * API in accordance with the CEHTML specification.
-       * @name antie.devices.mediaplayer.CEHTML
-       * @class
-       * @extends antie.devices.mediaplayer.MediaPlayer
-       */
+
       return function () {
         var CLAMP_OFFSET_FROM_END_OF_RANGE = 1.1;
 
@@ -151,31 +137,6 @@ define(
           return state;
         }
 
-        // function generateSourceElement (url, mimeType) {
-        //   var sourceElement = document.createElement('source');
-        //   sourceElement.src = url;
-        //   sourceElement.type = mimeType;
-        //   return sourceElement;
-        // }
-
-        // function appendChildElement (to, el) {
-        //   to.appendChild(el);
-        // }
-
-        // function prependChildElement (to, el) {
-        //   if (to.childNodes.length > 0) {
-        //     to.insertBefore(el, to.childNodes[0]);
-        //   } else {
-        //     to.appendChild(el);
-        //   }
-        // }
-
-        // function removeElement (el) {
-        //   if (el.parentNode) {
-        //     el.parentNode.removeChild(el);
-        //   }
-        // }
-
         function setSeekSentinelTolerance () {
           var ON_DEMAND_SEEK_SENTINEL_TOLERANCE = 15;
           var LIVE_SEEK_SENTINEL_TOLERANCE = 30;
@@ -291,7 +252,7 @@ define(
 
           switch (getState()) {
             case MediaPlayerBase.STATE.STOPPED:
-                      // Seeking past 0 requires calling play first when media has not been loaded
+              // Seeking past 0 requires calling play first when media has not been loaded
               toBuffering();
               playAndSetDeferredSeek(seconds);
               break;
@@ -649,23 +610,6 @@ define(
             timeAtLastSentinelInterval = newTime;
           }, 1100);
         }
-
-        // function setSentinelLimits () {
-        //   sentinelLimits = {
-        //     pause: {
-        //       maximumAttempts: 2,
-        //       successEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE,
-        //       failureEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE,
-        //       currentAttemptCount: 0
-        //     },
-        //     seek: {
-        //       maximumAttempts: 2,
-        //       successEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK,
-        //       failureEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE,
-        //       currentAttemptCount: 0
-        //     }
-        //   };
-        // }
 
         function clearSentinels () {
           clearInterval(sentinelInterval);

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -332,21 +332,21 @@ define(
         }
       }
 
-      // function reset () {
-      //   switch (getState()) {
-      //     case MediaPlayerBase.STATE.EMPTY:
-      //       break;
+      function reset () {
+        switch (getState()) {
+          case MediaPlayerBase.STATE.EMPTY:
+            break;
 
-      //     case MediaPlayerBase.STATE.STOPPED:
-      //     case MediaPlayerBase.STATE.ERROR:
-      //       toEmpty();
-      //       break;
+          case MediaPlayerBase.STATE.STOPPED:
+          case MediaPlayerBase.STATE.ERROR:
+            toEmpty();
+            break;
 
-      //     default:
-      //       toError('Cannot reset while in the \'' + getState() + '\' state');
-      //       break;
-      //   }
-      // }
+          default:
+            toError('Cannot reset while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
 
       function getCurrentTime () {
         switch (getState()) {
@@ -592,10 +592,10 @@ define(
         clearSentinels();
       }
 
-      // function toEmpty () {
-      //   wipe();
-      //   state = MediaPlayerBase.STATE.EMPTY;
-      // }
+      function toEmpty () {
+        wipe();
+        state = MediaPlayerBase.STATE.EMPTY;
+      }
 
       function toError (errorMessage) {
         wipe();
@@ -762,7 +762,7 @@ define(
           beginPlaybackFrom: beginPlaybackFrom,
           pause: pause,
           stop: stop,
-          reset: resizeTo,
+          reset: reset,
           getSource: getSource,
           getMimeType: getMimeType,
           getSeekableRange: getSeekableRange,

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -187,7 +187,6 @@ define(
         }
 
         function initialiseMedia (type, url, mediaMimeType, sourceContainer, opts) {
-          DebugTool.info('cehtml::initialiseMedia');
           disableSentinels = opts.disableSentinels;
           mediaType = type;
           source = url;
@@ -195,22 +194,14 @@ define(
           opts = opts || {};
 
           if (getState() === MediaPlayerBase.STATE.EMPTY) {
-            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, attempting initialization');
             timeAtLastSentinelInterval = 0;
             setSeekSentinelTolerance();
-            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, seekSentinelTolerance set!');
             createElement();
-            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, media element created!');
             addElementToDOM();
-            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, media element added to DOM!');
             mediaElement.data = source;
-            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, mediaElement.data set to source!');
             registerEventHandlers();
-            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, eventHandlers registered!');
             toStopped();
-            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, toStopped() called!');
           } else {
-            DebugTool.info('cehtml::initialiseMedia --> !MediaPlayerBase.STATE.EMPTY, failed to initialize');
             toError('Cannot set source unless in the \'' + MediaPlayerBase.STATE.EMPTY + '\' state');
           }
         }
@@ -330,24 +321,19 @@ define(
         }
 
         function stop () {
-          DebugTool.info('cehtml::stop()');
           switch (getState()) {
             case MediaPlayerBase.STATE.STOPPED:
-              DebugTool.info('cehtml::stop --> already in stopped state!');
               break;
 
             case MediaPlayerBase.STATE.BUFFERING:
             case MediaPlayerBase.STATE.PLAYING:
             case MediaPlayerBase.STATE.PAUSED:
             case MediaPlayerBase.STATE.COMPLETE:
-              DebugTool.info('cehtml::stop --> in MediaPlayerBase.STATE.COMPLETE, resetting sentinel seek time and stopping media element!');
               sentinelSeekTime = undefined;
               if (mediaElement.stop) {
                 mediaElement.stop();
               }
-              DebugTool.info('cehtml::stop --> in MediaPlayerBase.STATE.COMPLETE, media element stopped! attempting toStopped() call...');
               toStopped();
-              DebugTool.info('cehtml::stop --> in MediaPlayerBase.STATE.COMPLETE, toStopped() called!');
               break;
 
             default:
@@ -357,16 +343,13 @@ define(
         }
 
         function reset () {
-          DebugTool.info('cehtml::reset()');
           switch (getState()) {
             case MediaPlayerBase.STATE.EMPTY:
               break;
 
             case MediaPlayerBase.STATE.STOPPED:
             case MediaPlayerBase.STATE.ERROR:
-              DebugTool.info('cehtml::reset --> in MediaPlayerBase.STATE.ERROR, calling toEmpty()...');
               toEmpty();
-              DebugTool.info('cehtml::reset --> in MediaPlayerBase.STATE.ERROR, toEmpty() called!');
               break;
 
             default:
@@ -438,8 +421,6 @@ define(
         }
 
         function onDeviceError () {
-          DebugTool.info('cehtml::onDeviceError occured!');
-          DebugTool.info('cehtml::onDeviceError -->' + mediaElement.error);
           reportError('Media element error code: ' + mediaElement.error);
         }
 
@@ -462,9 +443,7 @@ define(
         }
 
         function createElement () {
-          DebugTool.info('cehtml::createElement --> creating object element...');
           mediaElement = document.createElement('object', 'mediaPlayer');
-          DebugTool.info('cehtml::createElement --> styling object element...');
           mediaElement.type = mimeType;
           mediaElement.style.position = 'absolute';
           mediaElement.style.top = '0px';
@@ -518,11 +497,8 @@ define(
         }
 
         function addElementToDOM () {
-          DebugTool.info('cehtml::addElementToDOM()');
           var body = document.getElementsByTagName('body')[0];
-          DebugTool.info('cehtml::addElementToDOM --> inserting mediaElement before body.firstChild...');
           body.insertBefore(mediaElement, body.firstChild);
-          DebugTool.info('cehtml::addElementToDOM --> mediaElement insertBefore() call successful!');
         }
 
         function cacheRange () {
@@ -564,34 +540,24 @@ define(
         }
 
         function wipe () {
-          DebugTool.info('cehtml::wipe()');
           mediaType = undefined;
           source = undefined;
           mimeType = undefined;
           sentinelSeekTime = undefined;
           range = undefined;
-          DebugTool.info('cehtml::wipe --> checking mediaElement exists...');
           if (mediaElement) {
             clearInterval(updateInterval);
             clearSentinels();
-            DebugTool.info('destroying media element');
             destroyMediaElement();
-            DebugTool.info('destroyed media element');
           } else {
-            DebugTool.info('cehtml::wipe --> mediaElement does not exist!');
           }
         }
 
         function destroyMediaElement () {
-          DebugTool.info('cehtml::destroyMediaElement()');
           delete mediaElement.onPlayStateChange;
-          DebugTool.info('cehtml::destroyMediaElement --> Checking mediaElement.parentElement exists...');
           if (mediaElement.parentElement) {
-            DebugTool.info('cehtml::destroyMediaElement --> mediaElement.parentElement exists! removing itself...');
             mediaElement.parentElement.removeChild(mediaElement);
-            DebugTool.info('cehtml::destroyMediaElement --> mediaElement.parentElement exists! sucessfully removed itself');
           } else {
-            DebugTool.info('cehtml::destroyMediaElement --> mediaElement.parentElement does not exist!');
           }
           mediaElement = undefined;
         }

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -24,7 +24,6 @@ define(
       return function () {
         var CLAMP_OFFSET_FROM_END_OF_RANGE = 1.1;
 
-        var eventCallback;
         var eventCallbacks = [];
         var state = MediaPlayerBase.STATE.EMPTY;
 
@@ -66,22 +65,22 @@ define(
           }
         };
 
-        function addEventCallback (thisArg, newCallback) {
-          eventCallback = function (event) {
-            newCallback.call(thisArg, event);
+        function addEventCallback (thisArg, callback) {
+          var eventCallback = function (event) {
+            callback.call(thisArg, event);
           };
-          eventCallbacks.push(eventCallback);
+
+          eventCallbacks.push({ from: callback, to: eventCallback });
         }
 
-        function removeEventCallback (callback) {
-          var index = eventCallbacks.indexOf(callback);
-          if (index !== -1) {
-            eventCallbacks.splice(index, 1);
-          }
+        function removeEventCallback (thisArg, callback) {
+          eventCallbacks = eventCallbacks.filter(function (cb) {
+            return cb.from !== callback;
+          });
         }
 
         function removeAllEventCallbacks () {
-          eventCallbacks = undefined;
+          eventCallbacks = [];
         }
 
         function emitEvent (eventType, eventLabels) {
@@ -103,9 +102,9 @@ define(
             }
           }
 
-          for (var index = 0; index < eventCallbacks.length; index++) {
-            eventCallbacks[index](event);
-          }
+          eventCallbacks.forEach(function (callback) {
+            callback.to(event);
+          });
         }
 
         function getClampedTime (seconds) {
@@ -766,8 +765,7 @@ define(
           getMediaDuration: getMediaDuration,
           getState: getState,
           getPlayerElement: getPlayerElement,
-          getDuration: getDuration,
-          toPaused: toPaused
+          getDuration: getDuration
         };
       };
     });

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -11,734 +11,6 @@ define(
   ],
     function (MediaPlayerBase) {
       'use strict';
-
-      var CLAMP_OFFSET_FROM_END_OF_RANGE = 1.1;
-
-      var eventCallback;
-      var eventCallbacks = [];
-      var state = MediaPlayerBase.STATE.EMPTY;
-
-      var mediaElement;
-      var updateInterval;
-
-      var mediaType;
-      var source;
-      var mimeType;
-
-      var deferSeekingTo;
-      var range;
-
-      var postBufferingState;
-      var device;
-
-      var disableSentinels;
-
-      var sentinelSeekTime;
-      var seekSentinelTolerance;
-      var sentinelInterval;
-      var sentinelIntervalNumber;
-      var timeAtLastSentinelInterval;
-
-      var sentinelTimeIsNearEnd;
-      var timeHasAdvanced;
-
-      var sentinelLimits = {
-        pause: {
-          maximumAttempts: 2,
-          successEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE,
-          failureEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE,
-          currentAttemptCount: 0
-        },
-        seek: {
-          maximumAttempts: 2,
-          successEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK,
-          failureEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE,
-          currentAttemptCount: 0
-        }
-      };
-
-      function addEventCallback (thisArg, newCallback) {
-        eventCallback = function (event) {
-          newCallback.call(thisArg, event);
-        };
-        eventCallbacks.push(eventCallback);
-      }
-
-      function removeEventCallback (callback) {
-        var index = eventCallbacks.indexOf(callback);
-        if (index !== -1) {
-          eventCallbacks.splice(index, 1);
-        }
-      }
-
-      function removeAllEventCallbacks () {
-        eventCallbacks = undefined;
-      }
-
-      function emitEvent (eventType, eventLabels) {
-        var event = {
-          type: eventType,
-          currentTime: getCurrentTime(),
-          seekableRange: getSeekableRange(),
-          duration: getDuration(),
-          url: getSource(),
-          mimeType: getMimeType(),
-          state: getState()
-        };
-
-        if (eventLabels) {
-          for (var key in eventLabels) {
-            if (eventLabels.hasOwnProperty(key)) {
-              event[key] = eventLabels[key];
-            }
-          }
-        }
-
-        for (var index = 0; index < eventCallbacks.length; index++) {
-          eventCallbacks[index](event);
-        }
-      }
-
-      function getClampedTime (seconds) {
-        var range = getSeekableRange();
-        var offsetFromEnd = getClampOffsetFromConfig();
-        var nearToEnd = Math.max(range.end - offsetFromEnd, range.start);
-        if (seconds < range.start) {
-          return range.start;
-        } else if (seconds > nearToEnd) {
-          return nearToEnd;
-        } else {
-          return seconds;
-        }
-      }
-
-      function getClampOffsetFromConfig () {
-        var clampOffsetFromEndOfRange;
-
-        // TODO: can we tidy this, is it needed any more? If so we can combine it into bigscreen-player configs
-        // if (config && config.streaming && config.streaming.overrides) {
-        //   clampOffsetFromEndOfRange = config.streaming.overrides.clampOffsetFromEndOfRange;
-        // }
-
-        if (clampOffsetFromEndOfRange !== undefined) {
-          return clampOffsetFromEndOfRange;
-        } else {
-          return CLAMP_OFFSET_FROM_END_OF_RANGE;
-        }
-      }
-
-      function isLiveMedia () {
-        return (mediaType === MediaPlayerBase.TYPE.LIVE_VIDEO) || (mediaType === MediaPlayerBase.TYPE.LIVE_AUDIO);
-      }
-
-      function getSource () {
-        return source;
-      }
-
-      function getMimeType () {
-        return mimeType;
-      }
-
-      function getState () {
-        return state;
-      }
-
-      // function generateSourceElement (url, mimeType) {
-      //   var sourceElement = document.createElement('source');
-      //   sourceElement.src = url;
-      //   sourceElement.type = mimeType;
-      //   return sourceElement;
-      // }
-
-      // function appendChildElement (to, el) {
-      //   to.appendChild(el);
-      // }
-
-      // function prependChildElement (to, el) {
-      //   if (to.childNodes.length > 0) {
-      //     to.insertBefore(el, to.childNodes[0]);
-      //   } else {
-      //     to.appendChild(el);
-      //   }
-      // }
-
-      // function removeElement (el) {
-      //   if (el.parentNode) {
-      //     el.parentNode.removeChild(el);
-      //   }
-      // }
-
-      function setSeekSentinelTolerance () {
-        var ON_DEMAND_SEEK_SENTINEL_TOLERANCE = 15;
-        var LIVE_SEEK_SENTINEL_TOLERANCE = 30;
-
-        seekSentinelTolerance = ON_DEMAND_SEEK_SENTINEL_TOLERANCE;
-        if (isLiveMedia()) {
-          seekSentinelTolerance = LIVE_SEEK_SENTINEL_TOLERANCE;
-        }
-      }
-
-      function initialiseMedia (type, url, mediaMimeType, sourceContainer, opts) {
-        disableSentinels = opts.disableSentinels;
-        mediaType = type;
-        source = url;
-        mimeType = mediaMimeType;
-        opts = opts || {};
-
-        if (getState() === MediaPlayerBase.STATE.EMPTY) {
-          timeAtLastSentinelInterval = 0;
-          setSeekSentinelTolerance();
-          createElement();
-          addElementToDOM();
-          mediaElement.data = source;
-          registerEventHandlers();
-          toStopped();
-        } else {
-          toError('Cannot set source unless in the \'' + MediaPlayerBase.STATE.EMPTY + '\' state');
-        }
-      }
-
-      function resume () {
-        postBufferingState = MediaPlayerBase.STATE.PLAYING;
-        switch (getState()) {
-          case MediaPlayerBase.STATE.PLAYING:
-          case MediaPlayerBase.STATE.BUFFERING:
-            break;
-
-          case MediaPlayerBase.STATE.PAUSED:
-            mediaElement.play(1);
-            toPlaying();
-            break;
-
-          default:
-            toError('Cannot resume while in the \'' + getState() + '\' state');
-            break;
-        }
-      }
-
-      function playFrom (seconds) {
-        postBufferingState = MediaPlayerBase.STATE.PLAYING;
-        sentinelLimits.seek.currentAttemptCount = 0;
-        switch (getState()) {
-          case MediaPlayerBase.STATE.BUFFERING:
-            deferSeekingTo = seconds;
-            break;
-
-          case MediaPlayerBase.STATE.COMPLETE:
-            toBuffering();
-            mediaElement.stop();
-            playAndSetDeferredSeek(seconds);
-            break;
-
-          case MediaPlayerBase.STATE.PLAYING:
-            toBuffering();
-            var seekResult = seekTo(seconds);
-            if (seekResult === false) {
-              toPlaying();
-            }
-            break;
-
-          case MediaPlayerBase.STATE.PAUSED:
-            toBuffering();
-            seekTo(seconds);
-            mediaElement.play(1);
-            break;
-
-          default:
-            toError('Cannot playFrom while in the \'' + getState() + '\' state');
-            break;
-        }
-      }
-
-      function getDuration () {
-        switch (getState()) {
-          case MediaPlayerBase.STATE.STOPPED:
-          case MediaPlayerBase.STATE.ERROR:
-            return undefined;
-          default:
-            if (isLiveMedia()) {
-              return Infinity;
-            }
-            return getMediaDuration();
-        }
-      }
-
-      function beginPlayback () {
-        postBufferingState = MediaPlayerBase.STATE.PLAYING;
-        switch (getState()) {
-          case MediaPlayerBase.STATE.STOPPED:
-            toBuffering();
-            mediaElement.play(1);
-            break;
-
-          default:
-            toError('Cannot beginPlayback while in the \'' + getState() + '\' state');
-            break;
-        }
-      }
-
-      function beginPlaybackFrom (seconds) {
-        postBufferingState = MediaPlayerBase.STATE.PLAYING;
-        sentinelLimits.seek.currentAttemptCount = 0;
-
-        switch (getState()) {
-          case MediaPlayerBase.STATE.STOPPED:
-                    // Seeking past 0 requires calling play first when media has not been loaded
-            toBuffering();
-            playAndSetDeferredSeek(seconds);
-            break;
-
-          default:
-            toError('Cannot beginPlayback while in the \'' + getState() + '\' state');
-            break;
-        }
-      }
-
-      function pause () {
-        postBufferingState = MediaPlayerBase.STATE.PAUSED;
-        switch (getState()) {
-          case MediaPlayerBase.STATE.BUFFERING:
-          case MediaPlayerBase.STATE.PAUSED:
-            break;
-
-          case MediaPlayerBase.STATE.PLAYING:
-            mediaElement.play(0);
-            toPaused();
-            break;
-
-          default:
-            toError('Cannot pause while in the \'' + getState() + '\' state');
-            break;
-        }
-      }
-
-      function stop () {
-        switch (getState()) {
-          case MediaPlayerBase.STATE.STOPPED:
-            break;
-
-          case MediaPlayerBase.STATE.BUFFERING:
-          case MediaPlayerBase.STATE.PLAYING:
-          case MediaPlayerBase.STATE.PAUSED:
-          case MediaPlayerBase.STATE.COMPLETE:
-            sentinelSeekTime = undefined;
-            mediaElement.stop();
-            toStopped();
-            break;
-
-          default:
-            toError('Cannot stop while in the \'' + getState() + '\' state');
-            break;
-        }
-      }
-
-      function reset () {
-        switch (getState()) {
-          case MediaPlayerBase.STATE.EMPTY:
-            break;
-
-          case MediaPlayerBase.STATE.STOPPED:
-          case MediaPlayerBase.STATE.ERROR:
-            toEmpty();
-            break;
-
-          default:
-            toError('Cannot reset while in the \'' + getState() + '\' state');
-            break;
-        }
-      }
-
-      function getCurrentTime () {
-        switch (getState()) {
-          case MediaPlayerBase.STATE.STOPPED:
-          case MediaPlayerBase.STATE.ERROR:
-            break;
-
-          case MediaPlayerBase.STATE.COMPLETE:
-            if (range) {
-              return range.end;
-            }
-            break;
-
-          default:
-            if (mediaElement) {
-              return mediaElement.playPosition / 1000;
-            }
-            break;
-        }
-        return undefined;
-      }
-
-      function getSeekableRange () {
-        switch (getState()) {
-          case MediaPlayerBase.STATE.STOPPED:
-          case MediaPlayerBase.STATE.ERROR:
-            break;
-
-          default:
-            return range;
-        }
-        return undefined;
-      }
-
-      function getMediaDuration () {
-        if (range) {
-          return range.end;
-        }
-        return undefined;
-      }
-
-      function getPlayerElement () {
-        return mediaElement;
-      }
-
-      function onFinishedBuffering () {
-        cacheRange();
-
-        if (getState() !== MediaPlayerBase.STATE.BUFFERING) {
-          return;
-        }
-
-        if (waitingToSeek()) {
-          toBuffering();
-          performDeferredSeek();
-        } else if (waitingToPause()) {
-          toPaused();
-          mediaElement.play(0);
-        } else {
-          toPlaying();
-        }
-      }
-
-      function onDeviceError () {
-        reportError('Media element error code: ' + mediaElement.error);
-      }
-
-      function onDeviceBuffering () {
-        if (getState() === MediaPlayerBase.STATE.PLAYING) {
-          toBuffering();
-        }
-      }
-
-      function onEndOfMedia () {
-        if (getState() !== MediaPlayerBase.STATE.COMPLETE) {
-          toComplete();
-        }
-      }
-
-      function onStatus () {
-        if (getState() === MediaPlayerBase.STATE.PLAYING) {
-          emitEvent(MediaPlayerBase.EVENT.STATUS);
-        }
-      }
-
-      function createElement () {
-        mediaElement = device._createElement('object', 'mediaPlayer');
-        mediaElement.type = mimeType;
-        mediaElement.style.position = 'absolute';
-        mediaElement.style.top = '0px';
-        mediaElement.style.left = '0px';
-        mediaElement.style.width = '100%';
-        mediaElement.style.height = '100%';
-      }
-
-      var states = {
-        PLAY_STATE_STOPPED: 0,
-        PLAY_STATE_PLAYING: 1,
-        PLAY_STATE_PAUSED: 2,
-        PLAY_STATE_CONNECTING: 3,
-        PLAY_STATE_BUFFERING: 4,
-        PLAY_STATE_FINISHED: 5,
-        PLAY_STATE_ERROR: 6
-      };
-
-      function registerEventHandlers () {
-        var DEVICE_UPDATE_PERIOD_MS = 500;
-
-        mediaElement.onPlayStateChange = function () {
-          switch (mediaElement.playState) {
-            case states.PLAY_STATE_STOPPED:
-              break;
-            case states.PLAY_STATE_PLAYING:
-              onFinishedBuffering();
-              break;
-            case states.PLAY_STATE_PAUSED:
-              break;
-            case states.PLAY_STATE_CONNECTING:
-              break;
-            case states.PLAY_STATE_BUFFERING:
-              onDeviceBuffering();
-              break;
-            case states.PLAY_STATE_FINISHED:
-              onEndOfMedia();
-              break;
-            case states.PLAY_STATE_ERROR:
-              onDeviceError();
-              break;
-            default:
-                      // do nothing
-              break;
-          }
-        };
-
-        updateInterval = setInterval(function () {
-          onStatus();
-        }, DEVICE_UPDATE_PERIOD_MS);
-      }
-
-      function addElementToDOM () {
-        var body = document.getElementsByTagName('body')[0];
-        device.prependChildElement(body, mediaElement);
-      }
-
-      function cacheRange () {
-        if (mediaElement) {
-          range = {
-            start: 0,
-            end: mediaElement.playTime / 1000
-          };
-        }
-      }
-
-      function playAndSetDeferredSeek (seconds) {
-        mediaElement.play(1);
-        if (seconds > 0) {
-          deferSeekingTo = seconds;
-        }
-      }
-
-      function waitingToSeek () {
-        return (deferSeekingTo !== undefined);
-      }
-
-      function performDeferredSeek () {
-        seekTo(deferSeekingTo);
-        deferSeekingTo = undefined;
-      }
-
-      function seekTo (seconds) {
-        var clampedTime = getClampedTime(seconds);
-        if (clampedTime !== seconds) {
-          device.getLogger().debug('playFrom ' + seconds + ' clamped to ' + clampedTime + ' - seekable range is { start: ' + range.start + ', end: ' + range.end + ' }');
-        }
-        sentinelSeekTime = clampedTime;
-        return mediaElement.seek(clampedTime * 1000);
-      }
-
-      function waitingToPause () {
-        return (postBufferingState === MediaPlayerBase.STATE.PAUSED);
-      }
-
-      function wipe () {
-        mediaType = undefined;
-        source = undefined;
-        mimeType = undefined;
-        sentinelSeekTime = undefined;
-        range = undefined;
-        if (mediaElement) {
-          clearInterval(updateInterval);
-          clearSentinels();
-          destroyMediaElement();
-        }
-      }
-
-      function destroyMediaElement () {
-        delete mediaElement.onPlayStateChange;
-        device.removeElement(mediaElement);
-        mediaElement = undefined;
-      }
-
-      function reportError (errorMessage) {
-        device.getLogger().error(errorMessage);
-        emitEvent(MediaPlayerBase.EVENT.ERROR, {'errorMessage': errorMessage});
-      }
-
-      function toStopped () {
-        state = MediaPlayerBase.STATE.STOPPED;
-        emitEvent(MediaPlayerBase.EVENT.STOPPED);
-        if (sentinelInterval) {
-          clearSentinels();
-        }
-      }
-
-      function toBuffering () {
-        state = MediaPlayerBase.STATE.BUFFERING;
-        emitEvent(MediaPlayerBase.EVENT.BUFFERING);
-        setSentinels([exitBufferingSentinel]);
-      }
-
-      function toPlaying () {
-        state = MediaPlayerBase.STATE.PLAYING;
-        emitEvent(MediaPlayerBase.EVENT.PLAYING);
-        setSentinels([
-          shouldBeSeekedSentinel,
-          enterCompleteSentinel,
-          enterBufferingSentinel
-        ]);
-      }
-
-      function toPaused () {
-        state = MediaPlayerBase.STATE.PAUSED;
-        emitEvent(MediaPlayerBase.EVENT.PAUSED);
-        setSentinels([
-          shouldBePausedSentinel,
-          shouldBeSeekedSentinel
-        ]);
-      }
-
-      function toComplete () {
-        state = MediaPlayerBase.STATE.COMPLETE;
-        emitEvent(MediaPlayerBase.EVENT.COMPLETE);
-        clearSentinels();
-      }
-
-      function toEmpty () {
-        wipe();
-        state = MediaPlayerBase.STATE.EMPTY;
-      }
-
-      function toError (errorMessage) {
-        wipe();
-        state = MediaPlayerBase.STATE.ERROR;
-        reportError(errorMessage);
-      }
-
-      function isNearToEnd (seconds) {
-        return (getDuration() - seconds <= 1);
-      }
-
-      function setSentinels (sentinels) {
-        if (disableSentinels) {
-          return;
-        }
-
-        sentinelLimits.pause.currentAttemptCount = 0;
-        timeAtLastSentinelInterval = getCurrentTime();
-        clearSentinels();
-        sentinelIntervalNumber = 0;
-        sentinelInterval = setInterval(function () {
-          var newTime = getCurrentTime();
-          sentinelIntervalNumber++;
-
-          timeHasAdvanced = newTime ? (newTime > (timeAtLastSentinelInterval + 0.2)) : false;
-          sentinelTimeIsNearEnd = isNearToEnd(newTime || timeAtLastSentinelInterval);
-
-          for (var i = 0; i < sentinels.length; i++) {
-            var sentinelActionPerformed = sentinels[i].call(this);
-            if (sentinelActionPerformed) {
-              break;
-            }
-          }
-
-          timeAtLastSentinelInterval = newTime;
-        }, 1100);
-      }
-
-      // function setSentinelLimits () {
-      //   sentinelLimits = {
-      //     pause: {
-      //       maximumAttempts: 2,
-      //       successEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE,
-      //       failureEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE,
-      //       currentAttemptCount: 0
-      //     },
-      //     seek: {
-      //       maximumAttempts: 2,
-      //       successEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK,
-      //       failureEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE,
-      //       currentAttemptCount: 0
-      //     }
-      //   };
-      // }
-
-      function clearSentinels () {
-        clearInterval(sentinelInterval);
-      }
-
-      function enterBufferingSentinel () {
-        var sentinelBufferingRequired = !timeHasAdvanced && !sentinelTimeIsNearEnd && (sentinelIntervalNumber > 1);
-        if (sentinelBufferingRequired) {
-          emitEvent(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
-          toBuffering();
-        }
-        return sentinelBufferingRequired;
-      }
-
-      function exitBufferingSentinel () {
-        var sentinelExitBufferingRequired = timeHasAdvanced;
-        if (sentinelExitBufferingRequired) {
-          emitEvent(MediaPlayerBase.EVENT.SENTINEL_EXIT_BUFFERING);
-          onFinishedBuffering();
-        }
-        return sentinelExitBufferingRequired;
-      }
-
-      function shouldBeSeekedSentinel () {
-        if (sentinelSeekTime === undefined) {
-          return false;
-        }
-
-        var currentTime = getCurrentTime();
-
-        var clampedSentinelSeekTime = getClampedTime(sentinelSeekTime);
-
-        var sentinelSeekRequired = Math.abs(clampedSentinelSeekTime - currentTime) > seekSentinelTolerance;
-        var sentinelActionTaken = false;
-
-        if (sentinelSeekRequired) {
-          var mediaElement = mediaElement;
-          sentinelActionTaken = nextSentinelAttempt(sentinelLimits.seek, function () {
-            mediaElement.seek(clampedSentinelSeekTime * 1000);
-          });
-        } else if (sentinelIntervalNumber < 3) {
-          sentinelSeekTime = currentTime;
-        } else {
-          sentinelSeekTime = undefined;
-        }
-        return sentinelActionTaken;
-      }
-
-      function shouldBePausedSentinel () {
-        var sentinelPauseRequired = timeHasAdvanced;
-        var sentinelActionTaken = false;
-        if (sentinelPauseRequired) {
-          var mediaElement = mediaElement;
-          sentinelActionTaken = nextSentinelAttempt(sentinelLimits.pause, function () {
-            mediaElement.play(0);
-          });
-        }
-        return sentinelActionTaken;
-      }
-
-      function enterCompleteSentinel () {
-        var sentinelCompleteRequired = !timeHasAdvanced && sentinelTimeIsNearEnd;
-        if (sentinelCompleteRequired) {
-          emitEvent(MediaPlayerBase.EVENT.SENTINEL_COMPLETE);
-          onEndOfMedia();
-        }
-        return sentinelCompleteRequired;
-      }
-
-      function nextSentinelAttempt (sentinelInfo, attemptFn) {
-        var currentAttemptCount, maxAttemptCount;
-
-        sentinelInfo.currentAttemptCount += 1;
-        currentAttemptCount = sentinelInfo.currentAttemptCount;
-        maxAttemptCount = sentinelInfo.maximumAttempts;
-
-        if (currentAttemptCount === maxAttemptCount + 1) {
-          emitEvent(sentinelInfo.failureEvent);
-        }
-
-        if (currentAttemptCount <= maxAttemptCount) {
-          attemptFn();
-          emitEvent(sentinelInfo.successEvent);
-          return true;
-        }
-
-        return false;
-      }
-
       /**
        * Main MediaPlayer implementation for CEHTML devices.
        * Use this device modifier if a device implements the CEHTML media playback standard.
@@ -748,8 +20,732 @@ define(
        * @class
        * @extends antie.devices.mediaplayer.MediaPlayer
        */
-      return function (newDevice) {
-        device = newDevice;
+      return function (device) {
+        var CLAMP_OFFSET_FROM_END_OF_RANGE = 1.1;
+
+        var eventCallback;
+        var eventCallbacks = [];
+        var state = MediaPlayerBase.STATE.EMPTY;
+
+        var mediaElement;
+        var updateInterval;
+
+        var mediaType;
+        var source;
+        var mimeType;
+
+        var deferSeekingTo;
+        var range;
+
+        var postBufferingState;
+
+        var disableSentinels;
+
+        var sentinelSeekTime;
+        var seekSentinelTolerance;
+        var sentinelInterval;
+        var sentinelIntervalNumber;
+        var timeAtLastSentinelInterval;
+
+        var sentinelTimeIsNearEnd;
+        var timeHasAdvanced;
+
+        var sentinelLimits = {
+          pause: {
+            maximumAttempts: 2,
+            successEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE,
+            failureEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE,
+            currentAttemptCount: 0
+          },
+          seek: {
+            maximumAttempts: 2,
+            successEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK,
+            failureEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE,
+            currentAttemptCount: 0
+          }
+        };
+
+        function addEventCallback (thisArg, newCallback) {
+          eventCallback = function (event) {
+            newCallback.call(thisArg, event);
+          };
+          eventCallbacks.push(eventCallback);
+        }
+
+        function removeEventCallback (callback) {
+          var index = eventCallbacks.indexOf(callback);
+          if (index !== -1) {
+            eventCallbacks.splice(index, 1);
+          }
+        }
+
+        function removeAllEventCallbacks () {
+          eventCallbacks = undefined;
+        }
+
+        function emitEvent (eventType, eventLabels) {
+          var event = {
+            type: eventType,
+            currentTime: getCurrentTime(),
+            seekableRange: getSeekableRange(),
+            duration: getDuration(),
+            url: getSource(),
+            mimeType: getMimeType(),
+            state: getState()
+          };
+
+          if (eventLabels) {
+            for (var key in eventLabels) {
+              if (eventLabels.hasOwnProperty(key)) {
+                event[key] = eventLabels[key];
+              }
+            }
+          }
+
+          for (var index = 0; index < eventCallbacks.length; index++) {
+            eventCallbacks[index](event);
+          }
+        }
+
+        function getClampedTime (seconds) {
+          var range = getSeekableRange();
+          var offsetFromEnd = getClampOffsetFromConfig();
+          var nearToEnd = Math.max(range.end - offsetFromEnd, range.start);
+          if (seconds < range.start) {
+            return range.start;
+          } else if (seconds > nearToEnd) {
+            return nearToEnd;
+          } else {
+            return seconds;
+          }
+        }
+
+        function getClampOffsetFromConfig () {
+          var clampOffsetFromEndOfRange;
+
+          // TODO: can we tidy this, is it needed any more? If so we can combine it into bigscreen-player configs
+          // if (config && config.streaming && config.streaming.overrides) {
+          //   clampOffsetFromEndOfRange = config.streaming.overrides.clampOffsetFromEndOfRange;
+          // }
+
+          if (clampOffsetFromEndOfRange !== undefined) {
+            return clampOffsetFromEndOfRange;
+          } else {
+            return CLAMP_OFFSET_FROM_END_OF_RANGE;
+          }
+        }
+
+        function isLiveMedia () {
+          return (mediaType === MediaPlayerBase.TYPE.LIVE_VIDEO) || (mediaType === MediaPlayerBase.TYPE.LIVE_AUDIO);
+        }
+
+        function getSource () {
+          return source;
+        }
+
+        function getMimeType () {
+          return mimeType;
+        }
+
+        function getState () {
+          return state;
+        }
+
+        // function generateSourceElement (url, mimeType) {
+        //   var sourceElement = document.createElement('source');
+        //   sourceElement.src = url;
+        //   sourceElement.type = mimeType;
+        //   return sourceElement;
+        // }
+
+        // function appendChildElement (to, el) {
+        //   to.appendChild(el);
+        // }
+
+        // function prependChildElement (to, el) {
+        //   if (to.childNodes.length > 0) {
+        //     to.insertBefore(el, to.childNodes[0]);
+        //   } else {
+        //     to.appendChild(el);
+        //   }
+        // }
+
+        // function removeElement (el) {
+        //   if (el.parentNode) {
+        //     el.parentNode.removeChild(el);
+        //   }
+        // }
+
+        function setSeekSentinelTolerance () {
+          var ON_DEMAND_SEEK_SENTINEL_TOLERANCE = 15;
+          var LIVE_SEEK_SENTINEL_TOLERANCE = 30;
+
+          seekSentinelTolerance = ON_DEMAND_SEEK_SENTINEL_TOLERANCE;
+          if (isLiveMedia()) {
+            seekSentinelTolerance = LIVE_SEEK_SENTINEL_TOLERANCE;
+          }
+        }
+
+        function initialiseMedia (type, url, mediaMimeType, sourceContainer, opts) {
+          disableSentinels = opts.disableSentinels;
+          mediaType = type;
+          source = url;
+          mimeType = mediaMimeType;
+          opts = opts || {};
+
+          if (getState() === MediaPlayerBase.STATE.EMPTY) {
+            timeAtLastSentinelInterval = 0;
+            setSeekSentinelTolerance();
+            createElement();
+            addElementToDOM();
+            mediaElement.data = source;
+            registerEventHandlers();
+            toStopped();
+          } else {
+            toError('Cannot set source unless in the \'' + MediaPlayerBase.STATE.EMPTY + '\' state');
+          }
+        }
+
+        function resume () {
+          postBufferingState = MediaPlayerBase.STATE.PLAYING;
+          switch (getState()) {
+            case MediaPlayerBase.STATE.PLAYING:
+            case MediaPlayerBase.STATE.BUFFERING:
+              break;
+
+            case MediaPlayerBase.STATE.PAUSED:
+              mediaElement.play(1);
+              toPlaying();
+              break;
+
+            default:
+              toError('Cannot resume while in the \'' + getState() + '\' state');
+              break;
+          }
+        }
+
+        function playFrom (seconds) {
+          postBufferingState = MediaPlayerBase.STATE.PLAYING;
+          sentinelLimits.seek.currentAttemptCount = 0;
+          switch (getState()) {
+            case MediaPlayerBase.STATE.BUFFERING:
+              deferSeekingTo = seconds;
+              break;
+
+            case MediaPlayerBase.STATE.COMPLETE:
+              toBuffering();
+              mediaElement.stop();
+              playAndSetDeferredSeek(seconds);
+              break;
+
+            case MediaPlayerBase.STATE.PLAYING:
+              toBuffering();
+              var seekResult = seekTo(seconds);
+              if (seekResult === false) {
+                toPlaying();
+              }
+              break;
+
+            case MediaPlayerBase.STATE.PAUSED:
+              toBuffering();
+              seekTo(seconds);
+              mediaElement.play(1);
+              break;
+
+            default:
+              toError('Cannot playFrom while in the \'' + getState() + '\' state');
+              break;
+          }
+        }
+
+        function getDuration () {
+          switch (getState()) {
+            case MediaPlayerBase.STATE.STOPPED:
+            case MediaPlayerBase.STATE.ERROR:
+              return undefined;
+            default:
+              if (isLiveMedia()) {
+                return Infinity;
+              }
+              return getMediaDuration();
+          }
+        }
+
+        function beginPlayback () {
+          postBufferingState = MediaPlayerBase.STATE.PLAYING;
+          switch (getState()) {
+            case MediaPlayerBase.STATE.STOPPED:
+              toBuffering();
+              mediaElement.play(1);
+              break;
+
+            default:
+              toError('Cannot beginPlayback while in the \'' + getState() + '\' state');
+              break;
+          }
+        }
+
+        function beginPlaybackFrom (seconds) {
+          postBufferingState = MediaPlayerBase.STATE.PLAYING;
+          sentinelLimits.seek.currentAttemptCount = 0;
+
+          switch (getState()) {
+            case MediaPlayerBase.STATE.STOPPED:
+                      // Seeking past 0 requires calling play first when media has not been loaded
+              toBuffering();
+              playAndSetDeferredSeek(seconds);
+              break;
+
+            default:
+              toError('Cannot beginPlayback while in the \'' + getState() + '\' state');
+              break;
+          }
+        }
+
+        function pause () {
+          postBufferingState = MediaPlayerBase.STATE.PAUSED;
+          switch (getState()) {
+            case MediaPlayerBase.STATE.BUFFERING:
+            case MediaPlayerBase.STATE.PAUSED:
+              break;
+
+            case MediaPlayerBase.STATE.PLAYING:
+              mediaElement.play(0);
+              toPaused();
+              break;
+
+            default:
+              toError('Cannot pause while in the \'' + getState() + '\' state');
+              break;
+          }
+        }
+
+        function stop () {
+          switch (getState()) {
+            case MediaPlayerBase.STATE.STOPPED:
+              break;
+
+            case MediaPlayerBase.STATE.BUFFERING:
+            case MediaPlayerBase.STATE.PLAYING:
+            case MediaPlayerBase.STATE.PAUSED:
+            case MediaPlayerBase.STATE.COMPLETE:
+              sentinelSeekTime = undefined;
+              mediaElement.stop();
+              toStopped();
+              break;
+
+            default:
+              toError('Cannot stop while in the \'' + getState() + '\' state');
+              break;
+          }
+        }
+
+        function reset () {
+          switch (getState()) {
+            case MediaPlayerBase.STATE.EMPTY:
+              break;
+
+            case MediaPlayerBase.STATE.STOPPED:
+            case MediaPlayerBase.STATE.ERROR:
+              toEmpty();
+              break;
+
+            default:
+              toError('Cannot reset while in the \'' + getState() + '\' state');
+              break;
+          }
+        }
+
+        function getCurrentTime () {
+          switch (getState()) {
+            case MediaPlayerBase.STATE.STOPPED:
+            case MediaPlayerBase.STATE.ERROR:
+              break;
+
+            case MediaPlayerBase.STATE.COMPLETE:
+              if (range) {
+                return range.end;
+              }
+              break;
+
+            default:
+              if (mediaElement) {
+                return mediaElement.playPosition / 1000;
+              }
+              break;
+          }
+          return undefined;
+        }
+
+        function getSeekableRange () {
+          switch (getState()) {
+            case MediaPlayerBase.STATE.STOPPED:
+            case MediaPlayerBase.STATE.ERROR:
+              break;
+
+            default:
+              return range;
+          }
+          return undefined;
+        }
+
+        function getMediaDuration () {
+          if (range) {
+            return range.end;
+          }
+          return undefined;
+        }
+
+        function getPlayerElement () {
+          return mediaElement;
+        }
+
+        function onFinishedBuffering () {
+          cacheRange();
+
+          if (getState() !== MediaPlayerBase.STATE.BUFFERING) {
+            return;
+          }
+
+          if (waitingToSeek()) {
+            toBuffering();
+            performDeferredSeek();
+          } else if (waitingToPause()) {
+            toPaused();
+            mediaElement.play(0);
+          } else {
+            toPlaying();
+          }
+        }
+
+        function onDeviceError () {
+          reportError('Media element error code: ' + mediaElement.error);
+        }
+
+        function onDeviceBuffering () {
+          if (getState() === MediaPlayerBase.STATE.PLAYING) {
+            toBuffering();
+          }
+        }
+
+        function onEndOfMedia () {
+          if (getState() !== MediaPlayerBase.STATE.COMPLETE) {
+            toComplete();
+          }
+        }
+
+        function onStatus () {
+          if (getState() === MediaPlayerBase.STATE.PLAYING) {
+            emitEvent(MediaPlayerBase.EVENT.STATUS);
+          }
+        }
+
+        function createElement () {
+          mediaElement = device._createElement('object', 'mediaPlayer');
+          mediaElement.type = mimeType;
+          mediaElement.style.position = 'absolute';
+          mediaElement.style.top = '0px';
+          mediaElement.style.left = '0px';
+          mediaElement.style.width = '100%';
+          mediaElement.style.height = '100%';
+        }
+
+        var states = {
+          PLAY_STATE_STOPPED: 0,
+          PLAY_STATE_PLAYING: 1,
+          PLAY_STATE_PAUSED: 2,
+          PLAY_STATE_CONNECTING: 3,
+          PLAY_STATE_BUFFERING: 4,
+          PLAY_STATE_FINISHED: 5,
+          PLAY_STATE_ERROR: 6
+        };
+
+        function registerEventHandlers () {
+          var DEVICE_UPDATE_PERIOD_MS = 500;
+
+          mediaElement.onPlayStateChange = function () {
+            switch (mediaElement.playState) {
+              case states.PLAY_STATE_STOPPED:
+                break;
+              case states.PLAY_STATE_PLAYING:
+                onFinishedBuffering();
+                break;
+              case states.PLAY_STATE_PAUSED:
+                break;
+              case states.PLAY_STATE_CONNECTING:
+                break;
+              case states.PLAY_STATE_BUFFERING:
+                onDeviceBuffering();
+                break;
+              case states.PLAY_STATE_FINISHED:
+                onEndOfMedia();
+                break;
+              case states.PLAY_STATE_ERROR:
+                onDeviceError();
+                break;
+              default:
+                        // do nothing
+                break;
+            }
+          };
+
+          updateInterval = setInterval(function () {
+            onStatus();
+          }, DEVICE_UPDATE_PERIOD_MS);
+        }
+
+        function addElementToDOM () {
+          var body = document.getElementsByTagName('body')[0];
+          device.prependChildElement(body, mediaElement);
+        }
+
+        function cacheRange () {
+          if (mediaElement) {
+            range = {
+              start: 0,
+              end: mediaElement.playTime / 1000
+            };
+          }
+        }
+
+        function playAndSetDeferredSeek (seconds) {
+          mediaElement.play(1);
+          if (seconds > 0) {
+            deferSeekingTo = seconds;
+          }
+        }
+
+        function waitingToSeek () {
+          return (deferSeekingTo !== undefined);
+        }
+
+        function performDeferredSeek () {
+          seekTo(deferSeekingTo);
+          deferSeekingTo = undefined;
+        }
+
+        function seekTo (seconds) {
+          var clampedTime = getClampedTime(seconds);
+          if (clampedTime !== seconds) {
+            device.getLogger().debug('playFrom ' + seconds + ' clamped to ' + clampedTime + ' - seekable range is { start: ' + range.start + ', end: ' + range.end + ' }');
+          }
+          sentinelSeekTime = clampedTime;
+          return mediaElement.seek(clampedTime * 1000);
+        }
+
+        function waitingToPause () {
+          return (postBufferingState === MediaPlayerBase.STATE.PAUSED);
+        }
+
+        function wipe () {
+          mediaType = undefined;
+          source = undefined;
+          mimeType = undefined;
+          sentinelSeekTime = undefined;
+          range = undefined;
+          if (mediaElement) {
+            clearInterval(updateInterval);
+            clearSentinels();
+            destroyMediaElement();
+          }
+        }
+
+        function destroyMediaElement () {
+          delete mediaElement.onPlayStateChange;
+          device.removeElement(mediaElement);
+          mediaElement = undefined;
+        }
+
+        function reportError (errorMessage) {
+          device.getLogger().error(errorMessage);
+          emitEvent(MediaPlayerBase.EVENT.ERROR, {'errorMessage': errorMessage});
+        }
+
+        function toStopped () {
+          state = MediaPlayerBase.STATE.STOPPED;
+          emitEvent(MediaPlayerBase.EVENT.STOPPED);
+          if (sentinelInterval) {
+            clearSentinels();
+          }
+        }
+
+        function toBuffering () {
+          state = MediaPlayerBase.STATE.BUFFERING;
+          emitEvent(MediaPlayerBase.EVENT.BUFFERING);
+          setSentinels([exitBufferingSentinel]);
+        }
+
+        function toPlaying () {
+          state = MediaPlayerBase.STATE.PLAYING;
+          emitEvent(MediaPlayerBase.EVENT.PLAYING);
+          setSentinels([
+            shouldBeSeekedSentinel,
+            enterCompleteSentinel,
+            enterBufferingSentinel
+          ]);
+        }
+
+        function toPaused () {
+          state = MediaPlayerBase.STATE.PAUSED;
+          emitEvent(MediaPlayerBase.EVENT.PAUSED);
+          setSentinels([
+            shouldBePausedSentinel,
+            shouldBeSeekedSentinel
+          ]);
+        }
+
+        function toComplete () {
+          state = MediaPlayerBase.STATE.COMPLETE;
+          emitEvent(MediaPlayerBase.EVENT.COMPLETE);
+          clearSentinels();
+        }
+
+        function toEmpty () {
+          wipe();
+          state = MediaPlayerBase.STATE.EMPTY;
+        }
+
+        function toError (errorMessage) {
+          wipe();
+          state = MediaPlayerBase.STATE.ERROR;
+          reportError(errorMessage);
+        }
+
+        function isNearToEnd (seconds) {
+          return (getDuration() - seconds <= 1);
+        }
+
+        function setSentinels (sentinels) {
+          if (disableSentinels) {
+            return;
+          }
+
+          sentinelLimits.pause.currentAttemptCount = 0;
+          timeAtLastSentinelInterval = getCurrentTime();
+          clearSentinels();
+          sentinelIntervalNumber = 0;
+          sentinelInterval = setInterval(function () {
+            var newTime = getCurrentTime();
+            sentinelIntervalNumber++;
+
+            timeHasAdvanced = newTime ? (newTime > (timeAtLastSentinelInterval + 0.2)) : false;
+            sentinelTimeIsNearEnd = isNearToEnd(newTime || timeAtLastSentinelInterval);
+
+            for (var i = 0; i < sentinels.length; i++) {
+              var sentinelActionPerformed = sentinels[i].call(this);
+              if (sentinelActionPerformed) {
+                break;
+              }
+            }
+
+            timeAtLastSentinelInterval = newTime;
+          }, 1100);
+        }
+
+        // function setSentinelLimits () {
+        //   sentinelLimits = {
+        //     pause: {
+        //       maximumAttempts: 2,
+        //       successEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE,
+        //       failureEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE,
+        //       currentAttemptCount: 0
+        //     },
+        //     seek: {
+        //       maximumAttempts: 2,
+        //       successEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK,
+        //       failureEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE,
+        //       currentAttemptCount: 0
+        //     }
+        //   };
+        // }
+
+        function clearSentinels () {
+          clearInterval(sentinelInterval);
+        }
+
+        function enterBufferingSentinel () {
+          var sentinelBufferingRequired = !timeHasAdvanced && !sentinelTimeIsNearEnd && (sentinelIntervalNumber > 1);
+          if (sentinelBufferingRequired) {
+            emitEvent(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
+            toBuffering();
+          }
+          return sentinelBufferingRequired;
+        }
+
+        function exitBufferingSentinel () {
+          var sentinelExitBufferingRequired = timeHasAdvanced;
+          if (sentinelExitBufferingRequired) {
+            emitEvent(MediaPlayerBase.EVENT.SENTINEL_EXIT_BUFFERING);
+            onFinishedBuffering();
+          }
+          return sentinelExitBufferingRequired;
+        }
+
+        function shouldBeSeekedSentinel () {
+          if (sentinelSeekTime === undefined) {
+            return false;
+          }
+
+          var currentTime = getCurrentTime();
+
+          var clampedSentinelSeekTime = getClampedTime(sentinelSeekTime);
+
+          var sentinelSeekRequired = Math.abs(clampedSentinelSeekTime - currentTime) > seekSentinelTolerance;
+          var sentinelActionTaken = false;
+
+          if (sentinelSeekRequired) {
+            var mediaElement = mediaElement;
+            sentinelActionTaken = nextSentinelAttempt(sentinelLimits.seek, function () {
+              mediaElement.seek(clampedSentinelSeekTime * 1000);
+            });
+          } else if (sentinelIntervalNumber < 3) {
+            sentinelSeekTime = currentTime;
+          } else {
+            sentinelSeekTime = undefined;
+          }
+          return sentinelActionTaken;
+        }
+
+        function shouldBePausedSentinel () {
+          var sentinelPauseRequired = timeHasAdvanced;
+          var sentinelActionTaken = false;
+          if (sentinelPauseRequired) {
+            var mediaElement = mediaElement;
+            sentinelActionTaken = nextSentinelAttempt(sentinelLimits.pause, function () {
+              mediaElement.play(0);
+            });
+          }
+          return sentinelActionTaken;
+        }
+
+        function enterCompleteSentinel () {
+          var sentinelCompleteRequired = !timeHasAdvanced && sentinelTimeIsNearEnd;
+          if (sentinelCompleteRequired) {
+            emitEvent(MediaPlayerBase.EVENT.SENTINEL_COMPLETE);
+            onEndOfMedia();
+          }
+          return sentinelCompleteRequired;
+        }
+
+        function nextSentinelAttempt (sentinelInfo, attemptFn) {
+          var currentAttemptCount, maxAttemptCount;
+
+          sentinelInfo.currentAttemptCount += 1;
+          currentAttemptCount = sentinelInfo.currentAttemptCount;
+          maxAttemptCount = sentinelInfo.maximumAttempts;
+
+          if (currentAttemptCount === maxAttemptCount + 1) {
+            emitEvent(sentinelInfo.failureEvent);
+          }
+
+          if (currentAttemptCount <= maxAttemptCount) {
+            attemptFn();
+            emitEvent(sentinelInfo.successEvent);
+            return true;
+          }
+
+          return false;
+        }
 
         return {
           addEventCallback: addEventCallback,

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -187,7 +187,6 @@ define(
         }
 
         function initialiseMedia (type, url, mediaMimeType, sourceContainer, opts) {
-          DebugTool.info('Start init media');
           disableSentinels = opts.disableSentinels;
           mediaType = type;
           source = url;
@@ -342,7 +341,6 @@ define(
         }
 
         function reset () {
-          DebugTool.info('Start reset');
           switch (getState()) {
             case MediaPlayerBase.STATE.EMPTY:
               break;
@@ -494,7 +492,6 @@ define(
           updateInterval = setInterval(function () {
             onStatus();
           }, DEVICE_UPDATE_PERIOD_MS);
-          DebugTool.info('set interval');
         }
 
         function addElementToDOM () {
@@ -548,7 +545,6 @@ define(
           range = undefined;
           if (mediaElement) {
             clearInterval(updateInterval);
-            DebugTool.info('clear interval');
             clearSentinels();
             destroyMediaElement();
           }

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -332,8 +332,10 @@ define(
               sentinelSeekTime = undefined;
               if (mediaElement.stop) {
                 mediaElement.stop();
+                toStopped();
+              } else {
+                toError('mediaElement.stop is not a function : failed to stop the media player');
               }
-              toStopped();
               break;
 
             default:

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -187,7 +187,7 @@ define(
         }
 
         function initialiseMedia (type, url, mediaMimeType, sourceContainer, opts) {
-          DebugTool.info('Starting...');
+          DebugTool.info('cehtml::initialiseMedia');
           disableSentinels = opts.disableSentinels;
           mediaType = type;
           source = url;
@@ -195,14 +195,22 @@ define(
           opts = opts || {};
 
           if (getState() === MediaPlayerBase.STATE.EMPTY) {
+            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, attempting initialization');
             timeAtLastSentinelInterval = 0;
             setSeekSentinelTolerance();
+            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, seekSentinelTolerance set!');
             createElement();
+            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, media element created!');
             addElementToDOM();
+            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, media element added to DOM!');
             mediaElement.data = source;
+            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, mediaElement.data set to source!');
             registerEventHandlers();
+            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, eventHandlers registered!');
             toStopped();
+            DebugTool.info('cehtml::initialiseMedia --> MediaPlayerBase.STATE.EMPTY, toStopped() called!');
           } else {
+            DebugTool.info('cehtml::initialiseMedia --> !MediaPlayerBase.STATE.EMPTY, failed to initialize');
             toError('Cannot set source unless in the \'' + MediaPlayerBase.STATE.EMPTY + '\' state');
           }
         }
@@ -322,17 +330,22 @@ define(
         }
 
         function stop () {
+          DebugTool.info('cehtml::stop()');
           switch (getState()) {
             case MediaPlayerBase.STATE.STOPPED:
+              DebugTool.info('cehtml::stop --> already in stopped state!');
               break;
 
             case MediaPlayerBase.STATE.BUFFERING:
             case MediaPlayerBase.STATE.PLAYING:
             case MediaPlayerBase.STATE.PAUSED:
             case MediaPlayerBase.STATE.COMPLETE:
+              DebugTool.info('cehtml::stop --> in MediaPlayerBase.STATE.COMPLETE, resetting sentinel seek time and stopping media element!');
               sentinelSeekTime = undefined;
               mediaElement.stop();
+              DebugTool.info('cehtml::stop --> in MediaPlayerBase.STATE.COMPLETE, media element stopped! attempting toStopped() call...');
               toStopped();
+              DebugTool.info('cehtml::stop --> in MediaPlayerBase.STATE.COMPLETE, toStopped() called!');
               break;
 
             default:
@@ -342,13 +355,16 @@ define(
         }
 
         function reset () {
+          DebugTool.info('cehtml::reset()');
           switch (getState()) {
             case MediaPlayerBase.STATE.EMPTY:
               break;
 
             case MediaPlayerBase.STATE.STOPPED:
             case MediaPlayerBase.STATE.ERROR:
+              DebugTool.info('cehtml::reset --> in MediaPlayerBase.STATE.ERROR, calling toEmpty()...');
               toEmpty();
+              DebugTool.info('cehtml::reset --> in MediaPlayerBase.STATE.ERROR, toEmpty() called!');
               break;
 
             default:
@@ -420,6 +436,8 @@ define(
         }
 
         function onDeviceError () {
+          DebugTool.info('cehtml::onDeviceError occured!');
+          DebugTool.info('cehtml::onDeviceError -->' + mediaElement.error);
           reportError('Media element error code: ' + mediaElement.error);
         }
 
@@ -442,7 +460,9 @@ define(
         }
 
         function createElement () {
+          DebugTool.info('cehtml::createElement --> creating object element...');
           mediaElement = document.createElement('object', 'mediaPlayer');
+          DebugTool.info('cehtml::createElement --> styling object element...');
           mediaElement.type = mimeType;
           mediaElement.style.position = 'absolute';
           mediaElement.style.top = '0px';
@@ -496,8 +516,11 @@ define(
         }
 
         function addElementToDOM () {
+          DebugTool.info('cehtml::addElementToDOM()');
           var body = document.getElementsByTagName('body')[0];
+          DebugTool.info('cehtml::addElementToDOM --> inserting mediaElement before body.firstChild...');
           body.insertBefore(mediaElement, body.firstChild);
+          DebugTool.info('cehtml::addElementToDOM --> mediaElement insertBefore() call successful!');
         }
 
         function cacheRange () {
@@ -539,25 +562,34 @@ define(
         }
 
         function wipe () {
-          DebugTool.info('wipe()');
+          DebugTool.info('cehtml::wipe()');
           mediaType = undefined;
           source = undefined;
           mimeType = undefined;
           sentinelSeekTime = undefined;
           range = undefined;
+          DebugTool.info('cehtml::wipe --> checking mediaElement exists...');
           if (mediaElement) {
             clearInterval(updateInterval);
             clearSentinels();
             DebugTool.info('destroying media element');
             destroyMediaElement();
             DebugTool.info('destroyed media element');
+          } else {
+            DebugTool.info('cehtml::wipe --> mediaElement does not exist!');
           }
         }
 
         function destroyMediaElement () {
+          DebugTool.info('cehtml::destroyMediaElement()');
           delete mediaElement.onPlayStateChange;
+          DebugTool.info('cehtml::destroyMediaElement --> Checking mediaElement.parentElement exists...');
           if (mediaElement.parentElement) {
+            DebugTool.info('cehtml::destroyMediaElement --> mediaElement.parentElement exists! removing itself...');
             mediaElement.parentElement.removeChild(mediaElement);
+            DebugTool.info('cehtml::destroyMediaElement --> mediaElement.parentElement exists! sucessfully removed itself');
+          } else {
+            DebugTool.info('cehtml::destroyMediaElement --> mediaElement.parentElement does not exist!');
           }
           mediaElement = undefined;
         }

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -552,7 +552,9 @@ define(
 
         function destroyMediaElement () {
           delete mediaElement.onPlayStateChange;
-          mediaElement.remove();
+          if (mediaElement.parentElement) {
+            mediaElement.parentElement.removeChild(mediaElement);
+          }
           mediaElement = undefined;
         }
 

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -187,6 +187,7 @@ define(
         }
 
         function initialiseMedia (type, url, mediaMimeType, sourceContainer, opts) {
+          DebugTool.info('Start init media');
           disableSentinels = opts.disableSentinels;
           mediaType = type;
           source = url;
@@ -341,6 +342,7 @@ define(
         }
 
         function reset () {
+          DebugTool.info('Start reset');
           switch (getState()) {
             case MediaPlayerBase.STATE.EMPTY:
               break;
@@ -492,6 +494,7 @@ define(
           updateInterval = setInterval(function () {
             onStatus();
           }, DEVICE_UPDATE_PERIOD_MS);
+          DebugTool.info('set interval');
         }
 
         function addElementToDOM () {
@@ -545,6 +548,7 @@ define(
           range = undefined;
           if (mediaElement) {
             clearInterval(updateInterval);
+            DebugTool.info('clear interval');
             clearSentinels();
             destroyMediaElement();
           }

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -342,7 +342,9 @@ define(
             case MediaPlayerBase.STATE.COMPLETE:
               DebugTool.info('cehtml::stop --> in MediaPlayerBase.STATE.COMPLETE, resetting sentinel seek time and stopping media element!');
               sentinelSeekTime = undefined;
-              mediaElement.stop();
+              if (mediaElement.stop) {
+                mediaElement.stop();
+              }
               DebugTool.info('cehtml::stop --> in MediaPlayerBase.STATE.COMPLETE, media element stopped! attempting toStopped() call...');
               toStopped();
               DebugTool.info('cehtml::stop --> in MediaPlayerBase.STATE.COMPLETE, toStopped() called!');

--- a/script/playbackstrategy/modifiers/live/none.js
+++ b/script/playbackstrategy/modifiers/live/none.js
@@ -1,0 +1,9 @@
+define(
+  'bigscreenplayer/playbackstrategy/modifiers/live/none',
+  [],
+  function () {
+    return function () {
+      throw new Error('Cannot create a none live support player');
+    };
+  }
+);

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -3,9 +3,10 @@ define(
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
     'bigscreenplayer/models/windowtypes',
-    'bigscreenplayer/dynamicwindowutils'
+    'bigscreenplayer/dynamicwindowutils',
+    'bigscreenplayer/debugger/debugtool'
   ],
-    function (MediaPlayerBase, WindowTypes, DynamicWindowUtils) {
+    function (MediaPlayerBase, WindowTypes, DynamicWindowUtils, DebugTool) {
       'use strict';
 
       function RestartableLivePlayer (mediaPlayer, deviceConfig, windowType, timeData) {
@@ -22,6 +23,11 @@ define(
 
           fakeTimer.runningTime = Date.now();
           fakeTimer.wasPlaying = event.state === MediaPlayerBase.STATE.PLAYING;
+
+          DebugTool.keyValue({key: 'event.state: ', value: event.state});
+          DebugTool.keyValue({key: 'fakeTimer.wasPlaying: ', value: fakeTimer.wasPlaying});
+          DebugTool.keyValue({key: 'fakeTimer.runningTime: ', value: fakeTimer.runningTime});
+          DebugTool.keyValue({key: 'fakeTimer.currentTime: ', value: fakeTimer.currentTime});
         }
 
         function addEventCallback (thisArg, callback) {

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -17,6 +17,7 @@ define(
         addEventCallback(this, updateFakeTimer);
 
         function updateFakeTimer (event) {
+          DebugTool.info('Update fake time');
           if (fakeTimer.wasPlaying && fakeTimer.runningTime) {
             fakeTimer.currentTime += (Date.now() - fakeTimer.runningTime) / 1000;
           }

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -3,10 +3,9 @@ define(
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
     'bigscreenplayer/models/windowtypes',
-    'bigscreenplayer/dynamicwindowutils',
-    'bigscreenplayer/debugger/debugtool'
+    'bigscreenplayer/dynamicwindowutils'
   ],
-    function (MediaPlayerBase, WindowTypes, DynamicWindowUtils, DebugTool) {
+    function (MediaPlayerBase, WindowTypes, DynamicWindowUtils) {
       'use strict';
 
       function RestartableLivePlayer (mediaPlayer, deviceConfig, windowType, timeData) {
@@ -17,18 +16,12 @@ define(
         addEventCallback(this, updateFakeTimer);
 
         function updateFakeTimer (event) {
-          DebugTool.info('Update fake time');
           if (fakeTimer.wasPlaying && fakeTimer.runningTime) {
             fakeTimer.currentTime += (Date.now() - fakeTimer.runningTime) / 1000;
           }
 
           fakeTimer.runningTime = Date.now();
           fakeTimer.wasPlaying = event.state === MediaPlayerBase.STATE.PLAYING;
-
-          DebugTool.keyValue({key: 'event.state: ', value: event.state});
-          DebugTool.keyValue({key: 'fakeTimer.wasPlaying: ', value: fakeTimer.wasPlaying});
-          DebugTool.keyValue({key: 'fakeTimer.runningTime: ', value: fakeTimer.runningTime});
-          DebugTool.keyValue({key: 'fakeTimer.currentTime: ', value: fakeTimer.currentTime});
         }
 
         function addEventCallback (thisArg, callback) {

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -118,7 +118,6 @@ define(
 
           stop: function () {
             mediaPlayer.stop();
-            removeEventCallback(this, updateFakeTimer);
           },
 
           reset: function () {

--- a/script/playbackstrategy/nativestrategy.js
+++ b/script/playbackstrategy/nativestrategy.js
@@ -2,15 +2,15 @@ define('bigscreenplayer/playbackstrategy/nativestrategy',
   [
     'bigscreenplayer/playbackstrategy/legacyplayeradapter',
     'bigscreenplayer/models/windowtypes',
-    'bigscreenplayer/playbackstrategy/modifiers/html5',
+    'bigscreenplayer/playbackstrategy/modifiers/' + (window.bigscreenPlayer.mediaPlayer || 'html5'),
     'bigscreenplayer/playbackstrategy/modifiers/live/' + (window.bigscreenPlayer.liveSupport || 'playable')
   ],
-  function (LegacyAdapter, WindowTypes, Html5Player, LivePlayer) {
+  function (LegacyAdapter, WindowTypes, MediaPlayer, LivePlayer) {
     var NativeStrategy = function (windowType, mediaKind, timeData, playbackElement, isUHD, device) {
       var mediaPlayer;
       var tempConfig = device.getConfig();
 
-      mediaPlayer = Html5Player(tempConfig);
+      mediaPlayer = MediaPlayer(window.bigscreenPlayer.mediaPlayer === 'html5' ? tempConfig : device);
       if (windowType !== WindowTypes.STATIC) {
         mediaPlayer = LivePlayer(mediaPlayer, tempConfig, windowType, timeData);
       }

--- a/script/playbackstrategy/nativestrategy.js
+++ b/script/playbackstrategy/nativestrategy.js
@@ -10,7 +10,7 @@ define('bigscreenplayer/playbackstrategy/nativestrategy',
       var mediaPlayer;
       var tempConfig = device.getConfig();
 
-      mediaPlayer = MediaPlayer(window.bigscreenPlayer.mediaPlayer === 'html5' ? tempConfig : device);
+      mediaPlayer = MediaPlayer(window.bigscreenPlayer.mediaPlayer === 'cehtml' ? device : tempConfig);
       if (windowType !== WindowTypes.STATIC) {
         mediaPlayer = LivePlayer(mediaPlayer, tempConfig, windowType, timeData);
       }

--- a/script/playbackstrategy/nativestrategy.js
+++ b/script/playbackstrategy/nativestrategy.js
@@ -10,7 +10,7 @@ define('bigscreenplayer/playbackstrategy/nativestrategy',
       var mediaPlayer;
       var tempConfig = device.getConfig();
 
-      mediaPlayer = MediaPlayer(window.bigscreenPlayer.mediaPlayer === 'cehtml' ? device : tempConfig);
+      mediaPlayer = MediaPlayer(tempConfig);
       if (windowType !== WindowTypes.STATIC) {
         mediaPlayer = LivePlayer(mediaPlayer, tempConfig, windowType, timeData);
       }


### PR DESCRIPTION
Add the cehtml player as an alternative to the html5 player. Setting `window.bigscreenPlayer.mediaPlayer` to `cehtml` will enable this, leaving it unset or setting it to `html5` will use the existing player