### PR TITLE
Improve The Debug Tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -109,6 +109,7 @@ require(
             };
           };
 
+          var mockDebugTool = jasmine.createSpyObj('mockDebugTool', ['apicall', 'time', 'event', 'tearDown', 'setRootElement']);
           mockPlayerComponentInstance = jasmine.createSpyObj('playerComponentMock', [
             'play', 'pause', 'isEnded', 'isPaused', 'setCurrentTime', 'getCurrentTime', 'getDuration', 'getSeekableRange',
             'getPlayerElement', 'isSubtitlesAvailable', 'isSubtitlesEnabled', 'setSubtitlesEnabled', 'tearDown',
@@ -122,7 +123,8 @@ require(
           injector.mock({
             'bigscreenplayer/mediasources': mediaSourcesMock,
             'bigscreenplayer/playercomponent': mockPlayerComponent,
-            'bigscreenplayer/plugins': Plugins
+            'bigscreenplayer/plugins': Plugins,
+            'bigscreenplayer/debugger/debugtool': mockDebugTool
           });
 
           injector.require(['bigscreenplayer/bigscreenplayer'], function (bigscreenPlayerReference) {

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -119,9 +119,16 @@ define('bigscreenplayer/bigscreenplayer',
         return mediaSources && mediaSources.time().windowEndTime;
       }
 
+      function toggleDebug () {
+        if (playerComponent) {
+          DebugTool.toggleVisibility();
+        }
+      }
+
       return {
         init: function (playbackElement, bigscreenPlayerData, newWindowType, enableSubtitles, newDevice, callbacks) {
           Chronicle.init();
+          DebugTool.setRootElement(playbackElement);
           device = newDevice;
           windowType = newWindowType;
           serverDate = bigscreenPlayerData.serverDate;
@@ -276,7 +283,8 @@ define('bigscreenplayer/bigscreenplayer',
         convertEpochMsToVideoTimeSeconds: function (epochTime) {
           return getWindowStartTime() ? Math.floor((epochTime - getWindowStartTime()) / 1000) : undefined;
         },
-        convertVideoTimeSecondsToEpochMs: convertVideoTimeSecondsToEpochMs
+        convertVideoTimeSecondsToEpochMs: convertVideoTimeSecondsToEpochMs,
+        toggleDebug: toggleDebug
       };
     }
 

--- a/script/debugger/debugpresenter.js
+++ b/script/debugger/debugpresenter.js
@@ -101,13 +101,8 @@ define('bigscreenplayer/debugger/debugpresenter',
      return type;
    }
 
-   function tearDown () {
-     view = undefined;
-   }
-
    return {
      init: init,
-     update: update,
-     tearDown: tearDown
+     update: update
    };
  });

--- a/script/debugger/debugtool.js
+++ b/script/debugger/debugtool.js
@@ -7,6 +7,7 @@ define('bigscreenplayer/debugger/debugtool',
  function (Chronicle, DebugPresenter, DebugView) {
    'use strict';
    function DebugTool () {
+     var rootElement;
      var presenter = DebugPresenter;
      var view;
      var visible = false;
@@ -23,6 +24,7 @@ define('bigscreenplayer/debugger/debugtool',
 
      function show () {
        view = DebugView;
+       view.setRootElement(rootElement);
        view.init();
        presenter.init(view);
        Chronicle.registerForUpdates(presenter.update);
@@ -30,7 +32,6 @@ define('bigscreenplayer/debugger/debugtool',
      }
 
      function hide () {
-       presenter.tearDown();
        view.tearDown();
        Chronicle.unregisterForUpdates(presenter.update);
        visible = false;
@@ -50,12 +51,18 @@ define('bigscreenplayer/debugger/debugtool',
        }
      }
 
+     function setRootElement (element) {
+       rootElement = element;
+     }
+
      function tearDown () {
        staticFieldValues = {};
+       hide();
      }
 
      return {
        toggleVisibility: toggleVisibility,
+       setRootElement: setRootElement,
        info: Chronicle.info,
        error: Chronicle.error,
        event: Chronicle.event,

--- a/script/debugger/debugtool.js
+++ b/script/debugger/debugtool.js
@@ -27,6 +27,7 @@ define('bigscreenplayer/debugger/debugtool',
        view.setRootElement(rootElement);
        view.init();
        presenter.init(view);
+       presenter.update(Chronicle.retrieve());
        Chronicle.registerForUpdates(presenter.update);
        visible = true;
      }

--- a/script/debugger/debugtool.js
+++ b/script/debugger/debugtool.js
@@ -58,7 +58,9 @@ define('bigscreenplayer/debugger/debugtool',
 
      function tearDown () {
        staticFieldValues = {};
-       hide();
+       if (visible) {
+         hide();
+       }
      }
 
      return {

--- a/script/debugger/debugview.js
+++ b/script/debugger/debugview.js
@@ -1,14 +1,19 @@
 define('bigscreenplayer/debugger/debugview',
  function () {
    'use strict';
-   var logBox, logContainer, staticContainer, staticBox;
-   var appElement = document.getElementById('app');
+   var appElement, logBox, logContainer, staticContainer, staticBox;
 
    function init () {
      logBox = document.createElement('div');
      logContainer = document.createElement('span');
      staticBox = document.createElement('div');
      staticContainer = document.createElement('span');
+
+     if (appElement === undefined) {
+       appElement = document.body;
+     }
+
+     // TAP link builder -> TAP window options -> CorePlayback.init -> if window.debugTools==true -> BigscreenPlayer.enableDebug()
 
      logBox.id = 'logBox';
      logBox.style.position = 'absolute';
@@ -52,6 +57,12 @@ define('bigscreenplayer/debugger/debugview',
      appElement.appendChild(staticBox);
    }
 
+   function setRootElement (root) {
+     if (root) {
+       appElement = root;
+     }
+   }
+
    function render (logData) {
      var dynamicLogs = logData.dynamic;
      var LINES_TO_DISPLAY = 29;
@@ -71,8 +82,11 @@ define('bigscreenplayer/debugger/debugview',
    }
 
    function tearDown () {
-     appElement.removeChild(document.getElementById('logBox'));
-     appElement.removeChild(document.getElementById('staticBox'));
+     if (appElement) {
+       appElement.removeChild(document.getElementById('logBox'));
+       appElement.removeChild(document.getElementById('staticBox'));
+       appElement = undefined;
+     }
      staticContainer = undefined;
      logContainer = undefined;
      logBox = undefined;
@@ -81,6 +95,7 @@ define('bigscreenplayer/debugger/debugview',
 
    return {
      init: init,
+     setRootElement: setRootElement,
      render: render,
      tearDown: tearDown
    };

--- a/script/debugger/debugview.js
+++ b/script/debugger/debugview.js
@@ -13,8 +13,6 @@ define('bigscreenplayer/debugger/debugview',
        appElement = document.body;
      }
 
-     // TAP link builder -> TAP window options -> CorePlayback.init -> if window.debugTools==true -> BigscreenPlayer.enableDebug()
-
      logBox.id = 'logBox';
      logBox.style.position = 'absolute';
      logBox.style.width = '63%';


### PR DESCRIPTION
📺 What

Slightly improve the media debug tool.

🛠 How

1. Attach the debug tool to the same parent DOM node as the media element.
2. Tear it down correctly.
3. Also show the current log contents immediately on enabling instead of waiting for an event.