### PR TITLE
support parsing urn:ebu:tt:distribution:2018-04 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script-test/domhelpers.js
+++ b/script-test/domhelpers.js
@@ -1,0 +1,22 @@
+require(
+  [
+    'bigscreenplayer/domhelpers'
+  ],
+  function (DOMHelpers) {
+    'use strict';
+
+    describe('DOMHelpers', function () {
+      it('Converts an RGBA tuple string to RGB tripple string', function () {
+        expect(DOMHelpers.rgbaToRGB('#FFAAFFAA')).toBe('#FFAAFF');
+      });
+
+      it('Will return a RGB as it is', function () {
+        expect(DOMHelpers.rgbaToRGB('#FFAAFF')).toBe('#FFAAFF');
+      });
+
+      it('Will return a non-RGBA as it is', function () {
+        expect(DOMHelpers.rgbaToRGB('black')).toBe('black');
+      });
+    });
+  }
+);

--- a/script/captions.js
+++ b/script/captions.js
@@ -178,7 +178,6 @@ define('bigscreenplayer/captions',
           if (isNaN(opacity)) {
             opacity = 1.0;
           }
-          opacity = 0.5;
           value = DOMHelpers.rgbaToRGB(value);
           value += '; opacity: ' + opacity + ';';
         }

--- a/script/captions.js
+++ b/script/captions.js
@@ -192,7 +192,18 @@ define('bigscreenplayer/captions',
             value = map.conversion(value);
           }
           if (map.attribute === 'tts:backgroundColor') {
+            // rgba -> rgb
+            if (value.length > 7) {
+              value = 'black';
+            }
             value += ' 2px 2px 1px';
+          }
+
+          if (map.attribute === 'tts:color') {
+            // rgba -> rgb
+            if (value.length > 7) {
+              value = value.slice(0, 7);
+            }
           }
 
           stringStyle += map.property + ': ' + value + '; ';

--- a/script/captions.js
+++ b/script/captions.js
@@ -95,10 +95,16 @@ define('bigscreenplayer/captions',
         updateCaptions(time);
       }
 
+      function isEBUDistribution (metadata) {
+        return metadata === 'urn:ebu:tt:distribution:2014-01' || metadata === 'urn:ebu:tt:distribution:2018-04';
+      }
+
       function transformXML (xml) {
         // Use .getElementsByTagNameNS() when parsing XML as some implementations of .getElementsByTagName() will lowercase its argument before proceding
-        var conformsToStandardElements = xml.getElementsByTagNameNS('urn:ebu:tt:metadata', 'conformsToStandard')[0];
-        var isEBUTTD = conformsToStandardElements && conformsToStandardElements.textContent === 'urn:ebu:tt:distribution:2014-01';
+        var conformsToStandardElements = Array.prototype.slice.call(xml.getElementsByTagNameNS('urn:ebu:tt:metadata', 'conformsToStandard'));
+        var isEBUTTD = conformsToStandardElements && conformsToStandardElements.some(function (node) {
+          return isEBUDistribution(node.textContent);
+        });
 
         var captionValues = {
           ttml: {

--- a/script/captions.js
+++ b/script/captions.js
@@ -172,6 +172,18 @@ define('bigscreenplayer/captions',
         return items;
       }
 
+      function rgbWithOpacity (value) {
+        if (DOMHelpers.isRGBA(value)) {
+          var opacity = parseInt(value.slice(7, 9), 16) / 255;
+          if (isNaN(opacity)) {
+            opacity = 1.0;
+          }
+          value = DOMHelpers.rgbaToRGB(value);
+          value += '; opacity: ' + opacity + ';';
+        }
+        return value;
+      }
+
       function elementToStyle (el) {
         var stringStyle = '';
         var styles = _styles;
@@ -192,13 +204,14 @@ define('bigscreenplayer/captions',
           if (map.conversion) {
             value = map.conversion(value);
           }
+
           if (map.attribute === 'tts:backgroundColor') {
-            value = DOMHelpers.rgbaToRGB(value);
+            value = rgbWithOpacity(value);
             value += ' 2px 2px 1px';
           }
 
           if (map.attribute === 'tts:color') {
-            value = DOMHelpers.rgbaToRGB(value);
+            value = rgbWithOpacity(value);
           }
 
           stringStyle += map.property + ': ' + value + '; ';

--- a/script/captions.js
+++ b/script/captions.js
@@ -1,8 +1,9 @@
 define('bigscreenplayer/captions',
   [
-    'bigscreenplayer/debugger/debugtool'
+    'bigscreenplayer/debugger/debugtool',
+    'bigscreenplayer/domhelpers'
   ],
-  function (DebugTool) {
+  function (DebugTool, DOMHelpers) {
     'use strict';
 
     var elementToStyleMap = [
@@ -192,18 +193,12 @@ define('bigscreenplayer/captions',
             value = map.conversion(value);
           }
           if (map.attribute === 'tts:backgroundColor') {
-            // rgba -> rgb
-            if (value.length > 7) {
-              value = 'black';
-            }
+            value = DOMHelpers.rgbaToRGB(value);
             value += ' 2px 2px 1px';
           }
 
           if (map.attribute === 'tts:color') {
-            // rgba -> rgb
-            if (value.length > 7) {
-              value = value.slice(0, 7);
-            }
+            value = DOMHelpers.rgbaToRGB(value);
           }
 
           stringStyle += map.property + ': ' + value + '; ';

--- a/script/captions.js
+++ b/script/captions.js
@@ -178,6 +178,7 @@ define('bigscreenplayer/captions',
           if (isNaN(opacity)) {
             opacity = 1.0;
           }
+          opacity = 0.5;
           value = DOMHelpers.rgbaToRGB(value);
           value += '; opacity: ' + opacity + ';';
         }

--- a/script/domhelpers.js
+++ b/script/domhelpers.js
@@ -17,7 +17,7 @@ define(
       }
     };
 
-    var hasClass = function hasClass (el, className) {
+    var hasClass = function (el, className) {
       if (el.classList) {
         return el.classList.contains(className);
       } else {

--- a/script/domhelpers.js
+++ b/script/domhelpers.js
@@ -17,7 +17,7 @@ define(
       }
     };
 
-    var hasClass = function (el, className) {
+    var hasClass = function hasClass (el, className) {
       if (el.classList) {
         return el.classList.contains(className);
       } else {
@@ -25,10 +25,27 @@ define(
       }
     };
 
+    function isRGBATuple (rgbaString) {
+      return new RegExp('^#([A-Fa-f0-9]{8})$').test(rgbaString);
+    }
+
+    /**
+     *  Checks that the string is an RGBA tuple and returns a RGB Tripple.
+     *  A string that isn't an RGBA tuple will be returned to the caller.
+     * @param {String} rgbaString
+     */
+    function rgbaToRGB (rgbaString) {
+      if (isRGBATuple(rgbaString)) {
+        rgbaString = rgbaString.slice(0, 7);
+      }
+      return rgbaString;
+    }
+
     return {
       addClass: addClass,
       removeClass: removeClass,
-      hasClass: hasClass
+      hasClass: hasClass,
+      rgbaToRGB: rgbaToRGB
     };
   }
 );

--- a/script/domhelpers.js
+++ b/script/domhelpers.js
@@ -45,7 +45,8 @@ define(
       addClass: addClass,
       removeClass: removeClass,
       hasClass: hasClass,
-      rgbaToRGB: rgbaToRGB
+      rgbaToRGB: rgbaToRGB,
+      isRGBA: isRGBATuple
     };
   }
 );

--- a/script/version.js
+++ b/script/version.js
@@ -1,5 +1,5 @@
 define('bigscreenplayer/version',
   function () {
-    return '3.9.0';
+    return '3.10.0';
   }
 );


### PR DESCRIPTION
📺 What

Add 'urn:ebu:tt:distribution:2018-04' to the standards checked to determine the namespace of a captions document and which id attribute to parse on.

🛠 How

Parse on the same attributes and values as 'urn:ebu:tt:distribution:2014-01'.

♿  Accessibility

Captions should display correctly given a new standard subtitle document.

 ✅ Acceptance criteria 
* [] [Captions are displayed in the accepted style and timing]