### PR TITLE
Log events before actioning callbacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -62,11 +62,11 @@ define('bigscreenplayer/bigscreenplayer',
           }
 
           stateObject.endOfStream = endOfStream;
+          DebugTool.event(stateObject);
 
           stateChangeCallbacks.forEach(function (callback) {
             callback(stateObject);
           });
-          DebugTool.event(stateObject);
         }
 
         if (evt.data.seekableRange) {

--- a/script/version.js
+++ b/script/version.js
@@ -1,5 +1,5 @@
 define('bigscreenplayer/version',
   function () {
-    return '3.13.1';
+    return '3.13.2';
   }
 );


### PR DESCRIPTION
📺 What
Synchronously tearing down the player based upon an event will not log the event that caused the teardown.

🛠 How
Log the event before actioning callbacks registered to the event.
