### PR TITLE
Add ability to notified to subtitles being turned on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,23 @@ var timeUpdateToken = bigscreenPlayer.registerForTimeUpdates(function (event) {
 bigscreenPlayer.unRegisterForTimeUpdates(timeUpdateToken);
 ```
 
+### Reacting to subtitles being turned on/off
+
+This is emitted on every `setSubtitlesEnabled` call. The emitted object contains an `enabled` property.
+
+This may be registered for before initialisation and will automatically be cleared upon `tearDown()` of the player.
+
+```javascript
+var bigscreenPlayer = BigscreenPlayer();
+
+// The token is only required in the case where the function is anonymous, a reference to the function can be stored and used to unregister otherwise.
+var subtitleChangeToken = bigscreenPlayer.registerForSubtitleChanges(function (event) {
+    console.log('Subttiles enabled: ' + event.enabled);
+});
+
+bigscreenPlayer.unregisterForSubtitleChanges(subtitleChangeToken);
+```
+
 ### Creating a plugin
 
 Plugins can be created to extend the functionality of the Bigscreen Player by adhering to an interface which propogates non state change events from the player. For example, when an error is raised or cleared.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.13.3",
+  "version": "3.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.13.3",
+  "version": "3.14.0",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -404,6 +404,69 @@ require(
           });
         });
 
+        describe('registerForSubtitleChanges', function () {
+          it('should call the callback when we subtitles are turned on/off', function () {
+            var callback = jasmine.createSpy('listener1');
+            initialiseBigscreenPlayer();
+            bigscreenPlayer.registerForSubtitleChanges(callback);
+
+            expect(callback).not.toHaveBeenCalled();
+
+            bigscreenPlayer.setSubtitlesEnabled(true);
+
+            expect(callback).toHaveBeenCalledWith({enabled: true});
+
+            bigscreenPlayer.setSubtitlesEnabled(false);
+
+            expect(callback).toHaveBeenCalledWith({enabled: false});
+          });
+
+          it('returns a reference to the callback passed in', function () {
+            var callback = jasmine.createSpy();
+            var reference = bigscreenPlayer.registerForSubtitleChanges(callback);
+
+            expect(reference).toBe(callback);
+          });
+        });
+
+        describe('unregisterForSubtitleChanges', function () {
+          it('should remove callback from subtitleCallbacks', function () {
+            initialiseBigscreenPlayer();
+
+            var listener1 = jasmine.createSpy('listener1');
+            var listener2 = jasmine.createSpy('listener2');
+            var listener3 = jasmine.createSpy('listener3');
+
+            bigscreenPlayer.registerForSubtitleChanges(listener1);
+            bigscreenPlayer.registerForSubtitleChanges(listener2);
+            bigscreenPlayer.registerForSubtitleChanges(listener3);
+
+            bigscreenPlayer.setSubtitlesEnabled(true);
+
+            bigscreenPlayer.unregisterForSubtitleChanges(listener2);
+
+            bigscreenPlayer.setSubtitlesEnabled(false);
+
+            expect(listener1).toHaveBeenCalledTimes(2);
+            expect(listener2).toHaveBeenCalledTimes(1);
+            expect(listener3).toHaveBeenCalledTimes(2);
+          });
+
+          it('should only remove existing callbacks from subtitleCallbacks', function () {
+            initialiseBigscreenPlayer();
+
+            var listener1 = jasmine.createSpy('listener1');
+            var listener2 = jasmine.createSpy('listener2');
+
+            bigscreenPlayer.registerForSubtitleChanges(listener1);
+            bigscreenPlayer.unregisterForSubtitleChanges(listener2);
+
+            bigscreenPlayer.setSubtitlesEnabled(true);
+
+            expect(listener1).toHaveBeenCalledWith({enabled: true});
+          });
+        });
+
         describe('setCurrentTime', function () {
           it('should setCurrentTime on the strategy/playerComponent', function () {
             initialiseBigscreenPlayer();

--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -421,6 +421,24 @@ require(
             expect(callback).toHaveBeenCalledWith({enabled: false});
           });
 
+          it('should call the callback when init() is called with subtitles enabled', function () {
+            var callback = jasmine.createSpy('listener1');
+
+            bigscreenPlayer.registerForSubtitleChanges(callback);
+            initialiseBigscreenPlayer({ subtitlesEnabled: true });
+
+            expect(callback).toHaveBeenCalledWith({enabled: true});
+          });
+
+          it('should not call the callback when init() is called without subtitles enabled', function () {
+            var callback = jasmine.createSpy('listener1');
+
+            bigscreenPlayer.registerForSubtitleChanges(callback);
+            initialiseBigscreenPlayer();
+
+            expect(callback).not.toHaveBeenCalled();
+          });
+
           it('returns a reference to the callback passed in', function () {
             var callback = jasmine.createSpy();
             var reference = bigscreenPlayer.registerForSubtitleChanges(callback);

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -18,6 +18,7 @@ define('bigscreenplayer/bigscreenplayer',
     function BigscreenPlayer () {
       var stateChangeCallbacks = [];
       var timeUpdateCallbacks = [];
+      var subtitleCallbacks = [];
 
       var mediaKind;
       var initialPlaybackTimeEpoch;
@@ -167,6 +168,7 @@ define('bigscreenplayer/bigscreenplayer',
           }
           stateChangeCallbacks = [];
           timeUpdateCallbacks = [];
+          subtitleCallbacks = [];
           endOfStream = undefined;
           mediaKind = undefined;
           pauseTrigger = undefined;
@@ -196,6 +198,16 @@ define('bigscreenplayer/bigscreenplayer',
 
           if (indexOf !== -1) {
             timeUpdateCallbacks.splice(indexOf, 1);
+          }
+        },
+        registerForSubtitleChanges: function (callback) {
+          subtitleCallbacks.push(callback);
+          return callback;
+        },
+        unregisterForSubtitleChanges: function (callback) {
+          var indexOf = subtitleCallbacks.indexOf(callback);
+          if (indexOf !== -1) {
+            subtitleCallbacks.splice(indexOf, 1);
           }
         },
         setCurrentTime: function (time) {
@@ -253,6 +265,9 @@ define('bigscreenplayer/bigscreenplayer',
         },
         setSubtitlesEnabled: function (value) {
           playerComponent.setSubtitlesEnabled(value);
+          subtitleCallbacks.forEach(function (callback) {
+            callback({ enabled: value });
+          });
         },
         isSubtitlesEnabled: function () {
           return playerComponent ? playerComponent.isSubtitlesEnabled() : false;

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -115,6 +115,10 @@ define('bigscreenplayer/bigscreenplayer',
           device
         );
 
+        if (enableSubtitles) {
+          callSubtitlesCallbacks(true);
+        }
+
         if (successCallback) {
           successCallback();
         }
@@ -132,6 +136,12 @@ define('bigscreenplayer/bigscreenplayer',
         if (playerComponent) {
           DebugTool.toggleVisibility();
         }
+      }
+
+      function callSubtitlesCallbacks (enabled) {
+        subtitleCallbacks.forEach(function (callback) {
+          callback({ enabled: enabled });
+        });
       }
 
       return {
@@ -265,9 +275,7 @@ define('bigscreenplayer/bigscreenplayer',
         },
         setSubtitlesEnabled: function (value) {
           playerComponent.setSubtitlesEnabled(value);
-          subtitleCallbacks.forEach(function (callback) {
-            callback({ enabled: value });
-          });
+          callSubtitlesCallbacks(value);
         },
         isSubtitlesEnabled: function () {
           return playerComponent ? playerComponent.isSubtitlesEnabled() : false;

--- a/script/version.js
+++ b/script/version.js
@@ -1,5 +1,5 @@
 define('bigscreenplayer/version',
   function () {
-    return '3.13.3';
+    return '3.14.0';
   }
 );


### PR DESCRIPTION
📺 What

This adds `registerForSubtitleChanges()`. The listener is called whenever `setSubtitlesEnabled` is.

> Tickets: IPLAYERTVV1-11166


🛠 How
Implement `registerForSubtitleChanges` and `unregisterForSubtitleChanges` using the other similar functions as an example.

 ✅ Acceptance criteria

* [x] The callback is called when subtitles are turned on/off and no longer called when it's unregistered.