### PR TITLE
Return `undefined` from `getCurrentTime()` when it is unknown

### DIFF
--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -252,7 +252,7 @@ require(
             expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: false, endOfStream: false});
           });
 
-          it('should set the isPaused flag to true when waiting after a setCurrentTime', function () {
+          it('should set the isSeeking flag to true when waiting after a setCurrentTime', function () {
             mockEventHook({data: {state: MediaState.PLAYING}});
 
             expect(callback).toHaveBeenCalledWith({state: MediaState.PLAYING, endOfStream: false});
@@ -265,7 +265,15 @@ require(
             expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: true, endOfStream: false});
           });
 
-          it('should set clear the isPaused flag after a waiting event is fired', function () {
+          it('should set the isSeeking flag to false when it is a normal waiting state', function () {
+            mockEventHook({data: {state: MediaState.PLAYING}});
+
+            mockEventHook({data: {state: MediaState.WAITING}});
+
+            expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: false, endOfStream: false});
+          });
+
+          it('should set the isSeeking flag to false when it is a normal waiting state after a previous seek', function () {
             mockEventHook({data: {state: MediaState.PLAYING}});
 
             bigscreenPlayer.setCurrentTime(60);
@@ -273,8 +281,8 @@ require(
 
             expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: true, endOfStream: false});
 
+            mockEventHook({data: {state: MediaState.PLAYING}});
             callback.calls.reset();
-
             mockEventHook({data: {state: MediaState.WAITING}});
 
             expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: false, endOfStream: false});
@@ -473,16 +481,75 @@ require(
         });
 
         describe('getCurrentTime', function () {
-          it('should return the current time from the strategy', function () {
+          it('should return the initialPlaybackTime before player initialised', function () {
+            initialiseBigscreenPlayer({initialPlaybackTime: 123});
+
+            mockPlayerComponentInstance.getCurrentTime.and.returnValue(10);
+
+            expect(bigscreenPlayer.getCurrentTime()).toBe(123);
+
+            mockEventHook({data: {state: MediaState.WAITING}});
+
+            expect(bigscreenPlayer.getCurrentTime()).toBe(123);
+          });
+
+          it('should return the latest requested time before player initialised', function () {
+            initialiseBigscreenPlayer({initialPlaybackTime: 123});
+
+            mockPlayerComponentInstance.getCurrentTime.and.returnValue(10);
+
+            expect(bigscreenPlayer.getCurrentTime()).toBe(123);
+
+            bigscreenPlayer.setCurrentTime(11);
+
+            expect(bigscreenPlayer.getCurrentTime()).toBe(11);
+          });
+
+          it('should return undefined before player initialised if there is no initialPlaybackTime', function () {
             initialiseBigscreenPlayer();
 
             mockPlayerComponentInstance.getCurrentTime.and.returnValue(10);
 
+            expect(bigscreenPlayer.getCurrentTime()).toBe(undefined);
+          });
+
+          it('should return the current time from the strategy once player initialised', function () {
+            initialiseBigscreenPlayer({initialPlaybackTime: 123});
+
+            mockPlayerComponentInstance.getCurrentTime.and.returnValue(10);
+
+            mockEventHook({data: {state: MediaState.PAUSED}});
+
             expect(bigscreenPlayer.getCurrentTime()).toBe(10);
           });
 
-          it('should return 0 if bigscreenPlayer is not initialised', function () {
-            expect(bigscreenPlayer.getCurrentTime()).toBe(0);
+          it('should return undefined if bigscreenPlayer is not initialised', function () {
+            expect(bigscreenPlayer.getCurrentTime()).toBe(undefined);
+          });
+
+          it('should return the value provided to setCurrentTime whilst seek in flight', function () {
+            initialiseBigscreenPlayer();
+
+            mockPlayerComponentInstance.getCurrentTime.and.returnValue(10);
+            bigscreenPlayer.setCurrentTime(11);
+
+            expect(bigscreenPlayer.getCurrentTime()).toBe(11);
+
+            mockEventHook({data: {state: MediaState.PAUSED}});
+
+            expect(bigscreenPlayer.getCurrentTime()).toBe(11);
+
+            bigscreenPlayer.setCurrentTime(12);
+
+            expect(bigscreenPlayer.getCurrentTime()).toBe(12);
+
+            mockEventHook({data: {state: MediaState.WAITING}});
+
+            expect(bigscreenPlayer.getCurrentTime()).toBe(12);
+
+            mockEventHook({data: {state: MediaState.PLAYING}});
+
+            expect(bigscreenPlayer.getCurrentTime()).toBe(10);
           });
         });
 
@@ -530,6 +597,7 @@ require(
 
           it('should return true when playing live and current time is within tolerance of seekable range end', function () {
             initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
+            mockEventHook({data: {state: MediaState.PLAYING}});
 
             mockPlayerComponentInstance.getCurrentTime.and.returnValue(100);
             mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 105});

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -26,8 +26,8 @@ require(
     var mockPlugins;
     var mockPluginsInterface;
     var mockDynamicWindowUtils;
-    var mockAudioElement = document.createElement('audio');
-    var mockVideoElement = document.createElement('video');
+    var mockAudioElement = document.createElement('div');
+    var mockVideoElement = document.createElement('div');
     var mockRefresher;
     var testManifestObject;
     var timeUtilsMock;
@@ -512,16 +512,17 @@ require(
         it('returns the correct time from the DASH Mediaplayer', function () {
           setUpMSE();
           mockVideoElement.currentTime = 10;
+          mockVideoElement.readyState = 1;
 
           mseStrategy.load(null, 0);
 
           expect(mseStrategy.getCurrentTime()).toBe(10);
         });
 
-        it('returns 0 when MediaPlayer is undefined', function () {
+        it('returns undefined when MediaPlayer is undefined', function () {
           setUpMSE();
 
-          expect(mseStrategy.getCurrentTime()).toBe(0);
+          expect(mseStrategy.getCurrentTime()).toBe(undefined);
         });
       });
 

--- a/script/models/seekstate.js
+++ b/script/models/seekstate.js
@@ -1,0 +1,23 @@
+define(
+  'bigscreenplayer/models/seekstate',
+  /**
+   * Provides an enumeration of possible media states.
+   */
+  function () {
+    'use strict';
+
+    /**
+     * Enumeration of possible seek states.
+     */
+    var SeekState = {
+      /** No seek in progress. */
+      NONE: 0,
+      /** A seek is about to be processed. */
+      QUEUED: 1,
+      /** A seek is in progress. */
+      IN_FLIGHT: 2
+    };
+
+    return SeekState;
+  }
+);

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -406,7 +406,10 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       }
 
       function getCurrentTime () {
-        return (mediaElement) ? mediaElement.currentTime - timeCorrection : 0;
+        if (!mediaPlayer || !mediaPlayer.isReady() || !mediaElement || mediaElement.readyState < 1 /* HAVE_METADATA */) {
+          return undefined;
+        }
+        return mediaElement.currentTime - timeCorrection;
       }
 
       function refreshManifestBeforeSeek (seekToTime) {


### PR DESCRIPTION
📺 What

Currently `getCurrentTime()` has a default value of 0 in several cases. This is not ideal because it makes it impossible to know if it truly is time 0, or if the time is not known yet.

It also sometimes returns the wrong value.

An example where this is an issue is if you start a live stream from the live point. Currently you will get back the incorrect time whilst the stream loads, and then it will jump to the correct value.

With this PR when the strategy is still loading (hasn't changed the state to something other than `WAITING`) `getCurrentTime()` will now always return

- the value of the latest `setCurrentTime` request or
- `initialPlaybackTime` or
- `undefined`

I chose to put this logic in 'bigscreenplayer.js' instead of the individual strategies because I think this is something that benefits them all.

This also means a call to `getCurrentTime()` in the same stack as `setCurrentTime()` is guaranteed to be what you expect even if the update happens asynchronously in the strategy.

This PR also contains a fix in the `msestrategy` `getCurrentTime()` to prevent it returning incorrect values when the media element isn't ready. This change isn't strictly needed given the other change in 'bigscreenplayer.js' prevents it causing an issue, but it's probably good to fix anyway.

> N/A (but can create one)


🛠 How

- Introduce a `SeekState` enum which can be `NONE`, `QUEUED` or `IN_FLIGHT`. When a seek is `QUEUED` or `IN_FLIGHT` we now return the time we're seeking to from `getCurrentTime()` instead of calling through to the strategy.
- In `msestrategy` return `undefined` instead of `0` from `getCurrentTime` when the time is unknown.
- In `msestrategy` return `undefined` when the media element [`readyState`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState) is at least `HAVE_METADATA`. Before this dashjs has not set the current time to near the live point meaning it would return the wrong value.
- Update/add tests


 ✅ Acceptance criteria
- [ ] `getCurrentTime()` returns `undefined` whilst a stream is loading with no `initialPlaybackTime` using the mse strategy
- [ ] `getCurrentTime()` always returns the time it was set to immediately after `setCurrentTime()`
- [ ] `getCurrentTime()` initially returns the value of `initialPlaybackTime`.
- [ ] `getCurrentTime()` returns the expected time when the media state is not WAITING


* [ ] [Mark correctly if it is covered in this PR or not]