### PR TITLE
Add Framework Version

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 /spec/lib/
 /docs/
+buildVersion.js

--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ When writing tests for your application it may be useful to use the mocking func
 
 See [here](https://github.com/bbc/bigscreen-player/wiki/Mocking-Bigscreen-Player) for example usage.
 
+### Releasing
+
+`npm run pre-release:major|minor|patch` will bump the package.json and internal version.
+
 ## API Reference
 
 The full api is documented [here](https://github.com/bbc/bigscreen-player/wiki/API-Reference).

--- a/buildVersion.js
+++ b/buildVersion.js
@@ -1,21 +1,23 @@
-(function () {
-  'use strict';
-  const fs = require('fs');
-  const path = require('path');
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const packagePath = path.resolve() + '/package.json';
+const versionFilePath = path.resolve() + '/script/version.js';
 
-  const packagePath = path.resolve() + '/package.json';
-  const versionFilePath = path.resolve() + '/script/version.js';
+fs.readFile(packagePath, (packageReadError, data) => {
+  if (packageReadError) throw packageReadError;
+  const packageVersion = JSON.parse(data).version;
+  const versionMatches = packageVersion.match(/^[0-9]+\.[0-9]+\.[0-9]+$/);
 
-  try {
-    const packageVersion = JSON.parse(fs.readFileSync(packagePath, 'utf8')).version;
-    const versionMatches = packageVersion.match(/[0-9]+\.[0-9]+\.[0-9]+/);
+  if (versionMatches) {
+    fs.readFile(versionFilePath, (versionReadError, data) => {
+      if (versionReadError) throw versionReadError;
+      var versionFile = data.toString().replace(/[0-9]+\.[0-9]+\.[0-9]/, versionMatches[0]);
 
-    if (versionMatches) {
-      var versionFile = fs.readFileSync(versionFilePath, 'utf8');
-      versionFile = versionFile.replace(/[0-9]+\.[0-9]+\.[0-9]+/, versionMatches[0]);
-      fs.writeFileSync(versionFilePath, versionFile);
-    }
-  } catch (e) {
-    console.error('Error setting version');
+      fs.writeFile(versionFilePath, versionFile, (writeError) => {
+        if (writeError) throw writeError;
+        console.log(`version updated to: ${versionMatches[0]} `);
+      });
+    });
   }
-})();
+});

--- a/buildVersion.js
+++ b/buildVersion.js
@@ -16,6 +16,6 @@
       fs.writeFileSync(versionFilePath, versionFile);
     }
   } catch (e) {
-    console.log('Error setting version');
+    console.error('Error setting version');
   }
 })();

--- a/buildVersion.js
+++ b/buildVersion.js
@@ -1,0 +1,21 @@
+(function () {
+  'use strict';
+  const fs = require('fs');
+  const path = require('path');
+
+  const packagePath = path.resolve() + '/package.json';
+  const versionFilePath = path.resolve() + '/script/version.js';
+
+  try {
+    const packageVersion = JSON.parse(fs.readFileSync(packagePath, 'utf8')).version;
+    const versionMatches = packageVersion.match(/[0-9]+\.[0-9]+\.[0-9]+/);
+
+    if (versionMatches) {
+      var versionFile = fs.readFileSync(versionFilePath, 'utf8');
+      versionFile = versionFile.replace(/[0-9]+\.[0-9]+\.[0-9]+/, versionMatches[0]);
+      fs.writeFileSync(versionFilePath, versionFile);
+    }
+  } catch (e) {
+    console.log('Error setting version');
+  }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "spec": "grunt --force spec-web",
     "lint": "npx eslint .",
     "lint:code:changed": "git diff-index --name-only HEAD | egrep '.js$' | xargs eslint",
-    "build:example-app": "cd docs/example-app/ && npm install && npm run build && cd ../../"
+    "build:example-app": "cd docs/example-app/ && npm install && npm run build && cd ../../",
+    "build:version": " node ./buildVersion.js",
+    "pre-release:patch": "npm version patch --no-git-tag --no-git-commit && npm run build:version",
+    "pre-release:minor": "npm version minor --no-git-tag --no-git-commit && npm run build:version",
+    "pre-release:major": "npm version major --no-git-tag --no-git-commit && npm run build:version"
   },
   "pre-commit": [
     "test"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "npx eslint .",
     "lint:code:changed": "git diff-index --name-only HEAD | egrep '.js$' | xargs eslint",
     "build:example-app": "cd docs/example-app/ && npm install && npm run build && cd ../../",
-    "build:version": " node ./buildVersion.js",
+    "build:version": "node ./buildVersion.js",
     "pre-release:patch": "npm version patch --no-git-tag --no-git-commit && npm run build:version",
     "pre-release:minor": "npm version minor --no-git-tag --no-git-commit && npm run build:version",
     "pre-release:major": "npm version major --no-git-tag --no-git-commit && npm run build:version"

--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -109,7 +109,7 @@ require(
             };
           };
 
-          var mockDebugTool = jasmine.createSpyObj('mockDebugTool', ['apicall', 'time', 'event', 'tearDown', 'setRootElement']);
+          var mockDebugTool = jasmine.createSpyObj('mockDebugTool', ['apicall', 'time', 'event', 'keyValue', 'tearDown', 'setRootElement']);
           mockPlayerComponentInstance = jasmine.createSpyObj('playerComponentMock', [
             'play', 'pause', 'isEnded', 'isPaused', 'setCurrentTime', 'getCurrentTime', 'getDuration', 'getSeekableRange',
             'getPlayerElement', 'isSubtitlesAvailable', 'isSubtitlesEnabled', 'setSubtitlesEnabled', 'tearDown',

--- a/script-test/version.js
+++ b/script-test/version.js
@@ -1,0 +1,11 @@
+require(
+    ['bigscreenplayer/version'],
+    function (Version) {
+      'use strict';
+      describe('Version ', function () {
+        it('should return a semver string', function () {
+          expect(Version).toMatch(/^[0-9]+\.[0-9]+\.[0-9]+$/);
+        });
+      });
+    }
+);

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -292,6 +292,9 @@ define('bigscreenplayer/bigscreenplayer',
         convertEpochMsToVideoTimeSeconds: function (epochTime) {
           return getWindowStartTime() ? Math.floor((epochTime - getWindowStartTime()) / 1000) : undefined;
         },
+        getFrameworkVersion: function () {
+          return Version;
+        },
         convertVideoTimeSecondsToEpochMs: convertVideoTimeSecondsToEpochMs,
         toggleDebug: toggleDebug
       };

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -295,7 +295,7 @@ define('bigscreenplayer/bigscreenplayer',
 
     BigscreenPlayer.getLiveSupport = getLiveSupport;
 
-    BigscreenPlayer.version = Version();
+    BigscreenPlayer.version = Version;
 
     return BigscreenPlayer;
   }

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -137,6 +137,7 @@ define('bigscreenplayer/bigscreenplayer',
         init: function (playbackElement, bigscreenPlayerData, newWindowType, enableSubtitles, newDevice, callbacks) {
           Chronicle.init();
           DebugTool.setRootElement(playbackElement);
+          DebugTool.keyValue({key: 'framework-version', value: Version});
           device = newDevice;
           windowType = newWindowType;
           serverDate = bigscreenPlayerData.serverDate;

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -10,9 +10,10 @@ define('bigscreenplayer/bigscreenplayer',
     'bigscreenplayer/debugger/chronicle',
     'bigscreenplayer/debugger/debugtool',
     'bigscreenplayer/utils/timeutils',
-    'bigscreenplayer/mediasources'
+    'bigscreenplayer/mediasources',
+    'bigscreenplayer/version'
   ],
-  function (MediaState, PlayerComponent, PauseTriggers, DynamicWindowUtils, WindowTypes, MockBigscreenPlayer, Plugins, Chronicle, DebugTool, SlidingWindowUtils, MediaSources) {
+  function (MediaState, PlayerComponent, PauseTriggers, DynamicWindowUtils, WindowTypes, MockBigscreenPlayer, Plugins, Chronicle, DebugTool, SlidingWindowUtils, MediaSources, Version) {
     'use strict';
     function BigscreenPlayer () {
       var stateChangeCallbacks = [];
@@ -293,6 +294,8 @@ define('bigscreenplayer/bigscreenplayer',
     }
 
     BigscreenPlayer.getLiveSupport = getLiveSupport;
+
+    BigscreenPlayer.version = Version();
 
     return BigscreenPlayer;
   }

--- a/script/version.js
+++ b/script/version.js
@@ -1,0 +1,5 @@
+define('bigscreenplayer/version',
+  function () {
+    return '3.6.0';
+  }
+);

--- a/script/version.js
+++ b/script/version.js
@@ -1,5 +1,5 @@
 define('bigscreenplayer/version',
   function () {
-    return '3.7.0';
+    return '3.8.0';
   }
 );

--- a/script/version.js
+++ b/script/version.js
@@ -1,5 +1,5 @@
 define('bigscreenplayer/version',
   function () {
-    return '3.6.0';
+    return '3.7.0';
   }
 );


### PR DESCRIPTION
📺 What

This exposes the current framework version on the public api as `BigscreenPlayer.version`

🛠 How

This updates the framework version available at runtime based upon the package lock.

`npm run pre-release:patch|minor|major` does `npm version patch|minor|major` then updates the version JS module.