### PR TITLE
Added getFrameworkVersion() to mockBigscreenPlayer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script/mockbigscreenplayer.js
+++ b/script/mockbigscreenplayer.js
@@ -6,9 +6,10 @@ define('bigscreenplayer/mockbigscreenplayer',
     'bigscreenplayer/utils/playbackutils',
     'bigscreenplayer/plugins',
     'bigscreenplayer/plugindata',
-    'bigscreenplayer/pluginenums'
+    'bigscreenplayer/pluginenums',
+    'bigscreenplayer/version'
   ],
-  function (MediaState, PauseTriggers, WindowTypes, PlaybackUtils, Plugins, PluginData, PluginEnums) {
+  function (MediaState, PauseTriggers, WindowTypes, PlaybackUtils, Plugins, PluginData, PluginEnums, Version) {
     var sourceList;
     var source;
     var cdn;
@@ -46,8 +47,6 @@ define('bigscreenplayer/mockbigscreenplayer',
 
     var liveWindowData;
     var manifestError;
-
-    var version;
 
     function startProgress (progressCause) {
       setTimeout(function () {
@@ -268,7 +267,7 @@ define('bigscreenplayer/mockbigscreenplayer',
         return;
       },
       getFrameworkVersion: function () {
-        return version;
+        return Version;
       },
       tearDown: function () {
         manifestError = false;

--- a/script/mockbigscreenplayer.js
+++ b/script/mockbigscreenplayer.js
@@ -47,6 +47,8 @@ define('bigscreenplayer/mockbigscreenplayer',
     var liveWindowData;
     var manifestError;
 
+    var version;
+
     function startProgress (progressCause) {
       setTimeout(function () {
         if (!autoProgressInterval) {
@@ -148,6 +150,7 @@ define('bigscreenplayer/mockbigscreenplayer',
         sourceList = bigscreenPlayerData && bigscreenPlayerData.media && bigscreenPlayerData.media.urls;
         source = sourceList && sourceList[0].url;
         cdn = sourceList && sourceList[0].cdn;
+        version = '0.0.0';
 
         duration = windowType === WindowTypes.STATIC ? 4808 : Infinity;
         seekableRange = {start: 0, end: 4808};
@@ -263,6 +266,9 @@ define('bigscreenplayer/mockbigscreenplayer',
       },
       getPlayerElement: function () {
         return;
+      },
+      getFrameworkVersion: function () {
+        return version;
       },
       tearDown: function () {
         manifestError = false;

--- a/script/mockbigscreenplayer.js
+++ b/script/mockbigscreenplayer.js
@@ -149,7 +149,6 @@ define('bigscreenplayer/mockbigscreenplayer',
         sourceList = bigscreenPlayerData && bigscreenPlayerData.media && bigscreenPlayerData.media.urls;
         source = sourceList && sourceList[0].url;
         cdn = sourceList && sourceList[0].cdn;
-        version = '0.0.0';
 
         duration = windowType === WindowTypes.STATIC ? 4808 : Infinity;
         seekableRange = {start: 0, end: 4808};

--- a/script/version.js
+++ b/script/version.js
@@ -1,5 +1,5 @@
 define('bigscreenplayer/version',
   function () {
-    return '3.8.0';
+    return '3.8.1';
   }
 );


### PR DESCRIPTION
📺 What

Update mockBigscreenPlayer.
> Tickets: IPLAYERTVV1-10142


🛠 How
Added `getFrameworkVersion` to `mockBigscreenPlayer` to return mocked value of `bigscreenPlayer` version.
