### PR TITLE
Multiple seek event bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -956,5 +956,35 @@ require(
           expect(mockErrorCallback).toHaveBeenCalled();
         });
       });
+
+      describe('seeking and waiting events', function () {
+        var eventCallbackSpy;
+
+        beforeEach(function () {
+          setUpMSE();
+          eventCallbackSpy = jasmine.createSpy();
+          mseStrategy.addEventCallback(this, eventCallbackSpy);
+          mseStrategy.load(null, 0);
+          mseStrategy.play();
+        });
+
+        it('should call the event callback once when seeking', function () {
+          mseStrategy.pause();
+
+          mseStrategy.setCurrentTime(60);
+
+          eventCallbacks('seeking');
+          eventCallbacks('waiting');
+
+          expect(eventCallbackSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should call the event callback more than once when not seeking', function () {
+          eventCallbacks('waiting');
+          eventCallbacks('waiting');
+
+          expect(eventCallbackSpy).toHaveBeenCalledTimes(2);
+        });
+      });
     });
   });

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -77,16 +77,6 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         }
       }
 
-      function onWaiting () {
-        DebugTool.info('Waiting *****************');
-        onBuffering();
-      }
-
-      function onSeeking () {
-        DebugTool.info('Seeking *****************');
-        onBuffering();
-      }
-
       function onSeeked () {
         isSeeking = false;
         DebugTool.info('Seeked Event');
@@ -349,8 +339,8 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         mediaElement.addEventListener('timeupdate', onTimeUpdate);
         mediaElement.addEventListener('playing', onPlaying);
         mediaElement.addEventListener('pause', onPaused);
-        mediaElement.addEventListener('waiting', onWaiting);
-        mediaElement.addEventListener('seeking', onSeeking);
+        mediaElement.addEventListener('waiting', onBuffering);
+        mediaElement.addEventListener('seeking', onBuffering);
         mediaElement.addEventListener('seeked', onSeeked);
         mediaElement.addEventListener('ended', onEnded);
         mediaElement.addEventListener('error', onError);

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -327,13 +327,22 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       function modifySource (playbackTime) {
         mediaPlayer.attachSource(calculateSourceAnchor(mediaSources.currentSource(), playbackTime));
       }
+      function onSeeking () {
+        DebugTool.info('Seek event!******* ');
+        onBuffering();
+      }
+
+      function onWaiting () {
+        DebugTool.info('Wait event!*******');
+        onBuffering();
+      }
 
       function setUpMediaListeners () {
         mediaElement.addEventListener('timeupdate', onTimeUpdate);
         mediaElement.addEventListener('playing', onPlaying);
         mediaElement.addEventListener('pause', onPaused);
-        mediaElement.addEventListener('waiting', onBuffering);
-        mediaElement.addEventListener('seeking', onBuffering);
+        mediaElement.addEventListener('waiting', onWaiting);
+        mediaElement.addEventListener('seeking', onSeeking);
         mediaElement.addEventListener('seeked', onSeeked);
         mediaElement.addEventListener('ended', onEnded);
         mediaElement.addEventListener('error', onError);

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -77,6 +77,16 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         }
       }
 
+      function onWaiting () {
+        DebugTool.info('Waiting *****************');
+        onBuffering();
+      }
+
+      function onSeeking () {
+        DebugTool.info('Seeking *****************');
+        onBuffering();
+      }
+
       function onSeeked () {
         isSeeking = false;
         DebugTool.info('Seeked Event');
@@ -339,8 +349,8 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         mediaElement.addEventListener('timeupdate', onTimeUpdate);
         mediaElement.addEventListener('playing', onPlaying);
         mediaElement.addEventListener('pause', onPaused);
-        mediaElement.addEventListener('waiting', onBuffering);
-        mediaElement.addEventListener('seeking', onBuffering);
+        mediaElement.addEventListener('waiting', onWaiting);
+        mediaElement.addEventListener('seeking', onSeeking);
         mediaElement.addEventListener('seeked', onSeeked);
         mediaElement.addEventListener('ended', onEnded);
         mediaElement.addEventListener('error', onError);

--- a/script/version.js
+++ b/script/version.js
@@ -1,5 +1,5 @@
 define('bigscreenplayer/version',
   function () {
-    return '3.12.0';
+    return '3.13.0';
   }
 );


### PR DESCRIPTION
📺 What
For most MSE devices, we throw TWO buffering state changes from `bigscreen-player`, one on the media element's `waiting` event, and another on the media element's `seeking` event. The first one will be suppressed when seeking, but the second will not. We need to throw one `WAITING` event to stop reporting false buffering.

[Tickets: IPLAYERTVV1-10185](https://jira.dev.bbc.co.uk/browse/IPLAYERTVV1-10185)

🛠 How
Set seeking state when `setCurrentTime` is called in `msestrategy`. Throw onw `WAITING` for the first seeking/waiting event when we are in the seeking state.