### PR TITLE
Update dash.js to 2.9.3-3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1125,8 +1125,8 @@
       }
     },
     "dashjs": {
-      "version": "github:bbc/dash.js#a24fbcdcda5c83788217cf4178e58ef4d9c6266a",
-      "from": "github:bbc/dash.js#smp-v2.9.3-0",
+      "version": "github:bbc/dash.js#54766df3c327864432b60817b3ce2fa1b61bbd61",
+      "from": "github:bbc/dash.js#smp-v2.9.3-3",
       "requires": {
         "codem-isoboxer": "0.3.6",
         "fast-deep-equal": "2.0.1",
@@ -2474,9 +2474,9 @@
       }
     },
     "imsc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/imsc/-/imsc-1.0.2.tgz",
-      "integrity": "sha512-oxQWr4g2bAzjz5TIXA4K+9xQ4nnktsDI12/nijLQ42lT5c76JO7A8i9pbVkC8MUNQl3sd+bdwshnxB1Wn8lZlQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/imsc/-/imsc-1.1.0.tgz",
+      "integrity": "sha512-z2aUE3X00O39fCgkLHEVbfKG/D9cBrmsbf4NjP7K1gQb06YBjgljq5nZD72HYMFG2lRJI7QY7v+JVxg6o6I/Jg==",
       "requires": {
         "sax": "1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "squirejs": "0.2.1"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#smp-v2.9.3-0"
+    "dashjs": "github:bbc/dash.js#smp-v2.9.3-3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
📺 What

Update dash.js to [v2.9.3-3](https://github.com/bbc/dash.js/releases/tag/smp-v2.9.3-3)


🛠 How

[Changelog between 2.9.3-0 and 2.9.3-3](https://github.com/bbc/dash.js/compare/smp-v2.9.3-0...smp-v2.9.3-3)
