### PR TITLE
Add a guard to eventCallbacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script-test/playbackstrategies/modifiers/html5tests.js
+++ b/script-test/playbackstrategies/modifiers/html5tests.js
@@ -1831,6 +1831,17 @@ require(
 
             expect(mockVideoMediaElement.removeEventListener).toHaveBeenCalledTimes(listeners.length);
           });
+
+          it('Remove all event callbacks works correctly', function () {
+            function playAndEmitAfterRemoveAllCallbacks () {
+              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+              player.beginPlaybackFrom(0);
+              player.removeAllEventCallbacks();
+              endedCallback();
+            }
+
+            expect(playAndEmitAfterRemoveAllCallbacks).not.toThrowError();
+          });
         });
 
         describe('Events', function () {

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -582,6 +582,17 @@ require(
 
           expect(playbackElement.childElementCount).toBe(0);
         });
+
+        it('should empty the eventCallbacks array and stop emitting events', function () {
+          setUpMSE();
+          function tearDownAndError () {
+            mseStrategy.load(null, 0);
+            mseStrategy.tearDown();
+            dashEventCallback('pause');
+          }
+
+          expect(tearDownAndError).not.toThrowError();
+        });
       });
 
       describe('isEnded()', function () {

--- a/script/playbackstrategy/modifiers/html5.js
+++ b/script/playbackstrategy/modifiers/html5.js
@@ -74,10 +74,8 @@ define(
           }
         }
 
-        if (eventCallbacks) {
-          for (var index = 0; index < eventCallbacks.length; index++) {
-            eventCallbacks[index](event);
-          }
+        for (var index = 0; index < eventCallbacks.length; index++) {
+          eventCallbacks[index](event);
         }
       }
 
@@ -630,7 +628,7 @@ define(
         },
 
         removeAllEventCallbacks: function () {
-          eventCallbacks = undefined;
+          eventCallbacks = [];
         },
 
         initialiseMedia: function (type, url, mediaMimeType, sourceContainer, opts) {

--- a/script/playbackstrategy/modifiers/html5.js
+++ b/script/playbackstrategy/modifiers/html5.js
@@ -74,8 +74,10 @@ define(
           }
         }
 
-        for (var index = 0; index < eventCallbacks.length; index++) {
-          eventCallbacks[index](event);
+        if (eventCallbacks) {
+          for (var index = 0; index < eventCallbacks.length; index++) {
+            eventCallbacks[index](event);
+          }
         }
       }
 

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -490,7 +490,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
 
           mediaPlayer = undefined;
           mediaElement = undefined;
-          eventCallbacks = undefined;
+          eventCallbacks = [];
           errorCallback = undefined;
           timeUpdateCallback = undefined;
           timeCorrection = undefined;

--- a/script/version.js
+++ b/script/version.js
@@ -1,5 +1,5 @@
 define('bigscreenplayer/version',
   function () {
-    return '3.13.0';
+    return '3.13.1';
   }
 );


### PR DESCRIPTION
📺 What
Spotted in automated testing telemetry. Calling tearDown will set `eventCallbacks` to `undefined` causing a type error when a media element emits an event.

Spotted during
> Tickets: IPLAYERTVV1-9375


🛠 How

Guard iterating through the `eventCallbacks` if the array is `undefined`.

