### PR TITLE
Growing window manifest refresh

### DIFF
--- a/script-test/playbackstrategies/growingwindowrefreshertest.js
+++ b/script-test/playbackstrategies/growingwindowrefreshertest.js
@@ -5,9 +5,9 @@ require(
     function (GrowingWindowRefresher) {
       describe('GrowingWindowRefresher', function () {
         var mediaPlayerSpy;
-        var growingWindowRefresher;
         var eventHandlers;
         var dashEventCallback;
+        var seekCallbacksSpy;
 
         var dashjsMediaPlayerEvents = {
           ERROR: 'error',
@@ -25,7 +25,8 @@ require(
             eventHandlers[eventType](event);
           };
 
-          growingWindowRefresher = GrowingWindowRefresher(mediaPlayerSpy);
+          seekCallbacksSpy = jasmine.createSpy('seekCallbacksSpy');
+          GrowingWindowRefresher(mediaPlayerSpy, seekCallbacksSpy);
           jasmine.clock().install();
         });
 
@@ -33,79 +34,19 @@ require(
           jasmine.clock().uninstall();
         });
 
-        it('Start() refreshes the manifest at interval timeout ', function () {
-          growingWindowRefresher.start();
+        it('calls the given callback on media player MANIFEST_LOADED event', function () {
+          dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {data: {mediaPresentationDuration: 100}});
 
-          expect(mediaPlayerSpy.refreshManifest).not.toHaveBeenCalled();
-          jasmine.clock().tick(60000);
-
-          expect(mediaPlayerSpy.refreshManifest).toHaveBeenCalledTimes(1);
-
-          jasmine.clock().tick(60000);
-
-          expect(mediaPlayerSpy.refreshManifest).toHaveBeenCalledTimes(2);
+          expect(seekCallbacksSpy).toHaveBeenCalled();
         });
 
-        it('Stop() clears the refresh interval', function () {
-          growingWindowRefresher.start();
-
-          growingWindowRefresher.stop();
-          jasmine.clock().tick(60000);
-
-          expect(mediaPlayerSpy.refreshManifest).not.toHaveBeenCalled();
-        });
-
-        it('Seek() calls the given callback on media player load manifest event', function () {
-          var seekCallbacksSpy = jasmine.createSpyObj('seekCallbacksSpy', ['onSuccess', 'onError']);
-          growingWindowRefresher.seek(seekCallbacksSpy);
-
-          dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {});
-
-          expect(seekCallbacksSpy.onSuccess).toHaveBeenCalled();
-        });
-
-        it('Seek() calls the given callback on manifest load error event', function () {
-          var seekCallbacksSpy = jasmine.createSpyObj('seekCallbacksSpy', ['onSuccess', 'onError']);
-          growingWindowRefresher.seek(seekCallbacksSpy);
-
-          dashEventCallback(dashjsMediaPlayerEvents.ERROR, {code: 25});
-
-          expect(seekCallbacksSpy.onError).toHaveBeenCalled();
-        });
-
-        it('Seek() does not call the given error callback on dashjs non manifest load error', function () {
-          var seekCallbacksSpy = jasmine.createSpyObj('seekCallbacksSpy', ['onSuccess', 'onError']);
-          growingWindowRefresher.seek(seekCallbacksSpy);
-
-          dashEventCallback(dashjsMediaPlayerEvents.ERROR, {code: 100});
-
-          expect(seekCallbacksSpy.onError).not.toHaveBeenCalled();
-        });
-
-        it('Seek() removes all listeners following manifest load event', function () {
-          var seekCallbacksSpy = jasmine.createSpyObj('seekCallbacksSpy', ['onSuccess', 'onError']);
-          growingWindowRefresher.seek(seekCallbacksSpy);
-
-          dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {});
+        it('removes MANIFEST_LOADED listener following manifest load event', function () {
+          dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {data: {mediaPresentationDuration: 100}});
 
           expect(mediaPlayerSpy.off).toHaveBeenCalledWith('manifestLoaded', eventHandlers.manifestLoaded);
-          expect(mediaPlayerSpy.off).toHaveBeenCalledWith('error', eventHandlers.error);
         });
 
-        it('Seek() removes all the listeners following a manifest error event', function () {
-          var seekCallbacksSpy = jasmine.createSpyObj('seekCallbacksSpy', ['onSuccess', 'onError']);
-          growingWindowRefresher.seek(seekCallbacksSpy);
-
-          dashEventCallback(dashjsMediaPlayerEvents.ERROR, {code: 25});
-
-          expect(mediaPlayerSpy.off).toHaveBeenCalledWith('manifestLoaded', eventHandlers.manifestLoaded);
-          expect(mediaPlayerSpy.off).toHaveBeenCalledWith('error', eventHandlers.error);
-        });
-
-        it('Seek() attempts to refresh the manifest', function () {
-          var seekCallbacksSpy = jasmine.createSpyObj('seekCallbacksSpy', ['onSuccess', 'onError']);
-          growingWindowRefresher.seek(seekCallbacksSpy);
-
+        it('should instruct the media player to refresh the manifest', function () {
           expect(mediaPlayerSpy.refreshManifest).toHaveBeenCalledTimes(1);
         });
       });

--- a/script-test/playbackstrategies/growingwindowrefreshertest.js
+++ b/script-test/playbackstrategies/growingwindowrefreshertest.js
@@ -26,28 +26,26 @@ require(
           };
 
           seekCallbacksSpy = jasmine.createSpy('seekCallbacksSpy');
-          GrowingWindowRefresher(mediaPlayerSpy, seekCallbacksSpy);
-          jasmine.clock().install();
         });
 
-        afterEach(function () {
-          jasmine.clock().uninstall();
+        it('should instruct the media player to refresh the manifest', function () {
+          GrowingWindowRefresher(mediaPlayerSpy, seekCallbacksSpy);
+
+          expect(mediaPlayerSpy.refreshManifest).toHaveBeenCalledTimes(1);
         });
 
         it('calls the given callback on media player MANIFEST_LOADED event', function () {
+          GrowingWindowRefresher(mediaPlayerSpy, seekCallbacksSpy);
           dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {data: {mediaPresentationDuration: 100}});
 
           expect(seekCallbacksSpy).toHaveBeenCalled();
         });
 
         it('removes MANIFEST_LOADED listener following manifest load event', function () {
+          GrowingWindowRefresher(mediaPlayerSpy, seekCallbacksSpy);
           dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {data: {mediaPresentationDuration: 100}});
 
           expect(mediaPlayerSpy.off).toHaveBeenCalledWith('manifestLoaded', eventHandlers.manifestLoaded);
-        });
-
-        it('should instruct the media player to refresh the manifest', function () {
-          expect(mediaPlayerSpy.refreshManifest).toHaveBeenCalledTimes(1);
         });
       });
     });

--- a/script-test/playbackstrategies/growingwindowrefreshertest.js
+++ b/script-test/playbackstrategies/growingwindowrefreshertest.js
@@ -1,0 +1,113 @@
+require(
+  [
+    'bigscreenplayer/playbackstrategy/growingwindowrefresher'
+  ],
+    function (GrowingWindowRefresher) {
+      describe('GrowingWindowRefresher', function () {
+        var mediaPlayerSpy;
+        var growingWindowRefresher;
+        var eventHandlers;
+        var dashEventCallback;
+
+        var dashjsMediaPlayerEvents = {
+          ERROR: 'error',
+          MANIFEST_LOADED: 'manifestLoaded'
+        };
+
+        beforeEach(function () {
+          eventHandlers = {};
+          mediaPlayerSpy = jasmine.createSpyObj('mediaPlayer', ['refreshManifest', 'on', 'off']);
+          mediaPlayerSpy.on.and.callFake(function (eventType, handler) {
+            eventHandlers[eventType] = handler;
+          });
+
+          dashEventCallback = function (eventType, event) {
+            eventHandlers[eventType](event);
+          };
+
+          growingWindowRefresher = GrowingWindowRefresher(mediaPlayerSpy);
+          jasmine.clock().install();
+        });
+
+        afterEach(function () {
+          jasmine.clock().uninstall();
+        });
+
+        it('Start() refreshes the manifest at interval timeout ', function () {
+          growingWindowRefresher.start();
+
+          expect(mediaPlayerSpy.refreshManifest).not.toHaveBeenCalled();
+          jasmine.clock().tick(60000);
+
+          expect(mediaPlayerSpy.refreshManifest).toHaveBeenCalledTimes(1);
+
+          jasmine.clock().tick(60000);
+
+          expect(mediaPlayerSpy.refreshManifest).toHaveBeenCalledTimes(2);
+        });
+
+        it('Stop() clears the refresh interval', function () {
+          growingWindowRefresher.start();
+
+          growingWindowRefresher.stop();
+          jasmine.clock().tick(60000);
+
+          expect(mediaPlayerSpy.refreshManifest).not.toHaveBeenCalled();
+        });
+
+        it('Seek() calls the given callback on media player load manifest event', function () {
+          var seekCallbacksSpy = jasmine.createSpyObj('seekCallbacksSpy', ['onSuccess', 'onError']);
+          growingWindowRefresher.seek(seekCallbacksSpy);
+
+          dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {});
+
+          expect(seekCallbacksSpy.onSuccess).toHaveBeenCalled();
+        });
+
+        it('Seek() calls the given callback on manifest load error event', function () {
+          var seekCallbacksSpy = jasmine.createSpyObj('seekCallbacksSpy', ['onSuccess', 'onError']);
+          growingWindowRefresher.seek(seekCallbacksSpy);
+
+          dashEventCallback(dashjsMediaPlayerEvents.ERROR, {code: 25});
+
+          expect(seekCallbacksSpy.onError).toHaveBeenCalled();
+        });
+
+        it('Seek() does not call the given error callback on dashjs non manifest load error', function () {
+          var seekCallbacksSpy = jasmine.createSpyObj('seekCallbacksSpy', ['onSuccess', 'onError']);
+          growingWindowRefresher.seek(seekCallbacksSpy);
+
+          dashEventCallback(dashjsMediaPlayerEvents.ERROR, {code: 100});
+
+          expect(seekCallbacksSpy.onError).not.toHaveBeenCalled();
+        });
+
+        it('Seek() removes all listeners following manifest load event', function () {
+          var seekCallbacksSpy = jasmine.createSpyObj('seekCallbacksSpy', ['onSuccess', 'onError']);
+          growingWindowRefresher.seek(seekCallbacksSpy);
+
+          dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {});
+
+          expect(mediaPlayerSpy.off).toHaveBeenCalledWith('manifestLoaded', eventHandlers.manifestLoaded);
+          expect(mediaPlayerSpy.off).toHaveBeenCalledWith('error', eventHandlers.error);
+        });
+
+        it('Seek() removes all the listeners following a manifest error event', function () {
+          var seekCallbacksSpy = jasmine.createSpyObj('seekCallbacksSpy', ['onSuccess', 'onError']);
+          growingWindowRefresher.seek(seekCallbacksSpy);
+
+          dashEventCallback(dashjsMediaPlayerEvents.ERROR, {code: 25});
+
+          expect(mediaPlayerSpy.off).toHaveBeenCalledWith('manifestLoaded', eventHandlers.manifestLoaded);
+          expect(mediaPlayerSpy.off).toHaveBeenCalledWith('error', eventHandlers.error);
+        });
+
+        it('Seek() attempts to refresh the manifest', function () {
+          var seekCallbacksSpy = jasmine.createSpyObj('seekCallbacksSpy', ['onSuccess', 'onError']);
+          growingWindowRefresher.seek(seekCallbacksSpy);
+
+          expect(mediaPlayerSpy.refreshManifest).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -176,8 +176,16 @@ require(
         document.body.removeChild(playbackElement);
         mockPluginsInterface.onErrorHandled.calls.reset();
         mockDashInstance.attachSource.calls.reset();
+        mockDashInstance.seek.calls.reset();
         mockRefresherStartSpy.calls.reset();
         mockRefresherStopSpy.calls.reset();
+
+        if (refresherCallbackSuccessSpy) {
+          refresherCallbackSuccessSpy.calls.reset();
+        }
+        if (refresherCallbackErrorSpy) {
+          refresherCallbackErrorSpy.calls.reset();
+        }
       });
 
       function setUpMSE (timeCorrection, windowType, mediaKind, windowStartTimeMS, windowEndTimeMS) {

--- a/script/playbackstrategy/growingwindowrefresher.js
+++ b/script/playbackstrategy/growingwindowrefresher.js
@@ -1,0 +1,9 @@
+define('bigscreenplayer/playbackstrategy/growingwindowrefresher',
+  function () {
+    return function (mediaPlayer) {
+      return {
+
+      };
+    };
+  }
+);

--- a/script/playbackstrategy/growingwindowrefresher.js
+++ b/script/playbackstrategy/growingwindowrefresher.js
@@ -1,47 +1,14 @@
 define('bigscreenplayer/playbackstrategy/growingwindowrefresher', [],
   function () {
-    return function (mediaPlayer) {
-      var refreshInterval;
-
-      function start () {
-        refreshInterval = setInterval(function () {
-          mediaPlayer.refreshManifest();
-        }, 60000);
+    return function (mediaPlayer, callback) {
+      function onSuccess (event) {
+        mediaPlayer.off('manifestLoaded', onSuccess);
+        callback(event.data.mediaPresentationDuration);
       }
 
-      function stop () {
-        clearInterval(refreshInterval);
-      }
+      mediaPlayer.on('manifestLoaded', onSuccess);
 
-      function seek (callbacks) {
-        function onSuccess () {
-          removeListeners();
-          callbacks.onSuccess();
-        }
-
-        function onError (evt) {
-          if (evt.code === 25) { // code 25 is a dashjs manifest load error
-            removeListeners();
-            callbacks.onError();
-          }
-        }
-
-        function removeListeners () {
-          mediaPlayer.off('manifestLoaded', onSuccess);
-          mediaPlayer.off('error', onError);
-        }
-
-        mediaPlayer.on('manifestLoaded', onSuccess);
-        mediaPlayer.on('error', onError);
-
-        mediaPlayer.refreshManifest();
-      }
-
-      return {
-        start: start,
-        stop: stop,
-        seek: seek
-      };
+      mediaPlayer.refreshManifest();
     };
   }
 );

--- a/script/playbackstrategy/growingwindowrefresher.js
+++ b/script/playbackstrategy/growingwindowrefresher.js
@@ -1,8 +1,46 @@
-define('bigscreenplayer/playbackstrategy/growingwindowrefresher',
+define('bigscreenplayer/playbackstrategy/growingwindowrefresher', [],
   function () {
     return function (mediaPlayer) {
-      return {
+      var refreshInterval;
 
+      function start () {
+        refreshInterval = setInterval(function () {
+          mediaPlayer.refreshManifest();
+        }, 60000);
+      }
+
+      function stop () {
+        clearInterval(refreshInterval);
+      }
+
+      function seek (callbacks) {
+        function onSuccess () {
+          removeListeners();
+          callbacks.onSuccess();
+        }
+
+        function onError (evt) {
+          if (evt.code === 25) { // code 25 is a dashjs manifest load error
+            removeListeners();
+            callbacks.onError();
+          }
+        }
+
+        function removeListeners () {
+          mediaPlayer.off('manifestLoaded', onSuccess);
+          mediaPlayer.off('error', onError);
+        }
+
+        mediaPlayer.on('manifestLoaded', onSuccess);
+        mediaPlayer.on('error', onError);
+
+        mediaPlayer.refreshManifest();
+      }
+
+      return {
+        start: start,
+        stop: stop,
+        seek: seek
       };
     };
   }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -479,7 +479,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           var seekToTime = getClampedTime(time, getSeekableRange());
           if (windowType === WindowTypes.SLIDING) {
             mediaElement.currentTime = (seekToTime + timeCorrection);
-          } else if (windowType === WindowTypes.GROWING) {
+          } else if (windowType === WindowTypes.GROWING && seekToTime > getCurrentTime()) {
             refreshManifestBeforeSeek(seekToTime);
           } else {
             mediaPlayer.seek(seekToTime);

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -372,6 +372,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         refreshFailoverTime = seekToTime;
         GrowingWindowRefresher(mediaPlayer, function (mediaPresentationDuration) {
           if (!isNaN(mediaPresentationDuration)) {
+            DebugTool.info('Stream ended. Clamping seek point to end of stream');
             mediaPlayer.seek(getClampedTime(seekToTime, {start: getSeekableRange().start, end: mediaPresentationDuration}));
           } else {
             mediaPlayer.seek(seekToTime);

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -24,6 +24,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
 
       var timeCorrection = mediaSources.time() && mediaSources.time().correction || 0;
       var failoverTime;
+      var refreshFailoverTime;
       var isEnded = false;
 
       var bitrateInfoList;
@@ -338,6 +339,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       }
 
       function refreshManifestBeforeSeek (seekToTime) {
+        refreshFailoverTime = seekToTime;
         GrowingWindowRefresher(mediaPlayer, function (mediaPresentationDuration) {
           if (!isNaN(mediaPresentationDuration)) {
             mediaPlayer.seek(getClampedTime(seekToTime, {start: getSeekableRange().start, end: mediaPresentationDuration}));
@@ -381,7 +383,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
             setUpMediaPlayer(playbackTime);
             setUpMediaListeners();
           } else {
-            modifySource(failoverTime);
+            modifySource(refreshFailoverTime || failoverTime);
           }
         },
         getSeekableRange: getSeekableRange,


### PR DESCRIPTION
📺 What

Prevent seeking beyond the end of a growing window stream, which will result in multiple 404's and eventually a fatal error.

> Tickets: IPLAYERTVV1-9617

🛠 How

Refreshes the manifest when seeking forwards in a GROWING WINDOW asset. If the asset has ended, and the manifest contains a `mediaPresentationDuration`, the seek time will be clamped to this.