### PR TITLE
Modify manifest  service location to absolute url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script-test/manifest/manifestmodifiertest.js
+++ b/script-test/manifest/manifestmodifiertest.js
@@ -344,23 +344,65 @@ require(
           expect(manifest).toEqual(expectedManifest);
         });
 
-        it('should leave the manifest unchanged for absolute base urls', function () {
-          var manifest = {
-            Period: {
-              BaseURL: 'http://cdn-a.com/dash/'
-            }
-          };
-
+        describe('should return a single base url object for absolute base urls', function () {
           var expectedManifest = {
-            Period: {
-              BaseURL: 'http://cdn-a.com/dash/'
-            }
+            Period: {},
+            BaseURL: { __text: 'https://cdn-a.com/dash/', 'dvb:priority': 0, serviceLocation: 'https://cdn-a.com/' },
+            BaseURL_asArray: [
+              { __text: 'https://cdn-a.com/dash/', 'dvb:priority': 0, serviceLocation: 'https://cdn-a.com/' }
+            ]
           };
 
-          ManifestModifier.generateBaseUrls(manifest, sources);
+          it('the url is on the manifest as a string', function () {
+            var manifest = {
+              Period: {},
+              BaseURL: 'https://cdn-a.com/dash/'
+            };
 
-          expect(manifest).toEqual(expectedManifest);
-        });
+            ManifestModifier.generateBaseUrls(manifest, sources);
+
+            expect(manifest).toEqual(expectedManifest);
+          });
+
+          it('the url is on the manifest as an object', function () {
+            var manifest = {
+              Period: {},
+              BaseURL: {
+                __text: 'https://cdn-a.com/dash/'
+              }
+            };
+
+            ManifestModifier.generateBaseUrls(manifest, sources);
+
+            expect(manifest).toEqual(expectedManifest);
+          });
+
+          it('the url is on the manifest in the period as a string', function () {
+            var manifest = {
+              Period: {
+                BaseURL: 'https://cdn-a.com/dash/'
+              }
+            };
+
+            ManifestModifier.generateBaseUrls(manifest, sources);
+
+            expect(manifest).toEqual(expectedManifest);
+          });
+
+          it('the url is on the manifest in the period as an object', function () {
+            var manifest = {
+              Period: {
+                BaseURL: {
+                  __text: 'https://cdn-a.com/dash/'
+                }
+              }
+            };
+
+            ManifestModifier.generateBaseUrls(manifest, sources);
+
+            expect(manifest).toEqual(expectedManifest);
+          });
+        },
 
         it('should leave the manifest unchanged if there is no base url', function () {
           var manifest = {
@@ -374,7 +416,7 @@ require(
           ManifestModifier.generateBaseUrls(manifest, sources);
 
           expect(manifest).toEqual(expectedManifest);
-        });
+        }));
       });
     });
   });

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -62,7 +62,7 @@ function (PlaybackUtils, WindowTypes, Plugins, PluginEnums, PluginData, DebugToo
     }
 
     function shouldFailover (failoverParams) {
-      if (failoverParams.serviceLocation === getCurrentUrl()) {
+      if (isFirstManifest(failoverParams.serviceLocation)) {
         return false;
       }
 
@@ -71,6 +71,13 @@ function (PlaybackUtils, WindowTypes, Plugins, PluginEnums, PluginData, DebugToo
       var shouldStaticFailover = windowType === WindowTypes.STATIC && !aboutToEnd;
       var shouldLiveFailover = windowType !== WindowTypes.STATIC && !talRestartable;
       return isFailoverInfoValid(failoverParams) && hasSourcesToFailoverTo() && (shouldStaticFailover || shouldLiveFailover);
+    }
+
+    // we don't want to failover on the first playback
+    // the serviceLocation is set to our first cdn url
+    // see manifest modifier - generateBaseUrls
+    function isFirstManifest (serviceLocation) {
+      return serviceLocation === getCurrentUrl();
     }
 
     function isFailoverInfoValid (failoverParams) {

--- a/script/version.js
+++ b/script/version.js
@@ -1,5 +1,5 @@
 define('bigscreenplayer/version',
   function () {
-    return '3.11.0';
+    return '3.12.0';
   }
 );


### PR DESCRIPTION
📺 What

Stop incorrectly failing over to the next CDN for simulcast audio.

> Ticket: [IPLAYERTVV1-10390](https://jira.dev.bbc.co.uk/browse/IPLAYERTVV1-10390)

🛠 How

Overwrite the serviceLocation property on the manifest with the correct value (an absolute url).
