### PR TITLE
Improve Caption Spacing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script/captions.js
+++ b/script/captions.js
@@ -337,6 +337,10 @@ define('bigscreenplayer/captions',
           html.style.cssText = style;
         }
 
+        if (localName === 'p') {
+          html.style.margin = '0px';
+        }
+
         for (var i = 0, j = source.childNodes.length; i < j; i++) {
           var n = source.childNodes[i];
           if (n.nodeType === 3) {

--- a/script/version.js
+++ b/script/version.js
@@ -1,5 +1,5 @@
 define('bigscreenplayer/version',
   function () {
-    return '3.10.0';
+    return '3.11.0';
   }
 );


### PR DESCRIPTION
📺 What

In some cases, multiple `p` tags can cause subtitles to cover more of the video than is desirable.


🛠 How

Make sure the margin of the paragraph tags that are created is `0px`.

