### PR TITLE
Avstats bug seek event

### DIFF
--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -956,5 +956,35 @@ require(
           expect(mockErrorCallback).toHaveBeenCalled();
         });
       });
+
+      describe('seeking and waiting events', function () {
+        var eventCallbackSpy;
+
+        beforeEach(function () {
+          setUpMSE();
+          eventCallbackSpy = jasmine.createSpy();
+          mseStrategy.addEventCallback(this, eventCallbackSpy);
+          mseStrategy.load(null, 0);
+          mseStrategy.play();
+        });
+
+        it('should call the event callback once when seeking', function () {
+          mseStrategy.pause();
+
+          mseStrategy.setCurrentTime(60);
+
+          eventCallbacks('seeking');
+          eventCallbacks('waiting');
+
+          expect(eventCallbackSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should call the event callback more than once when not seeking', function () {
+          eventCallbacks('waiting');
+          eventCallbacks('waiting');
+
+          expect(eventCallbackSpy).toHaveBeenCalledTimes(2);
+        });
+      });
     });
   });

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -33,6 +33,9 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       var mediaMetrics;
       var dashMetrics;
 
+      var publishedSeekEvent = false;
+      var isSeeking = false;
+
       var playerMetadata = {
         playbackBitrate: undefined,
         bufferLength: undefined,
@@ -68,10 +71,16 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
 
       function onBuffering () {
         isEnded = false;
-        publishMediaState(MediaState.WAITING);
+        if (isSeeking && !publishedSeekEvent) {
+          publishMediaState(MediaState.WAITING);
+          publishedSeekEvent = true;
+        } else if (!isSeeking) {
+          publishMediaState(MediaState.WAITING);
+        }
       }
 
       function onSeeked () {
+        isSeeking = false;
         DebugTool.info('Seeked Event');
         publishMediaState(isPaused() ? MediaState.PAUSED : MediaState.PLAYING);
       }
@@ -327,22 +336,13 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       function modifySource (playbackTime) {
         mediaPlayer.attachSource(calculateSourceAnchor(mediaSources.currentSource(), playbackTime));
       }
-      function onSeeking () {
-        DebugTool.info('Seek event!******* ');
-        onBuffering();
-      }
-
-      function onWaiting () {
-        DebugTool.info('Wait event!*******');
-        onBuffering();
-      }
 
       function setUpMediaListeners () {
         mediaElement.addEventListener('timeupdate', onTimeUpdate);
         mediaElement.addEventListener('playing', onPlaying);
         mediaElement.addEventListener('pause', onPaused);
-        mediaElement.addEventListener('waiting', onWaiting);
-        mediaElement.addEventListener('seeking', onSeeking);
+        mediaElement.addEventListener('waiting', onBuffering);
+        mediaElement.addEventListener('seeking', onBuffering);
         mediaElement.addEventListener('seeked', onSeeked);
         mediaElement.addEventListener('ended', onEnded);
         mediaElement.addEventListener('error', onError);
@@ -539,6 +539,8 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           mediaPlayer.play();
         },
         setCurrentTime: function (time) {
+          publishedSeekEvent = false;
+          isSeeking = true;
           var seekToTime = getClampedTime(time, getSeekableRange());
           if (windowType === WindowTypes.GROWING && seekToTime > getCurrentTime()) {
             refreshManifestBeforeSeek(seekToTime);

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -327,13 +327,22 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       function modifySource (playbackTime) {
         mediaPlayer.attachSource(calculateSourceAnchor(mediaSources.currentSource(), playbackTime));
       }
+      function onSeeking () {
+        DebugTool.info('Seek event!******* ');
+        onBuffering();
+      }
+
+      function onWaiting () {
+        DebugTool.info('Wait event!*******');
+        onBuffering();
+      }
 
       function setUpMediaListeners () {
         mediaElement.addEventListener('timeupdate', onTimeUpdate);
         mediaElement.addEventListener('playing', onPlaying);
         mediaElement.addEventListener('pause', onPaused);
-        mediaElement.addEventListener('waiting', onBuffering);
-        mediaElement.addEventListener('seeking', onBuffering);
+        mediaElement.addEventListener('waiting', onWaiting);
+        mediaElement.addEventListener('seeking', onSeeking);
         mediaElement.addEventListener('seeked', onSeeked);
         mediaElement.addEventListener('ended', onEnded);
         mediaElement.addEventListener('error', onError);


### PR DESCRIPTION
📺 What
For most MSE devices, we throw TWO buffering state changes from bigscreen-player, one on the media element's 'waiting' event, and another on the media element's 'seeking' event. The first one will be suppressed when seeking, but the second will not. We need to throw one `waiting` event to stop reporting false buffering. 


> [Tickets: IPLAYERTVV1-10185](https://jira.dev.bbc.co.uk/browse/IPLAYERTVV1-10185)

🛠 How
Set seeking state when `setCurrentTime` is called in `msestrategy`.  Throw only the first seeking/waiting event when we are in the seeking state. 



