### PR TITLE
Add seeking context to WAITING event. Clear after firing the event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -245,9 +245,39 @@ require(
 
             expect(callback).toHaveBeenCalledWith({state: MediaState.PLAYING, endOfStream: false});
 
+            callback.calls.reset();
+
             mockEventHook({data: {state: MediaState.WAITING}});
 
-            expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, endOfStream: false});
+            expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: false, endOfStream: false});
+          });
+
+          it('should set the isPaused flag to true when waiting after a setCurrentTime', function () {
+            mockEventHook({data: {state: MediaState.PLAYING}});
+
+            expect(callback).toHaveBeenCalledWith({state: MediaState.PLAYING, endOfStream: false});
+
+            callback.calls.reset();
+
+            bigscreenPlayer.setCurrentTime(60);
+            mockEventHook({data: {state: MediaState.WAITING}});
+
+            expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: true, endOfStream: false});
+          });
+
+          it('should set clear the isPaused flag after a waiting event is fired', function () {
+            mockEventHook({data: {state: MediaState.PLAYING}});
+
+            bigscreenPlayer.setCurrentTime(60);
+            mockEventHook({data: {state: MediaState.WAITING}});
+
+            expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: true, endOfStream: false});
+
+            callback.calls.reset();
+
+            mockEventHook({data: {state: MediaState.WAITING}});
+
+            expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: false, endOfStream: false});
           });
 
           it('should set the pause trigger to the one set when a pause event comes back from strategy', function () {

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -199,9 +199,9 @@ define('bigscreenplayer/bigscreenplayer',
         setCurrentTime: function (time) {
           DebugTool.apicall('setCurrentTime');
           if (playerComponent) {
+            isSeeking = true; // this flag must be set before calling into playerComponent.setCurrentTime - as this synchronously fires a WAITING event.
             playerComponent.setCurrentTime(time);
             endOfStream = windowType !== WindowTypes.STATIC && Math.abs(this.getSeekableRange().end - time) < END_OF_STREAM_TOLERANCE;
-            isSeeking = true;
           }
         },
         getCurrentTime: function () {

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -23,6 +23,7 @@ define('bigscreenplayer/bigscreenplayer',
       var serverDate;
       var playerComponent;
       var pauseTrigger;
+      var isSeeking = false;
       var endOfStream;
       var windowType;
       var device;
@@ -53,6 +54,12 @@ define('bigscreenplayer/bigscreenplayer',
               isBufferingTimeoutError: evt.isBufferingTimeoutError
             };
           }
+
+          if (evt.data.state === MediaState.WAITING) {
+            stateObject.isSeeking = isSeeking;
+            isSeeking = false;
+          }
+
           stateObject.endOfStream = endOfStream;
 
           stateChangeCallbacks.forEach(function (callback) {
@@ -194,6 +201,7 @@ define('bigscreenplayer/bigscreenplayer',
           if (playerComponent) {
             playerComponent.setCurrentTime(time);
             endOfStream = windowType !== WindowTypes.STATIC && Math.abs(this.getSeekableRange().end - time) < END_OF_STREAM_TOLERANCE;
+            isSeeking = true;
           }
         },
         getCurrentTime: function () {

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -199,7 +199,7 @@ define('bigscreenplayer/bigscreenplayer',
         setCurrentTime: function (time) {
           DebugTool.apicall('setCurrentTime');
           if (playerComponent) {
-            isSeeking = true; // this flag must be set before calling into playerComponent.setCurrentTime - as this synchronously fires a WAITING event.
+            isSeeking = true; // this flag must be set before calling into playerComponent.setCurrentTime - as this synchronously fires a WAITING event (when native strategy).
             playerComponent.setCurrentTime(time);
             endOfStream = windowType !== WindowTypes.STATIC && Math.abs(this.getSeekableRange().end - time) < END_OF_STREAM_TOLERANCE;
           }

--- a/script/mockbigscreenplayer.js
+++ b/script/mockbigscreenplayer.js
@@ -197,8 +197,8 @@ define('bigscreenplayer/mockbigscreenplayer',
         currentTime = time;
         isSeeking = true;
         if (autoProgress) {
+          mockingHooks.changeState(MediaState.WAITING, 'other');
           if (!pausedState) {
-            mockingHooks.changeState(MediaState.WAITING, 'other');
             startProgress();
           }
         } else {

--- a/script/mockbigscreenplayer.js
+++ b/script/mockbigscreenplayer.js
@@ -17,6 +17,7 @@ define('bigscreenplayer/mockbigscreenplayer',
     var stateChangeCallbacks = [];
 
     var currentTime;
+    var isSeeking;
     var seekableRange;
     var duration;
     var liveWindowStart;
@@ -194,6 +195,7 @@ define('bigscreenplayer/mockbigscreenplayer',
       },
       setCurrentTime: function (time) {
         currentTime = time;
+        isSeeking = true;
         if (autoProgress) {
           if (!pausedState) {
             mockingHooks.changeState(MediaState.WAITING, 'other');
@@ -328,6 +330,10 @@ define('bigscreenplayer/mockbigscreenplayer',
         if (state === MediaState.FATAL_ERROR) {
           stateObject.errorId = opts && opts.error;
           stateObject.isBufferingTimeoutError = opts && opts.isBufferingTimeoutError;
+        }
+        if (state === MediaState.WAITING) {
+          stateObject.isSeeking = isSeeking;
+          isSeeking = false;
         }
         stateObject.endOfStream = endOfStream;
 


### PR DESCRIPTION
📺 What

Add some context when buffering, to inform consumers if the WAITING event was triggered following a seek.

> Tickets: IPLAYERTVV1-10049

🛠 How

* `isSeeking` parameter is added to the WAITING state object.
* Set a flag in bigscreenplayer.js when the `setCurrentTime` method is called.
* Use this flag as the `isSeeking` value
* Clear flag after the WAITING event is emitted.