### PR TITLE
Clear up playback properties on plugin events - missed as part of #92

### DIFF
--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -863,9 +863,9 @@ require(
             initialiseBigscreenPlayer();
             bigscreenPlayer.registerPlugin(mockPlugin);
 
-            Plugins.interface.onError({errorProperties: {}});
+            Plugins.interface.onError();
 
-            expect(mockPlugin.onError).toHaveBeenCalledWith({errorProperties: {}});
+            expect(mockPlugin.onError).toHaveBeenCalled();
           });
         });
 
@@ -890,16 +890,16 @@ require(
           it('should remove a specific plugin', function () {
             bigscreenPlayer.unregisterPlugin(mockPlugin);
 
-            Plugins.interface.onError({errorProperties: {}});
+            Plugins.interface.onError();
 
             expect(mockPlugin.onError).not.toHaveBeenCalled();
-            expect(mockPluginTwo.onError).toHaveBeenCalledWith({errorProperties: {}});
+            expect(mockPluginTwo.onError).toHaveBeenCalled();
           });
 
           it('should remove all plugins', function () {
             bigscreenPlayer.unregisterPlugin();
 
-            Plugins.interface.onError({errorProperties: {}});
+            Plugins.interface.onError();
 
             expect(mockPlugin.onError).not.toHaveBeenCalled();
             expect(mockPluginTwo.onError).not.toHaveBeenCalled();

--- a/script-test/playbackstrategies/legacyplayeradaptortest.js
+++ b/script-test/playbackstrategies/legacyplayeradaptortest.js
@@ -807,38 +807,6 @@ require(
 
           expect(timeUpdateCallbackSpy).toHaveBeenCalledWith();
         });
-
-        it('should publish an error event with history', function () {
-          jasmine.clock().install();
-          jasmine.clock().mockDate(new Date(Date.parse('2018-08-01T14:00:00.000Z')));
-
-          setUpLegacyAdaptor();
-
-          var errorCallbackSpy = jasmine.createSpy('errorSpy');
-          legacyAdaptor.addErrorCallback(this, errorCallbackSpy);
-
-          eventCallbacks({type: MediaPlayerEvent.PLAYING});
-          jasmine.clock().tick(1000);
-          eventCallbacks({type: MediaPlayerEvent.PAUSED});
-          jasmine.clock().tick(1000);
-          eventCallbacks({type: MediaPlayerEvent.BUFFERING});
-          jasmine.clock().tick(1000);
-          eventCallbacks({type: MediaPlayerEvent.ERROR, errorMessage: 'error'});
-
-          var args = errorCallbackSpy.calls.mostRecent().args[0];
-
-          expect(errorCallbackSpy).toHaveBeenCalledWith(jasmine.any(Object));
-          expect(args.type).toEqual('error');
-          expect(args.errorProperties.error_mssg).toEqual('error');
-          expect(args.errorProperties.event_history_1).toEqual('buffering');
-          expect(args.errorProperties.event_history_time_1).toEqual(1000);
-          expect(args.errorProperties.event_history_2).toEqual('paused');
-          expect(args.errorProperties.event_history_time_2).toEqual(2000);
-          expect(args.errorProperties.hasOwnProperty('event_history_3')).toEqual(false);
-          expect(args.errorProperties.hasOwnProperty('event_history_time_3')).toEqual(false);
-
-          jasmine.clock().uninstall();
-        });
       });
     });
   });

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -441,7 +441,7 @@ require(
 
           dashEventCallback(dashjsMediaPlayerEvents.ERROR, testError);
 
-          expect(mockErrorCallback).toHaveBeenCalledWith(jasmine.objectContaining(testError));
+          expect(mockErrorCallback).toHaveBeenCalled();
         });
 
         it('should call mediaSources failover on dash baseUrl changed event', function () {
@@ -943,7 +943,7 @@ require(
 
           dashEventCallback(dashjsMediaPlayerEvents.ERROR, mockEvent);
 
-          expect(mockErrorCallback).toHaveBeenCalledWith(mockEvent);
+          expect(mockErrorCallback).toHaveBeenCalled();
         });
       });
     });

--- a/script-test/playercomponenttest.js
+++ b/script-test/playercomponenttest.js
@@ -396,7 +396,7 @@ require(
             // trigger a error event to start the fatal error timeout,
             // after 5 seconds it should fire a media state update of FATAL
             // it is exptected to be cleared
-            mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+            mockStrategy.mockingHooks.fireErrorEvent();
 
             mockStrategy.mockingHooks.fireEvent(MediaState.PLAYING);
 
@@ -470,7 +470,7 @@ require(
             // trigger a error event to start the fatal error timeout,
             // after 5 seconds it should fire a media state update of FATAL
             // it is exptected to be cleared
-            mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+            mockStrategy.mockingHooks.fireErrorEvent();
 
             mockStrategy.mockingHooks.fireEvent(MediaState.PAUSED);
 
@@ -611,7 +611,7 @@ require(
             // trigger a error event to start the fatal error timeout,
             // after 5 seconds it should fire a media state update of FATAL
             // it is exptected to be cleared
-            mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+            mockStrategy.mockingHooks.fireErrorEvent();
 
             mockStrategy.mockingHooks.fireEvent(MediaState.ENDED);
 
@@ -688,7 +688,7 @@ require(
 
             setUpPlayerComponent();
 
-            mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {code: '2110'}});
+            mockStrategy.mockingHooks.fireErrorEvent();
 
             expect(mockPluginsInterface.onBufferingCleared).toHaveBeenCalledWith(jasmine.objectContaining(pluginData));
           });
@@ -706,7 +706,7 @@ require(
 
             jasmine.clock().tick(29999);
 
-            mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+            mockStrategy.mockingHooks.fireErrorEvent();
 
             jasmine.clock().tick(1);
 
@@ -719,7 +719,7 @@ require(
           it('should publish a media state update of waiting', function () {
             setUpPlayerComponent();
 
-            mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+            mockStrategy.mockingHooks.fireErrorEvent();
 
             expect(mockStateUpdateCallback.calls.mostRecent().args[0].data.state).toEqual(MediaState.WAITING);
           });
@@ -737,7 +737,7 @@ require(
 
             setUpPlayerComponent();
 
-            mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {code: '2110'}});
+            mockStrategy.mockingHooks.fireErrorEvent();
 
             expect(mockPluginsInterface.onError).toHaveBeenCalledWith(jasmine.objectContaining(pluginData));
           });
@@ -812,7 +812,7 @@ require(
 
         it('should failover after 5 seconds if we have not cleared an error from the device', function () {
           setUpPlayerComponent();
-          mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+          mockStrategy.mockingHooks.fireErrorEvent();
 
           jasmine.clock().tick(4999);
 
@@ -829,7 +829,7 @@ require(
           setUpPlayerComponent();
           forceMediaSourcesError = true;
 
-          mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+          mockStrategy.mockingHooks.fireErrorEvent();
 
           jasmine.clock().tick(5000);
 
@@ -842,7 +842,7 @@ require(
           setUpPlayerComponent();
           forceMediaSourcesError = true;
 
-          mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+          mockStrategy.mockingHooks.fireErrorEvent();
 
           jasmine.clock().tick(5000);
 
@@ -877,7 +877,7 @@ require(
           // after 30 seconds it should fire a media state update of FATAL
           // it is exptected to be cleared
           mockStrategy.mockingHooks.fireEvent(MediaState.WAITING);
-          mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+          mockStrategy.mockingHooks.fireErrorEvent();
 
           jasmine.clock().tick(30000);
 
@@ -890,7 +890,7 @@ require(
           // trigger a error event to start the fatal error timeout,
           // after 5 seconds it should fire a media state update of FATAL
           // it is exptected to be cleared
-          mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+          mockStrategy.mockingHooks.fireErrorEvent();
 
           jasmine.clock().tick(5000);
 
@@ -909,7 +909,7 @@ require(
 
           setUpPlayerComponent({multiCdn: true});
 
-          mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+          mockStrategy.mockingHooks.fireErrorEvent();
 
           jasmine.clock().tick(5000);
 
@@ -928,7 +928,7 @@ require(
 
           setUpPlayerComponent({multiCdn: true});
 
-          mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+          mockStrategy.mockingHooks.fireErrorEvent();
 
           jasmine.clock().tick(5000);
 
@@ -974,7 +974,7 @@ require(
           // trigger a error event to start the fatal error timeout,
           // after 5 seconds it should fire a media state update of FATAL
           // it is exptected to be cleared
-          mockStrategy.mockingHooks.fireErrorEvent({errorProperties: {error_mssg: 'testError'}});
+          mockStrategy.mockingHooks.fireErrorEvent();
 
           playerComponent.tearDown();
 

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -162,7 +162,6 @@ function (PlaybackUtils, WindowTypes, Plugins, PluginEnums, PluginData, DebugToo
       var evt = new PluginData({
         status: PluginEnums.STATUS.FAILOVER,
         stateType: PluginEnums.TYPE.ERROR,
-        properties: {error_mssg: failoverInfo.errorMessage},
         isBufferingTimeoutError: failoverInfo.isBufferingTimeoutError,
         cdn: mediaSources[0].cdn,
         newCdn: mediaSources[1].cdn

--- a/script/mockbigscreenplayer.js
+++ b/script/mockbigscreenplayer.js
@@ -268,8 +268,8 @@ define('bigscreenplayer/mockbigscreenplayer',
           return;
         }
 
-        Plugins.interface.onBufferingCleared(new PluginData({status: PluginEnums.STATUS.DISMISSED, stateType: PluginEnums.TYPE.BUFFERING, properties: {dismissed_by: 'teardown'}, isInitialPlay: initialBuffering}));
-        Plugins.interface.onErrorCleared(new PluginData({status: PluginEnums.STATUS.DISMISSED, stateType: PluginEnums.TYPE.ERROR, properties: {dismissed_by: 'teardown'}}));
+        Plugins.interface.onBufferingCleared(new PluginData({status: PluginEnums.STATUS.DISMISSED, stateType: PluginEnums.TYPE.BUFFERING, isInitialPlay: initialBuffering}));
+        Plugins.interface.onErrorCleared(new PluginData({status: PluginEnums.STATUS.DISMISSED, stateType: PluginEnums.TYPE.ERROR}));
         Plugins.unregisterPlugin();
 
         timeUpdateCallbacks = [];
@@ -312,9 +312,9 @@ define('bigscreenplayer/mockbigscreenplayer',
           fatalErrorBufferingTimeout = true;
           Plugins.interface.onBuffering(new PluginData({status: PluginEnums.STATUS.STARTED, stateType: PluginEnums.TYPE.BUFFERING}));
         } else {
-          Plugins.interface.onBufferingCleared(new PluginData({status: PluginEnums.STATUS.DISMISSED, stateType: PluginEnums.TYPE.BUFFERING, properties: {dismissed_by: eventTrigger}, isInitialPlay: initialBuffering}));
+          Plugins.interface.onBufferingCleared(new PluginData({status: PluginEnums.STATUS.DISMISSED, stateType: PluginEnums.TYPE.BUFFERING, isInitialPlay: initialBuffering}));
         }
-        Plugins.interface.onErrorCleared(new PluginData({status: PluginEnums.STATUS.DISMISSED, stateType: PluginEnums.TYPE.ERROR, properties: {dismissed_by: eventTrigger}}));
+        Plugins.interface.onErrorCleared(new PluginData({status: PluginEnums.STATUS.DISMISSED, stateType: PluginEnums.TYPE.ERROR}));
 
         if (state === MediaState.FATAL_ERROR) {
           Plugins.interface.onFatalError(new PluginData({status: PluginEnums.STATUS.FATAL, stateType: PluginEnums.TYPE.ERROR, isBufferingTimeoutError: fatalErrorBufferingTimeout}));
@@ -397,8 +397,8 @@ define('bigscreenplayer/mockbigscreenplayer',
           source = sourceList[0].url;
           cdn = sourceList[0].cdn;
         }
-        Plugins.interface.onBufferingCleared(new PluginData({status: PluginEnums.STATUS.DISMISSED, stateType: PluginEnums.TYPE.BUFFERING, properties: {dismissed_by: 'timeout'}, isInitialPlay: initialBuffering}));
-        Plugins.interface.onErrorCleared(new PluginData({status: PluginEnums.STATUS.DISMISSED, stateType: PluginEnums.TYPE.ERROR, properties: {dismissed_by: 'timeout'}}));
+        Plugins.interface.onBufferingCleared(new PluginData({status: PluginEnums.STATUS.DISMISSED, stateType: PluginEnums.TYPE.BUFFERING, isInitialPlay: initialBuffering}));
+        Plugins.interface.onErrorCleared(new PluginData({status: PluginEnums.STATUS.DISMISSED, stateType: PluginEnums.TYPE.ERROR}));
         Plugins.interface.onErrorHandled(new PluginData({status: PluginEnums.STATUS.FAILOVER, stateType: PluginEnums.TYPE.ERROR, isBufferingTimeoutError: fatalErrorBufferingTimeout, cdn: cdn}));
 
         if (autoProgress) {

--- a/script/playbackstrategy/legacyplayeradapter.js
+++ b/script/playbackstrategy/legacyplayeradapter.js
@@ -111,17 +111,15 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
         publishMediaState(MediaState.ENDED);
       }
 
-      function onError (event) {
+      function onError () {
         if (handleErrorOnExitingSeek && exitingSeek) {
           restartMediaPlayer();
         } else {
-          event.errorProperties = createEventHistoryLabels();
-          event.errorProperties.error_mssg = event.errorMessage;
-          publishError(event);
+          publishError();
         }
       }
 
-      function onSeekAttempted (event) {
+      function onSeekAttempted () {
         if (requiresLiveCurtain()) {
           var doNotForceBeginPlaybackToEndOfWindow = {
             forceBeginPlaybackToEndOfWindow: false
@@ -156,9 +154,9 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
         }
       }
 
-      function publishError (errorEvent) {
+      function publishError () {
         if (errorCallback) {
-          errorCallback(errorEvent);
+          errorCallback();
         }
       }
 
@@ -170,16 +168,6 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
 
       function getStrategy () {
         return strategy.toUpperCase();
-      }
-
-      function createEventHistoryLabels () {
-        var properties = {};
-        var now = new Date().getTime();
-        for (var i = 0; i < eventHistory.length; i++) {
-          properties['event_history_' + (i + 1)] = eventHistory[i].type;
-          properties['event_history_time_' + (i + 1)] = now - eventHistory[i].time;
-        }
-        return properties;
       }
 
       function setupExitSeekWorkarounds (mimeType) {

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -103,8 +103,6 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           delete event.error.data;
         }
 
-        event.errorProperties = { error_mssg: event.error };
-
         if (event.error) {
           if (event.error.message) {
             DebugTool.info('MSE Error: ' + event.error.message);
@@ -127,12 +125,12 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
             }
           }
         }
-        publishError(event);
+        publishError();
       }
 
       function manifestDownloadError (event) {
         var error = function () {
-          publishError(event);
+          publishError();
         };
 
         var failoverParams = {
@@ -239,9 +237,9 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         }
       }
 
-      function publishError (errorEvent) {
+      function publishError () {
         if (errorCallback) {
-          errorCallback(errorEvent);
+          errorCallback();
         }
       }
 

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -207,7 +207,7 @@ define(
         publishMediaStateUpdate(undefined, { timeUpdate: true });
       }
 
-      function onError (event) {
+      function onError () {
         bubbleBufferingCleared();
         raiseError();
       }


### PR DESCRIPTION
📺 What

Clears up various points in the code where playback properties are still sent on plugin events, most notably `event_history`. These were missed as part of #92

> Tickets: IPLAYERTVV1-9719

🛠 How

Deleting the code! Plugin events should no longer be emitting any `properties`.