### PR TITLE
Prepare release 3.0.0 - update package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "2.12.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
📺 What

Prepare release 3.0.0.

🛠 How

Update `package-lock`. Previous commit to master updated the `package.json` but I forgot to do the `package-lock`