### PR TITLE
Auto Resume Live Asset for MSE Devices 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.13.2",
+  "version": "3.13.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.13.2",
+  "version": "3.13.3",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script-test/dynamicwindowutilstest.js
+++ b/script-test/dynamicwindowutilstest.js
@@ -3,12 +3,29 @@ require(
     'bigscreenplayer/dynamicwindowutils'
   ],
     function (DynamicWindowUtils) {
-      describe('isAtStartOfRange', function () {
-        it('returns true if we are at the beginning of the playback range within a threshhold', function () {
-          // fail();
-          var isAtStart = DynamicWindowUtils.isAtStartOfRange(10, 10);
+      describe('shouldAutoResume', function () {
+        it('returns true if we are at the beginning of the playback range', function () {
+          var isAtStart = DynamicWindowUtils.shouldAutoResume(10, 10);
 
           expect(isAtStart).toBeTrue();
+        });
+
+        it('returns true if we are at the beginning of the playback range within a threshhold', function () {
+          var isAtStart = DynamicWindowUtils.shouldAutoResume(15, 10);
+
+          expect(isAtStart).toBeTrue();
+        });
+
+        it('returns true if we are at the beginning of the playback range at the threshhold', function () {
+          var isAtStart = DynamicWindowUtils.shouldAutoResume(18, 10);
+
+          expect(isAtStart).toBeTrue();
+        });
+
+        it('returns false if we are after the beginning and the threshhold', function () {
+          var isAtStart = DynamicWindowUtils.shouldAutoResume(20, 10);
+
+          expect(isAtStart).toBeFalse();
         });
       });
     }

--- a/script-test/dynamicwindowutilstest.js
+++ b/script-test/dynamicwindowutilstest.js
@@ -1,0 +1,15 @@
+require(
+  [
+    'bigscreenplayer/dynamicwindowutils'
+  ],
+    function (DynamicWindowUtils) {
+      describe('isAtStartOfRange', function () {
+        it('returns true if we are at the beginning of the playback range within a threshhold', function () {
+          // fail();
+          var isAtStart = DynamicWindowUtils.isAtStartOfRange(10, 10);
+
+          expect(isAtStart).toBeTrue();
+        });
+      });
+    }
+);

--- a/script-test/dynamicwindowutilstest.js
+++ b/script-test/dynamicwindowutilstest.js
@@ -28,5 +28,94 @@ require(
           expect(isAtStart).toBeFalse();
         });
       });
+
+      describe('autoResumeAtStartOfRange', function () {
+        var resume;
+        var addEventCallback;
+        var removeEventCallback;
+        var checkNotPauseEvent;
+        var currentTime = 20;
+        var seekableRange = {
+          start: 0
+        };
+
+        beforeEach(function () {
+          jasmine.clock().install();
+          resume = jasmine.createSpy('resume');
+          addEventCallback = jasmine.createSpy('addEventCallback');
+          removeEventCallback = jasmine.createSpy('removeEventCallback');
+          checkNotPauseEvent = jasmine.createSpy('checkNotPauseEvent');
+        });
+
+        afterEach(function () {
+          jasmine.clock().uninstall();
+        });
+
+        it('resumes play when the current time is equal to the start of the seekable range', function () {
+          DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, undefined, resume);
+
+          jasmine.clock().tick(20000);
+
+          expect(addEventCallback).toHaveBeenCalledTimes(1);
+          expect(removeEventCallback).toHaveBeenCalledTimes(1);
+          expect(resume).toHaveBeenCalledTimes(1);
+        });
+
+        it('resumes play when the current time at the start of the seekable range within a threshold', function () {
+          DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, undefined, resume);
+
+          jasmine.clock().tick(15000);
+
+          expect(addEventCallback).toHaveBeenCalledTimes(1);
+          expect(removeEventCallback).toHaveBeenCalledTimes(1);
+          expect(resume).toHaveBeenCalledTimes(1);
+        });
+
+        it('resumes play when the current time at the start of the seekable range at the threshold', function () {
+          DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, undefined, resume);
+
+          jasmine.clock().tick(12000);
+
+          expect(addEventCallback).toHaveBeenCalledTimes(1);
+          expect(removeEventCallback).toHaveBeenCalledTimes(1);
+          expect(resume).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not resume play when the current time is past the start of the seekable range plus the threshold', function () {
+          DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, undefined, resume);
+
+          jasmine.clock().tick(10000);
+
+          expect(addEventCallback).toHaveBeenCalledTimes(1);
+          expect(removeEventCallback).toHaveBeenCalledTimes(0);
+          expect(resume).toHaveBeenCalledTimes(0);
+        });
+
+        it('non pause event stops autoresume', function () {
+          checkNotPauseEvent.and.returnValue(true);
+
+          addEventCallback.and.callFake(function (context, callback) { callback(); });
+
+          DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, checkNotPauseEvent, resume);
+
+          jasmine.clock().tick(20000);
+
+          expect(removeEventCallback).toHaveBeenCalledTimes(1);
+          expect(resume).toHaveBeenCalledTimes(0);
+        });
+
+        it('pause event does not stop autoresume', function () {
+          checkNotPauseEvent.and.returnValue(false);
+
+          addEventCallback.and.callFake(function (context, callback) { callback(); });
+
+          DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, checkNotPauseEvent, resume);
+
+          jasmine.clock().tick(20000);
+
+          expect(removeEventCallback).toHaveBeenCalledTimes(1);
+          expect(resume).toHaveBeenCalledTimes(1);
+        });
+      });
     }
 );

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -57,7 +57,7 @@ require(
         mockPlugins = {
           interface: mockPluginsInterface
         };
-        mockDynamicWindowUtils = jasmine.createSpyObj('mockDynamicWindowUtils', ['autoResumeAtStartOfRange']);
+        mockDynamicWindowUtils = jasmine.createSpyObj('mockDynamicWindowUtils', ['autoResumeAtStartOfRange', 'isAtStartOfRange']);
 
         spyOn(mockVideoElement, 'addEventListener');
         spyOn(mockVideoElement, 'removeEventListener');
@@ -719,6 +719,7 @@ require(
             setUpMSE(0, WindowTypes.SLIDING, MediaKinds.VIDEO, 100, 1000);
             mseStrategy.load(null, 0);
             mockDynamicWindowUtils.autoResumeAtStartOfRange.calls.reset();
+            mockDashInstance.play.calls.reset();
           });
 
           it('should set current time on the video element', function () {
@@ -762,6 +763,25 @@ require(
             mseStrategy.setCurrentTime(101);
 
             expect(timeUtilsMock.calculateSlidingWindowSeekOffset).toHaveBeenCalledTimes(1);
+          });
+
+          it('should autoresume when paused and seeking to the start of the sliding window seekable range', function () {
+            mockDynamicWindowUtils.isAtStartOfRange.and.returnValue(true);
+            mockDashInstance.isPaused.and.returnValue(true);
+
+            mseStrategy.pause();
+            mseStrategy.setCurrentTime(0);
+
+            expect(mockDashInstance.play).toHaveBeenCalledTimes(1);
+          });
+
+          it('should not try to autoresume when playing and seeking to the start of the sliding window seekable range', function () {
+            mockDynamicWindowUtils.isAtStartOfRange.and.returnValue(true);
+            mockDashInstance.isPaused.and.returnValue(false);
+
+            mseStrategy.setCurrentTime(0);
+
+            expect(mockDashInstance.play).toHaveBeenCalledTimes(0);
           });
         });
 

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -57,7 +57,7 @@ require(
         mockPlugins = {
           interface: mockPluginsInterface
         };
-        mockDynamicWindowUtils = jasmine.createSpyObj('mockDynamicWindowUtils', ['autoResumeAtStartOfRange', 'isAtStartOfRange']);
+        mockDynamicWindowUtils = jasmine.createSpyObj('mockDynamicWindowUtils', ['autoResumeAtStartOfRange', 'shouldAutoResume']);
 
         spyOn(mockVideoElement, 'addEventListener');
         spyOn(mockVideoElement, 'removeEventListener');
@@ -766,21 +766,23 @@ require(
           });
 
           it('should autoresume when paused and seeking to the start of the sliding window seekable range', function () {
-            mockDynamicWindowUtils.isAtStartOfRange.and.returnValue(true);
+            mockDynamicWindowUtils.shouldAutoResume.and.returnValue(true);
             mockDashInstance.isPaused.and.returnValue(true);
 
             mseStrategy.pause();
             mseStrategy.setCurrentTime(0);
 
+            expect(mockDynamicWindowUtils.shouldAutoResume).toHaveBeenCalledWith(jasmine.any(Number), jasmine.any(Number));
             expect(mockDashInstance.play).toHaveBeenCalledTimes(1);
           });
 
           it('should not try to autoresume when playing and seeking to the start of the sliding window seekable range', function () {
-            mockDynamicWindowUtils.isAtStartOfRange.and.returnValue(true);
+            mockDynamicWindowUtils.shouldAutoResume.and.returnValue(true);
             mockDashInstance.isPaused.and.returnValue(false);
 
             mseStrategy.setCurrentTime(0);
 
+            expect(mockDynamicWindowUtils.shouldAutoResume).toHaveBeenCalledWith(jasmine.any(Number), jasmine.any(Number));
             expect(mockDashInstance.play).toHaveBeenCalledTimes(0);
           });
         });

--- a/script/dynamicwindowutils.js
+++ b/script/dynamicwindowutils.js
@@ -67,13 +67,13 @@ define(
       }
     }
 
-    function isAtStartOfRange (seekTime, seekableRangeStart) {
+    function shouldAutoResume (seekTime, seekableRangeStart) {
       return seekTime - seekableRangeStart <= AUTO_RESUME_WINDOW_START_CUSHION_SECONDS;
     }
 
     return {
       autoResumeAtStartOfRange: autoResumeAtStartOfRange,
-      isAtStartOfRange: isAtStartOfRange,
+      shouldAutoResume: shouldAutoResume,
       canPause: canPause,
       canSeek: canSeek
     };

--- a/script/dynamicwindowutils.js
+++ b/script/dynamicwindowutils.js
@@ -51,7 +51,7 @@ define(
 
     function autoResumeAtStartOfRange (currentTime, seekableRange, addEventCallback, removeEventCallback, checkNotPauseEvent, resume) {
       var resumeTimeOut = Math.max(0, currentTime - seekableRange.start - AUTO_RESUME_WINDOW_START_CUSHION_SECONDS);
-      DebugTool.keyValue({key: 'autoresume', value: resumeTimeOut});
+      // DebugTool.keyValue({key: 'autoresume', value: resumeTimeOut});
       var autoResumeTimer = setTimeout(function () {
         removeEventCallback(undefined, detectIfUnpaused);
         resume();
@@ -67,8 +67,13 @@ define(
       }
     }
 
+    function isAtStartOfRange (seekTime, seekableRangeStart) {
+      return seekTime - seekableRangeStart <= AUTO_RESUME_WINDOW_START_CUSHION_SECONDS;
+    }
+
     return {
       autoResumeAtStartOfRange: autoResumeAtStartOfRange,
+      isAtStartOfRange: isAtStartOfRange,
       canPause: canPause,
       canSeek: canSeek
     };

--- a/script/dynamicwindowutils.js
+++ b/script/dynamicwindowutils.js
@@ -51,7 +51,7 @@ define(
 
     function autoResumeAtStartOfRange (currentTime, seekableRange, addEventCallback, removeEventCallback, checkNotPauseEvent, resume) {
       var resumeTimeOut = Math.max(0, currentTime - seekableRange.start - AUTO_RESUME_WINDOW_START_CUSHION_SECONDS);
-      // DebugTool.keyValue({key: 'autoresume', value: resumeTimeOut});
+      DebugTool.keyValue({key: 'autoresume', value: resumeTimeOut});
       var autoResumeTimer = setTimeout(function () {
         removeEventCallback(undefined, detectIfUnpaused);
         resume();

--- a/script/playbackstrategy/legacyplayeradapter.js
+++ b/script/playbackstrategy/legacyplayeradapter.js
@@ -247,6 +247,7 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
           mediaPlayer.initialiseMedia('video', mediaSources.currentSource(), mimeType, playbackElement, setSourceOpts);
           if (mediaPlayer.beginPlaybackFrom && !isPlaybackFromLivePoint) {
             currentTime = startTime;
+            DebugTool.keyValue({key: 'initial-playback-time', value: startTime + timeCorrection});
             mediaPlayer.beginPlaybackFrom(startTime + timeCorrection || 0);
           } else {
             mediaPlayer.beginPlayback();

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -439,8 +439,8 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
       function resumeIfRequired (seekTime) {
         if (windowType !== WindowTypes.SLIDING) { return; }
         var seekableRange = getSeekableRange();
-        var isAtStart = DynamicWindowUtils.isAtStartOfRange(seekTime, seekableRange.start);
-        if (isPaused() && isAtStart) {
+        var shouldAutoResume = DynamicWindowUtils.shouldAutoResume(seekTime, seekableRange.start);
+        if (isPaused() && shouldAutoResume) {
           mediaPlayer.play();
         }
       }
@@ -554,7 +554,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           } else {
             var seekTime = calculateSeekOffset(time);
             mediaPlayer.seek(seekTime);
-            resumeIfRequired();
+            resumeIfRequired(seekTime);
           }
         }
       };

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -373,7 +373,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         }
 
         if (windowType === WindowTypes.SLIDING) {
-          DebugTool.keyValue({key: 'initial-playback-time', value: startTime});
+          DebugTool.keyValue({key: 'initial-playback-time', value: parseInt(startTime)});
           return startTime === 0 ? source : source + '#r=' + parseInt(startTime);
         }
 

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -373,6 +373,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         }
 
         if (windowType === WindowTypes.SLIDING) {
+          DebugTool.keyValue({key: 'initial-playback-time', value: startTime});
           return startTime === 0 ? source : source + '#r=' + parseInt(startTime);
         }
 

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -436,6 +436,15 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         return getClampedTime(time, getSeekableRange());
       }
 
+      function resumeIfRequired (seekTime) {
+        if (windowType !== WindowTypes.SLIDING) { return; }
+        var seekableRange = getSeekableRange();
+        var isAtStart = DynamicWindowUtils.isAtStartOfRange(seekTime, seekableRange.start);
+        if (isPaused() && isAtStart) {
+          mediaPlayer.play();
+        }
+      }
+
       return {
         transitions: {
           canBePaused: function () { return true; },
@@ -545,6 +554,7 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
           } else {
             var seekTime = calculateSeekOffset(time);
             mediaPlayer.seek(seekTime);
+            resumeIfRequired();
           }
         }
       };

--- a/script/version.js
+++ b/script/version.js
@@ -1,5 +1,5 @@
 define('bigscreenplayer/version',
   function () {
-    return '3.13.2';
+    return '3.13.3';
   }
 );


### PR DESCRIPTION
📺 What

Seeking to the beginning of the sliding window on a MSE device will resume play from a paused state.

> Tickets: [IPLAYERTVV1-9679](https://jira.dev.bbc.co.uk/browse/IPLAYERTVV1-9679)


🛠 How

When seeking to a point in the video, we check if the new time is at the start of the sliding window. If it is at the start and we are in a paused state then play the asset.



 ✅ Acceptance criteria [Optional]

[MANDATORY for cross-team reviews]
* [X] [The asset resumes when we seek to the beginning]