### PR TITLE
Report fragment request time to the plugins

### DIFF
--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -741,7 +741,8 @@ require(
           expect(mockPluginsInterface.onPlayerInfoUpdated).toHaveBeenCalledWith({
             playbackBitrate: 2.048,
             bufferLength: undefined,
-            fragmentRequestTime: undefined
+            fragmentRequestTime: undefined,
+            numFragment: undefined
           });
         });
 
@@ -776,7 +777,8 @@ require(
           expect(mockPluginsInterface.onPlayerInfoUpdated).toHaveBeenCalledWith({
             playbackBitrate: undefined,
             bufferLength: 'buffer',
-            fragmentRequestTime: undefined
+            fragmentRequestTime: undefined,
+            numFragment: undefined
           });
         });
 

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -740,7 +740,8 @@ require(
 
           expect(mockPluginsInterface.onPlayerInfoUpdated).toHaveBeenCalledWith({
             playbackBitrate: 2.048,
-            bufferLength: undefined
+            bufferLength: undefined,
+            fragmentRequestTime: undefined
           });
         });
 
@@ -774,7 +775,8 @@ require(
 
           expect(mockPluginsInterface.onPlayerInfoUpdated).toHaveBeenCalledWith({
             playbackBitrate: undefined,
-            bufferLength: 'buffer'
+            bufferLength: 'buffer',
+            fragmentRequestTime: undefined
           });
         });
 

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -740,11 +740,7 @@ require(
 
           expect(mockPluginsInterface.onPlayerInfoUpdated).toHaveBeenCalledWith({
             playbackBitrate: 2.048,
-            bufferLength: undefined,
-            fragmentInfo: {
-              requestTime: undefined,
-              numDownloaded: undefined
-            }
+            bufferLength: undefined
           });
         });
 
@@ -778,11 +774,7 @@ require(
 
           expect(mockPluginsInterface.onPlayerInfoUpdated).toHaveBeenCalledWith({
             playbackBitrate: undefined,
-            bufferLength: 'buffer',
-            fragmentInfo: {
-              requestTime: undefined,
-              numDownloaded: undefined
-            }
+            bufferLength: 'buffer'
           });
         });
 

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -741,8 +741,10 @@ require(
           expect(mockPluginsInterface.onPlayerInfoUpdated).toHaveBeenCalledWith({
             playbackBitrate: 2.048,
             bufferLength: undefined,
-            fragmentRequestTime: undefined,
-            numFragment: undefined
+            fragmentInfo: {
+              requestTime: undefined,
+              numDownloaded: undefined
+            }
           });
         });
 
@@ -777,8 +779,10 @@ require(
           expect(mockPluginsInterface.onPlayerInfoUpdated).toHaveBeenCalledWith({
             playbackBitrate: undefined,
             bufferLength: 'buffer',
-            fragmentRequestTime: undefined,
-            numFragment: undefined
+            fragmentInfo: {
+              requestTime: undefined,
+              numDownloaded: undefined
+            }
           });
         });
 

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -189,7 +189,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           }
         }
         if (event.mediaType === 'video' && event.metric === 'HttpList') {
-          playerMetadata.fragmentRequestTime = Math.abs(event.value._tfinish.getTime() - event.value.trequest.getTime()); // e.value.tresponse - e.value.trequest;
+          playerMetadata.fragmentRequestTime = Math.abs(event.value._tfinish.getTime() - event.value.trequest.getTime());
           Plugins.interface.onPlayerInfoUpdated(playerMetadata);
         }
       }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -188,7 +188,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
             Plugins.interface.onPlayerInfoUpdated(playerMetadata);
           }
         }
-        if (event.mediaType === 'video' && event.metric === 'HttpList') {
+        if (event.mediaType === mediaKind && event.metric === 'HttpList') {
           playerMetadata.fragmentRequestTime = Math.abs(event.value._tfinish.getTime() - event.value.trequest.getTime());
           Plugins.interface.onPlayerInfoUpdated(playerMetadata);
         }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -189,8 +189,8 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
             Plugins.interface.onPlayerInfoUpdated(playerMetadata);
           }
         }
-        if (event.mediaType === mediaKind && event.metric === 'HttpList') {
-          playerMetadata.fragmentRequestTime = Math.abs(event.value._tfinish.getTime() - event.value.trequest.getTime());
+        if (event.mediaType === mediaKind && event.metric === 'HttpList' && event.value._tfinish && event.value.trequest) {
+          playerMetadata.fragmentRequestTime = Math.floor(Math.abs(event.value._tfinish.getTime() - event.value.trequest.getTime()));
           playerMetadata.numFragment = playerMetadata.numFragment ? playerMetadata.numFragment++ : 1;
           Plugins.interface.onPlayerInfoUpdated(playerMetadata);
         }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -32,8 +32,10 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       var playerMetadata = {
         playbackBitrate: undefined,
         bufferLength: undefined,
-        fragmentRequestTime: undefined,
-        numFragment: undefined
+        fragmentInfo: {
+          requestTime: undefined,
+          numDownloaded: undefined
+        }
       };
 
       var DashJSEvents = {
@@ -190,8 +192,8 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           }
         }
         if (event.mediaType === mediaKind && event.metric === 'HttpList' && event.value._tfinish && event.value.trequest) {
-          playerMetadata.fragmentRequestTime = Math.floor(Math.abs(event.value._tfinish.getTime() - event.value.trequest.getTime()));
-          playerMetadata.numFragment = playerMetadata.numFragment ? playerMetadata.numFragment++ : 1;
+          playerMetadata.fragmentInfo.requestTime = Math.floor(Math.abs(event.value._tfinish.getTime() - event.value.trequest.getTime()));
+          playerMetadata.fragmentInfo.numDownloaded = playerMetadata.fragmentInfo.numDownloaded ? ++playerMetadata.fragmentInfo.numDownloaded : 1;
           Plugins.interface.onPlayerInfoUpdated(playerMetadata);
         }
       }
@@ -397,6 +399,14 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           bitrateInfoList = undefined;
           mediaMetrics = undefined;
           dashMetrics = undefined;
+          playerMetadata = {
+            playbackBitrate: undefined,
+            bufferLength: undefined,
+            fragmentInfo: {
+              requestTime: undefined,
+              numDownloaded: undefined
+            }
+          };
         },
         reset: function () {
           return;

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -32,7 +32,8 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       var playerMetadata = {
         playbackBitrate: undefined,
         bufferLength: undefined,
-        fragmentRequestTime: undefined
+        fragmentRequestTime: undefined,
+        numFragment: undefined
       };
 
       var DashJSEvents = {
@@ -190,6 +191,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         }
         if (event.mediaType === mediaKind && event.metric === 'HttpList') {
           playerMetadata.fragmentRequestTime = Math.abs(event.value._tfinish.getTime() - event.value.trequest.getTime());
+          playerMetadata.numFragment = playerMetadata.numFragment ? playerMetadata.numFragment++ : 1;
           Plugins.interface.onPlayerInfoUpdated(playerMetadata);
         }
       }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -152,7 +152,10 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
             DebugTool.keyValue({ key: event.mediaType + ' Representation', value: newRepresentation });
             DebugTool.info('ABR Change Rendered From Representation ' + oldRepresentation + ' To ' + newRepresentation);
           }
-          Plugins.interface.onPlayerInfoUpdated(playerMetadata);
+          Plugins.interface.onPlayerInfoUpdated({
+            bufferLength: playerMetadata.bufferLength,
+            playbackBitrate: playerMetadata.playbackBitrate
+          });
         }
       }
 
@@ -188,13 +191,18 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           if (mediaMetrics && dashMetrics) {
             playerMetadata.bufferLength = dashMetrics.getCurrentBufferLevel(mediaMetrics);
             DebugTool.keyValue({ key: 'Buffer Length', value: playerMetadata.bufferLength });
-            Plugins.interface.onPlayerInfoUpdated(playerMetadata);
+            Plugins.interface.onPlayerInfoUpdated({
+              bufferLength: playerMetadata.bufferLength,
+              playbackBitrate: playerMetadata.playbackBitrate
+            });
           }
         }
         if (event.mediaType === mediaKind && event.metric === 'HttpList' && event.value._tfinish && event.value.trequest) {
           playerMetadata.fragmentInfo.requestTime = Math.floor(Math.abs(event.value._tfinish.getTime() - event.value.trequest.getTime()));
           playerMetadata.fragmentInfo.numDownloaded = playerMetadata.fragmentInfo.numDownloaded ? ++playerMetadata.fragmentInfo.numDownloaded : 1;
-          Plugins.interface.onPlayerInfoUpdated(playerMetadata);
+          Plugins.interface.onPlayerInfoUpdated({
+            fragmentInfo: playerMetadata.fragmentInfo
+          });
         }
       }
 

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -31,7 +31,8 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
 
       var playerMetadata = {
         playbackBitrate: undefined,
-        bufferLength: undefined
+        bufferLength: undefined,
+        fragmentRequestTime: undefined
       };
 
       var DashJSEvents = {
@@ -186,6 +187,10 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
             DebugTool.keyValue({ key: 'Buffer Length', value: playerMetadata.bufferLength });
             Plugins.interface.onPlayerInfoUpdated(playerMetadata);
           }
+        }
+        if (event.mediaType === 'video' && event.metric === 'HttpList') {
+          playerMetadata.fragmentRequestTime = Math.abs(event.value._tfinish.getTime() - event.value.trequest.getTime()); // e.value.tresponse - e.value.trequest;
+          Plugins.interface.onPlayerInfoUpdated(playerMetadata);
         }
       }
 


### PR DESCRIPTION
📺 What

This adds the fragment download time of a dash fragment **(MSE only)** to the `onPlayerInfoUpdated` plugin callback.

> Tickets: IPLAYERTVV1-8976


🛠 How

This uses the `HttpList` object passed through when a dash metric is added to the player, and propagates the time it took the request in it's entirety to the plugins. 

