### PR TITLE
Update ESLint to 7.2.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,6 @@
 {
     "parserOptions": {
-      "ecmaVersion": 5,
-      "sourceType": "module"
+      "ecmaVersion": 2015
     },
     "env": {
       "node": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1657,27 +1657,16 @@
       }
     },
     "acorn": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "^3.0.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
     },
     "agent-base": {
       "version": "4.3.0",
@@ -1698,25 +1687,29 @@
       }
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "json-stable-stringify": "^1.0.1"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        }
       }
     },
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
-    },
-    "ajv-keywords": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
     "ansi-colors": {
@@ -1726,10 +1719,21 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-      "dev": true
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
     },
     "ansi-html": {
       "version": "0.0.7",
@@ -1853,12 +1857,6 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -1932,44 +1930,6 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
     },
     "babel-loader": {
       "version": "8.0.6",
@@ -2441,21 +2401,6 @@
         "unset-value": "^1.0.0"
       }
     },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "^0.2.0"
-      }
-    },
-    "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-      "dev": true
-    },
     "camel-case": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
@@ -2563,12 +2508,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -2698,12 +2637,12 @@
       }
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-width": {
@@ -2756,18 +2695,6 @@
           }
         }
       }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
     },
     "codem-isoboxer": {
       "version": "0.3.6",
@@ -3062,6 +2989,49 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -3113,15 +3083,6 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
-    },
-    "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "^0.10.9"
-      }
     },
     "dashjs": {
       "version": "github:bbc/dash.js#54766df3c327864432b60817b3ce2fa1b61bbd61",
@@ -3243,21 +3204,6 @@
         }
       }
     },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
-      }
-    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -3335,9 +3281,9 @@
       }
     },
     "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -3577,42 +3523,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es5-ext": {
-      "version": "0.10.46",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "es6-map": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
-      }
-    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -3628,41 +3538,6 @@
         "es6-promise": "^4.0.3"
       }
     },
-    "es6-set": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
-    "es6-weak-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -3675,112 +3550,202 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "escope": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true,
-      "requires": {
-        "es6-map": "^0.1.3",
-        "es6-weak-map": "^2.0.1",
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      }
-    },
     "eslint": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.2.0.tgz",
+      "integrity": "sha512-B3BtEyaDKC5MlfDa2Ha8/D6DsS4fju95zs0hjS3HdGazw+LNayai38A25qMppK37wWGWNYSPOR6oYzlz5MHsRQ==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.16.0",
-        "chalk": "^1.1.3",
-        "concat-stream": "^1.5.2",
-        "debug": "^2.1.1",
-        "doctrine": "^2.0.0",
-        "escope": "^3.6.0",
-        "espree": "^3.4.0",
-        "esquery": "^1.0.0",
-        "estraverse": "^4.2.0",
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.1.0",
+        "eslint-utils": "^2.0.0",
+        "eslint-visitor-keys": "^1.2.0",
+        "espree": "^7.1.0",
+        "esquery": "^1.2.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "glob": "^7.0.3",
-        "globals": "^9.14.0",
-        "ignore": "^3.2.0",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^0.12.0",
-        "is-my-json-valid": "^2.10.0",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.5.1",
-        "json-stable-stringify": "^1.0.0",
-        "levn": "^0.3.0",
-        "lodash": "^4.0.0",
-        "mkdirp": "^0.5.0",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.1",
-        "pluralize": "^1.2.1",
-        "progress": "^1.1.8",
-        "require-uncached": "^1.0.2",
-        "shelljs": "^0.7.5",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "~2.0.1",
-        "table": "^3.7.8",
-        "text-table": "~0.2.0",
-        "user-home": "^2.0.0"
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
         },
         "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "color-name": "~1.1.4"
           }
         },
-        "ms": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "eslint-scope": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",
+          "integrity": "sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ==",
           "dev": true
         },
-        "progress": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+        "esquery": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+          "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.1.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+              "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+              "dev": true
+            }
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
           "dev": true
+        },
+        "regexpp": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+          "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
         },
         "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
         }
       }
     },
@@ -3889,13 +3854,22 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
+      "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "^7.2.0",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.2.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",
+          "integrity": "sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ==",
+          "dev": true
+        }
       }
     },
     "esquery": {
@@ -3933,16 +3907,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
     },
     "eventemitter2": {
       "version": "0.4.14",
@@ -4015,12 +3979,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
-    },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
@@ -4317,23 +4275,21 @@
       "dev": true
     },
     "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "file-uri-to-path": {
@@ -4453,15 +4409,25 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -5134,24 +5100,6 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "generate-function": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "dev": true,
-      "requires": {
-        "is-property": "^1.0.2"
-      }
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "^1.0.0"
-      }
-    },
     "genfun": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
@@ -5268,23 +5216,12 @@
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
-    },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "type-fest": "^0.8.1"
       }
     },
     "graceful-fs": {
@@ -5954,15 +5891,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -6424,9 +6352,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
     "ignore-walk": {
@@ -6518,50 +6446,90 @@
       "dev": true
     },
     "inquirer": {
-      "version": "0.12.0",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.1.0",
-        "ansi-regex": "^2.0.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^3.1.2",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
           }
         },
         "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -6574,12 +6542,6 @@
         "default-gateway": "^4.2.0",
         "ipaddr.js": "^1.9.0"
       }
-    },
-    "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
-      "dev": true
     },
     "invariant": {
       "version": "2.2.4",
@@ -6746,13 +6708,10 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.1",
@@ -6761,25 +6720,6 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
-      }
-    },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
-      "dev": true,
-      "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
       }
     },
     "is-number": {
@@ -6802,30 +6742,6 @@
         }
       }
     },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "^1.0.0"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
-    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -6835,12 +6751,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
-    },
     "is-regex": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -6849,12 +6759,6 @@
       "requires": {
         "has": "^1.0.3"
       }
-    },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -6965,15 +6869,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -6995,22 +6890,10 @@
         "minimist": "^1.2.0"
       }
     },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-      "dev": true
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "just-extend": {
@@ -7542,9 +7425,9 @@
       "dev": true
     },
     "mute-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "nan": {
@@ -7589,12 +7472,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-      "dev": true
-    },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "nice-try": {
@@ -7844,12 +7721,6 @@
         "boolbase": "~1.0.0"
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8001,10 +7872,13 @@
       }
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
     },
     "opencollective-postinstall": {
       "version": "2.0.3",
@@ -8022,17 +7896,44 @@
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "dependencies": {
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
+        }
       }
     },
     "original": {
@@ -8535,12 +8436,6 @@
         "semver-compare": "^1.0.0"
       }
     },
-    "pluralize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
-      "dev": true
-    },
     "portfinder": {
       "version": "1.0.26",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
@@ -8850,26 +8745,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "readline2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "mute-stream": "0.0.5"
-      }
-    },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -9032,16 +8907,6 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
-      }
-    },
     "requirejs": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.0.0.tgz",
@@ -9100,12 +8965,6 @@
         }
       }
     },
-    "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-      "dev": true
-    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -9113,13 +8972,13 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -9154,13 +9013,10 @@
       }
     },
     "run-async": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
     },
     "run-queue": {
       "version": "1.0.3",
@@ -9170,12 +9026,6 @@
       "requires": {
         "aproba": "^1.1.1"
       }
-    },
-    "rx-lite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-      "dev": true
     },
     "rxjs": {
       "version": "6.5.5",
@@ -9462,17 +9312,6 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -9501,10 +9340,23 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
     },
     "smart-buffer": {
       "version": "4.1.0",
@@ -9928,14 +9780,37 @@
       "dev": true
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "string.prototype.trimleft": {
@@ -10001,9 +9876,9 @@
       }
     },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
       "dev": true
     },
     "supports-color": {
@@ -10016,43 +9891,22 @@
       }
     },
     "table": {
-      "version": "3.8.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
-        "ajv": "^4.7.0",
-        "ajv-keywords": "^1.0.0",
-        "chalk": "^1.1.1",
-        "lodash": "^4.0.0",
-        "slice-ansi": "0.0.4",
-        "string-width": "^2.0.0"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -10061,31 +9915,24 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
+            "strip-ansi": "^5.1.0"
           }
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
         }
       }
     },
@@ -10558,15 +10405,6 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
-    },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0"
-      }
     },
     "util": {
       "version": "0.11.1",
@@ -11234,12 +11072,6 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
-    },
     "worker-farm": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -11301,9 +11133,9 @@
       "dev": true
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigscreen-player",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "description": "Simplified media playback for bigscreen devices.",
   "main": "script/bigscreenplayer.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "pre-release:minor": "npm version minor --no-git-tag --no-git-commit && npm run build:version",
     "pre-release:major": "npm version major --no-git-tag --no-git-commit && npm run build:version"
   },
-  "husky" : {
-    "hooks" : {
+  "husky": {
+    "hooks": {
       "pre-commit": "npm test",
       "pre-push": "npm test"
     }
@@ -27,7 +27,7 @@
     "@babel/preset-env": "^7.9.6",
     "babel-loader": "^8.0.6",
     "clean-webpack-plugin": "^3.0.0",
-    "eslint": "^3.0.0",
+    "eslint": "^7.2.0",
     "eslint-plugin-es5": "1.3.1",
     "eslint-plugin-jasmine": "2.10.1",
     "eslint-plugin-node": "^7.0.1",

--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -9,1015 +9,1015 @@ require(
     'bigscreenplayer/models/transferformats',
     'bigscreenplayer/models/livesupport'
   ],
-    function (Squire, MediaState, WindowTypes, PauseTriggers, PluginEnums, Plugins, TransferFormats, LiveSupport) {
-      var injector = new Squire();
-      var bigscreenPlayer;
-      var bigscreenPlayerData;
-      var playbackElement;
-      var manifestData;
-      var liveSupport;
-      var successCallback;
-      var errorCallback;
-      var noCallbacks = false;
+  function (Squire, MediaState, WindowTypes, PauseTriggers, PluginEnums, Plugins, TransferFormats, LiveSupport) {
+    var injector = new Squire();
+    var bigscreenPlayer;
+    var bigscreenPlayerData;
+    var playbackElement;
+    var manifestData;
+    var liveSupport;
+    var successCallback;
+    var errorCallback;
+    var noCallbacks = false;
 
-      var mockEventHook;
-      var mockPlayerComponentInstance;
+    var mockEventHook;
+    var mockPlayerComponentInstance;
 
-      var mockPlayerComponent = function (playbackElement, bigscreenPlayerData, mediaSources, windowType, enableSubtitles, callback, device) {
-        mockEventHook = callback;
-        return mockPlayerComponentInstance;
+    var mockPlayerComponent = function (playbackElement, bigscreenPlayerData, mediaSources, windowType, enableSubtitles, callback, device) {
+      mockEventHook = callback;
+      return mockPlayerComponentInstance;
+    };
+
+    mockPlayerComponent.getLiveSupport = function () {
+      return liveSupport;
+    };
+
+    function setupManifestData (options) {
+      manifestData = {
+        time: options && options.time || {
+          windowStartTime: 724000,
+          windowEndTime: 4324000,
+          correction: 0
+        }
+      };
+    }
+
+    var mediaSourcesMock;
+    var mediaSourcesCallbackSuccessSpy;
+    var mediaSourcesCallbackErrorSpy;
+    var forceMediaSourcesConstructionFailure = false;
+
+    function initialiseBigscreenPlayer (options) {
+      // options = subtitlesAvailable, windowType, windowStartTime, windowEndTime
+      options = options || {};
+
+      var windowType = options.windowType || WindowTypes.STATIC;
+      var device = options.device;
+      var subtitlesEnabled = options.subtitlesEnabled || false;
+
+      playbackElement = document.createElement('div');
+      playbackElement.id = 'app';
+
+      bigscreenPlayerData = {
+        media: {
+          codec: 'codec',
+          urls: [{url: 'videoUrl', cdn: 'cdn'}],
+          kind: options.mediaKind || 'video',
+          type: 'mimeType',
+          bitrate: 'bitrate',
+          transferFormat: options.transferFormat
+        },
+        serverDate: options.serverDate,
+        initialPlaybackTime: options.initialPlaybackTime
       };
 
-      mockPlayerComponent.getLiveSupport = function () {
-        return liveSupport;
-      };
-
-      function setupManifestData (options) {
-        manifestData = {
-          time: options && options.time || {
-            windowStartTime: 724000,
-            windowEndTime: 4324000,
-            correction: 0
-          }
+      if (options.windowStartTime && options.windowEndTime) {
+        manifestData.time = {
+          windowStartTime: options.windowStartTime,
+          windowEndTime: options.windowEndTime
         };
       }
 
-      var mediaSourcesMock;
-      var mediaSourcesCallbackSuccessSpy;
-      var mediaSourcesCallbackErrorSpy;
-      var forceMediaSourcesConstructionFailure = false;
-
-      function initialiseBigscreenPlayer (options) {
-        // options = subtitlesAvailable, windowType, windowStartTime, windowEndTime
-        options = options || {};
-
-        var windowType = options.windowType || WindowTypes.STATIC;
-        var device = options.device;
-        var subtitlesEnabled = options.subtitlesEnabled || false;
-
-        playbackElement = document.createElement('div');
-        playbackElement.id = 'app';
-
-        bigscreenPlayerData = {
-          media: {
-            codec: 'codec',
-            urls: [{url: 'videoUrl', cdn: 'cdn'}],
-            kind: options.mediaKind || 'video',
-            type: 'mimeType',
-            bitrate: 'bitrate',
-            transferFormat: options.transferFormat
-          },
-          serverDate: options.serverDate,
-          initialPlaybackTime: options.initialPlaybackTime
-        };
-
-        if (options.windowStartTime && options.windowEndTime) {
-          manifestData.time = {
-            windowStartTime: options.windowStartTime,
-            windowEndTime: options.windowEndTime
-          };
-        }
-
-        if (options.subtitlesAvailable) {
-          bigscreenPlayerData.media.captionsUrl = 'captions';
-        }
-
-        var callbacks;
-        if (!noCallbacks) {
-          callbacks = {onSuccess: successCallback, onError: errorCallback};
-        }
-        bigscreenPlayer.init(playbackElement, bigscreenPlayerData, windowType, subtitlesEnabled, device, callbacks);
+      if (options.subtitlesAvailable) {
+        bigscreenPlayerData.media.captionsUrl = 'captions';
       }
 
-      describe('Bigscreen Player', function () {
-        beforeEach(function (done) {
-          mediaSourcesMock = function () {
-            return {
-              init: function (urls, serverDate, windowType, liveSupport, callbacks) {
-                mediaSourcesCallbackSuccessSpy = spyOn(callbacks, 'onSuccess').and.callThrough();
-                mediaSourcesCallbackErrorSpy = spyOn(callbacks, 'onError').and.callThrough();
-                if (forceMediaSourcesConstructionFailure) {
-                  callbacks.onError();
-                } else {
-                  callbacks.onSuccess();
-                }
-              },
+      var callbacks;
+      if (!noCallbacks) {
+        callbacks = {onSuccess: successCallback, onError: errorCallback};
+      }
+      bigscreenPlayer.init(playbackElement, bigscreenPlayerData, windowType, subtitlesEnabled, device, callbacks);
+    }
 
-              time: function () {
-                return manifestData.time;
+    describe('Bigscreen Player', function () {
+      beforeEach(function (done) {
+        mediaSourcesMock = function () {
+          return {
+            init: function (urls, serverDate, windowType, liveSupport, callbacks) {
+              mediaSourcesCallbackSuccessSpy = spyOn(callbacks, 'onSuccess').and.callThrough();
+              mediaSourcesCallbackErrorSpy = spyOn(callbacks, 'onError').and.callThrough();
+              if (forceMediaSourcesConstructionFailure) {
+                callbacks.onError();
+              } else {
+                callbacks.onSuccess();
               }
-            };
+            },
+
+            time: function () {
+              return manifestData.time;
+            }
           };
+        };
 
-          var mockDebugTool = jasmine.createSpyObj('mockDebugTool', ['apicall', 'time', 'event', 'keyValue', 'tearDown', 'setRootElement']);
-          mockPlayerComponentInstance = jasmine.createSpyObj('playerComponentMock', [
-            'play', 'pause', 'isEnded', 'isPaused', 'setCurrentTime', 'getCurrentTime', 'getDuration', 'getSeekableRange',
-            'getPlayerElement', 'isSubtitlesAvailable', 'isSubtitlesEnabled', 'setSubtitlesEnabled', 'tearDown',
-            'getWindowStartTime', 'getWindowEndTime']);
-          successCallback = jasmine.createSpy('successCallback');
-          errorCallback = jasmine.createSpy('errorCallback');
-          setupManifestData();
-          liveSupport = LiveSupport.SEEKABLE;
-          noCallbacks = false;
+        var mockDebugTool = jasmine.createSpyObj('mockDebugTool', ['apicall', 'time', 'event', 'keyValue', 'tearDown', 'setRootElement']);
+        mockPlayerComponentInstance = jasmine.createSpyObj('playerComponentMock', [
+          'play', 'pause', 'isEnded', 'isPaused', 'setCurrentTime', 'getCurrentTime', 'getDuration', 'getSeekableRange',
+          'getPlayerElement', 'isSubtitlesAvailable', 'isSubtitlesEnabled', 'setSubtitlesEnabled', 'tearDown',
+          'getWindowStartTime', 'getWindowEndTime']);
+        successCallback = jasmine.createSpy('successCallback');
+        errorCallback = jasmine.createSpy('errorCallback');
+        setupManifestData();
+        liveSupport = LiveSupport.SEEKABLE;
+        noCallbacks = false;
 
-          injector.mock({
-            'bigscreenplayer/mediasources': mediaSourcesMock,
-            'bigscreenplayer/playercomponent': mockPlayerComponent,
-            'bigscreenplayer/plugins': Plugins,
-            'bigscreenplayer/debugger/debugtool': mockDebugTool
-          });
-
-          injector.require(['bigscreenplayer/bigscreenplayer'], function (bigscreenPlayerReference) {
-            bigscreenPlayer = bigscreenPlayerReference();
-            done();
-          });
+        injector.mock({
+          'bigscreenplayer/mediasources': mediaSourcesMock,
+          'bigscreenplayer/playercomponent': mockPlayerComponent,
+          'bigscreenplayer/plugins': Plugins,
+          'bigscreenplayer/debugger/debugtool': mockDebugTool
         });
 
-        afterEach(function () {
-          Object.keys(mockPlayerComponentInstance).forEach(function (spyFunction) {
-            mockPlayerComponentInstance[spyFunction].calls.reset();
-          });
-          successCallback.calls.reset();
-          errorCallback.calls.reset();
-          forceMediaSourcesConstructionFailure = false;
+        injector.require(['bigscreenplayer/bigscreenplayer'], function (bigscreenPlayerReference) {
+          bigscreenPlayer = bigscreenPlayerReference();
+          done();
+        });
+      });
 
-          mediaSourcesCallbackSuccessSpy && mediaSourcesCallbackSuccessSpy.calls && mediaSourcesCallbackSuccessSpy.calls.reset();
-          mediaSourcesCallbackErrorSpy && mediaSourcesCallbackErrorSpy.calls && mediaSourcesCallbackErrorSpy.calls.reset();
+      afterEach(function () {
+        Object.keys(mockPlayerComponentInstance).forEach(function (spyFunction) {
+          mockPlayerComponentInstance[spyFunction].calls.reset();
+        });
+        successCallback.calls.reset();
+        errorCallback.calls.reset();
+        forceMediaSourcesConstructionFailure = false;
+
+        mediaSourcesCallbackSuccessSpy && mediaSourcesCallbackSuccessSpy.calls && mediaSourcesCallbackSuccessSpy.calls.reset();
+        mediaSourcesCallbackErrorSpy && mediaSourcesCallbackErrorSpy.calls && mediaSourcesCallbackErrorSpy.calls.reset();
+        bigscreenPlayer.tearDown();
+      });
+
+      describe('init', function () {
+        beforeEach(function () {
           bigscreenPlayer.tearDown();
         });
 
-        describe('init', function () {
-          beforeEach(function () {
-            bigscreenPlayer.tearDown();
-          });
+        it('should set endOfStream to true when playing live and no initial playback time is set', function () {
+          mockPlayerComponentInstance.getCurrentTime.and.returnValue(30);
 
-          it('should set endOfStream to true when playing live and no initial playback time is set', function () {
-            mockPlayerComponentInstance.getCurrentTime.and.returnValue(30);
+          var callback = jasmine.createSpy();
 
-            var callback = jasmine.createSpy();
+          initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
+          bigscreenPlayer.registerForTimeUpdates(callback);
 
-            initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
-            bigscreenPlayer.registerForTimeUpdates(callback);
+          mockEventHook({data: {currentTime: 30}, timeUpdate: true, isBufferingTimeoutError: false});
 
-            mockEventHook({data: {currentTime: 30}, timeUpdate: true, isBufferingTimeoutError: false});
-
-            expect(callback).toHaveBeenCalledWith({currentTime: 30, endOfStream: true});
-          });
-
-          it('should set endOfStream to false when playing live and initialPlaybackTime is 0', function () {
-            mockPlayerComponentInstance.getCurrentTime.and.returnValue(0);
-
-            var callback = jasmine.createSpy('listenerSimulcast');
-
-            initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING, initialPlaybackTime: 0});
-
-            bigscreenPlayer.registerForTimeUpdates(callback);
-
-            mockEventHook({data: {currentTime: 0}, timeUpdate: true, isBufferingTimeoutError: false});
-
-            expect(callback).toHaveBeenCalledWith({currentTime: 0, endOfStream: false});
-          });
-
-          it('should call the suppiled success callback if playing VOD', function () {
-            initialiseBigscreenPlayer();
-
-            expect(successCallback).toHaveBeenCalledWith();
-            expect(errorCallback).not.toHaveBeenCalled();
-          });
-
-          it('should call the suppiled success callback if playing LIVE and the manifest loads', function () {
-            initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
-
-            expect(mediaSourcesCallbackSuccessSpy).toHaveBeenCalledTimes(1);
-            expect(successCallback).toHaveBeenCalledWith();
-            expect(errorCallback).not.toHaveBeenCalled();
-          });
-
-          it('should call the supplied error callback if manifest fails to load', function () {
-            forceMediaSourcesConstructionFailure = true;
-            initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
-
-            expect(mediaSourcesCallbackErrorSpy).toHaveBeenCalledTimes(1);
-            expect(errorCallback).toHaveBeenCalledTimes(1);
-            expect(successCallback).not.toHaveBeenCalled();
-          });
-
-          it('should not attempt to call onSuccess callback if one is not provided', function () {
-            noCallbacks = true;
-            initialiseBigscreenPlayer();
-
-            expect(successCallback).not.toHaveBeenCalled();
-          });
-
-          it('should not attempt to call onError callback if one is not provided', function () {
-            noCallbacks = true;
-
-            initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
-
-            expect(errorCallback).not.toHaveBeenCalled();
-          });
+          expect(callback).toHaveBeenCalledWith({currentTime: 30, endOfStream: true});
         });
 
-        describe('getPlayerElement', function () {
-          it('Should call through to getPlayerElement on the playback strategy', function () {
-            initialiseBigscreenPlayer();
+        it('should set endOfStream to false when playing live and initialPlaybackTime is 0', function () {
+          mockPlayerComponentInstance.getCurrentTime.and.returnValue(0);
 
-            var mockedVideo = jasmine.createSpy('mockVideoElement');
+          var callback = jasmine.createSpy('listenerSimulcast');
 
-            mockPlayerComponentInstance.getPlayerElement.and.returnValue(mockedVideo);
+          initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING, initialPlaybackTime: 0});
 
-            bigscreenPlayer.getPlayerElement();
+          bigscreenPlayer.registerForTimeUpdates(callback);
 
-            expect(bigscreenPlayer.getPlayerElement()).toBe(mockedVideo);
-          });
+          mockEventHook({data: {currentTime: 0}, timeUpdate: true, isBufferingTimeoutError: false});
+
+          expect(callback).toHaveBeenCalledWith({currentTime: 0, endOfStream: false});
         });
 
-        describe('registerForStateChanges', function () {
-          var callback;
-          beforeEach(function () {
-            callback = jasmine.createSpy();
-            bigscreenPlayer.registerForStateChanges(callback);
-            initialiseBigscreenPlayer();
-          });
+        it('should call the suppiled success callback if playing VOD', function () {
+          initialiseBigscreenPlayer();
 
-          it('should fire the callback when a state event comes back from the strategy', function () {
-            mockEventHook({data: {state: MediaState.PLAYING}});
-
-            expect(callback).toHaveBeenCalledWith({state: MediaState.PLAYING, endOfStream: false});
-
-            callback.calls.reset();
-
-            mockEventHook({data: {state: MediaState.WAITING}});
-
-            expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: false, endOfStream: false});
-          });
-
-          it('should set the isPaused flag to true when waiting after a setCurrentTime', function () {
-            mockEventHook({data: {state: MediaState.PLAYING}});
-
-            expect(callback).toHaveBeenCalledWith({state: MediaState.PLAYING, endOfStream: false});
-
-            callback.calls.reset();
-
-            bigscreenPlayer.setCurrentTime(60);
-            mockEventHook({data: {state: MediaState.WAITING}});
-
-            expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: true, endOfStream: false});
-          });
-
-          it('should set clear the isPaused flag after a waiting event is fired', function () {
-            mockEventHook({data: {state: MediaState.PLAYING}});
-
-            bigscreenPlayer.setCurrentTime(60);
-            mockEventHook({data: {state: MediaState.WAITING}});
-
-            expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: true, endOfStream: false});
-
-            callback.calls.reset();
-
-            mockEventHook({data: {state: MediaState.WAITING}});
-
-            expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: false, endOfStream: false});
-          });
-
-          it('should set the pause trigger to the one set when a pause event comes back from strategy', function () {
-            bigscreenPlayer.pause();
-
-            mockEventHook({data: {state: MediaState.PAUSED}});
-
-            expect(callback).toHaveBeenCalledWith({state: MediaState.PAUSED, trigger: PauseTriggers.USER, endOfStream: false});
-          });
-
-          it('should set the pause trigger to device when a pause event comes back from strategy and a trigger is not set', function () {
-            mockEventHook({data: {state: MediaState.PAUSED}});
-
-            expect(callback).toHaveBeenCalledWith({state: MediaState.PAUSED, trigger: PauseTriggers.DEVICE, endOfStream: false});
-          });
-
-          it('should set isBufferingTimeoutError when a fatal error event comes back from strategy', function () {
-            mockEventHook({data: {state: MediaState.FATAL_ERROR}, isBufferingTimeoutError: false});
-
-            expect(callback).toHaveBeenCalledWith({state: MediaState.FATAL_ERROR, isBufferingTimeoutError: false, endOfStream: false});
-          });
-
-          it('should return a reference to the callback passed in', function () {
-            var reference = bigscreenPlayer.registerForStateChanges(callback);
-
-            expect(reference).toBe(callback);
-          });
+          expect(successCallback).toHaveBeenCalledWith();
+          expect(errorCallback).not.toHaveBeenCalled();
         });
 
-        describe('unregisterForStateChanges', function () {
-          it('should remove callback from stateChangeCallbacks', function () {
-            var listener1 = jasmine.createSpy('listener1');
-            var listener2 = jasmine.createSpy('listener2');
-            var listener3 = jasmine.createSpy('listener3');
+        it('should call the suppiled success callback if playing LIVE and the manifest loads', function () {
+          initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
 
-            initialiseBigscreenPlayer();
-
-            bigscreenPlayer.registerForStateChanges(listener1);
-            bigscreenPlayer.registerForStateChanges(listener2);
-            bigscreenPlayer.registerForStateChanges(listener3);
-
-            mockEventHook({data: {state: MediaState.PLAYING}});
-
-            bigscreenPlayer.unregisterForStateChanges(listener2);
-
-            mockEventHook({data: {state: MediaState.PLAYING}});
-
-            expect(listener1).toHaveBeenCalledTimes(2);
-            expect(listener2).toHaveBeenCalledTimes(1);
-            expect(listener3).toHaveBeenCalledTimes(2);
-          });
-
-          it('should only remove existing callbacks from stateChangeCallbacks', function () {
-            initialiseBigscreenPlayer();
-
-            var listener1 = jasmine.createSpy('listener1');
-            var listener2 = jasmine.createSpy('listener2');
-
-            bigscreenPlayer.registerForStateChanges(listener1);
-            bigscreenPlayer.unregisterForStateChanges(listener2);
-
-            mockEventHook({data: {state: MediaState.PLAYING}});
-
-            expect(listener1).toHaveBeenCalledWith({state: MediaState.PLAYING, endOfStream: false});
-          });
+          expect(mediaSourcesCallbackSuccessSpy).toHaveBeenCalledTimes(1);
+          expect(successCallback).toHaveBeenCalledWith();
+          expect(errorCallback).not.toHaveBeenCalled();
         });
 
-        describe('registerForTimeUpdates', function () {
-          it('should call the callback when we get a timeupdate event from the strategy', function () {
-            var callback = jasmine.createSpy('listener1');
-            initialiseBigscreenPlayer();
-            bigscreenPlayer.registerForTimeUpdates(callback);
+        it('should call the supplied error callback if manifest fails to load', function () {
+          forceMediaSourcesConstructionFailure = true;
+          initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
 
-            expect(callback).not.toHaveBeenCalled();
-
-            mockEventHook({data: {currentTime: 60}, timeUpdate: true});
-
-            expect(callback).toHaveBeenCalledWith({currentTime: 60, endOfStream: false});
-          });
-
-          it('returns a reference to the callback passed in', function () {
-            var callback = jasmine.createSpy();
-            var reference = bigscreenPlayer.registerForTimeUpdates(callback);
-
-            expect(reference).toBe(callback);
-          });
+          expect(mediaSourcesCallbackErrorSpy).toHaveBeenCalledTimes(1);
+          expect(errorCallback).toHaveBeenCalledTimes(1);
+          expect(successCallback).not.toHaveBeenCalled();
         });
 
-        describe('unregisterForTimeUpdates', function () {
-          it('should remove callback from timeUpdateCallbacks', function () {
-            initialiseBigscreenPlayer();
+        it('should not attempt to call onSuccess callback if one is not provided', function () {
+          noCallbacks = true;
+          initialiseBigscreenPlayer();
 
-            var listener1 = jasmine.createSpy('listener1');
-            var listener2 = jasmine.createSpy('listener2');
-            var listener3 = jasmine.createSpy('listener3');
-
-            bigscreenPlayer.registerForTimeUpdates(listener1);
-            bigscreenPlayer.registerForTimeUpdates(listener2);
-            bigscreenPlayer.registerForTimeUpdates(listener3);
-
-            mockEventHook({data: {currentTime: 0}, timeUpdate: true});
-
-            bigscreenPlayer.unregisterForTimeUpdates(listener2);
-
-            mockEventHook({data: {currentTime: 1}, timeUpdate: true});
-
-            expect(listener1).toHaveBeenCalledTimes(2);
-            expect(listener2).toHaveBeenCalledTimes(1);
-            expect(listener3).toHaveBeenCalledTimes(2);
-          });
-
-          it('should only remove existing callbacks from timeUpdateCallbacks', function () {
-            initialiseBigscreenPlayer();
-
-            var listener1 = jasmine.createSpy('listener1');
-            var listener2 = jasmine.createSpy('listener2');
-
-            bigscreenPlayer.registerForTimeUpdates(listener1);
-            bigscreenPlayer.unregisterForTimeUpdates(listener2);
-
-            mockEventHook({data: {currentTime: 60}, timeUpdate: true});
-
-            expect(listener1).toHaveBeenCalledWith({currentTime: 60, endOfStream: false});
-          });
+          expect(successCallback).not.toHaveBeenCalled();
         });
 
-        describe('registerForSubtitleChanges', function () {
-          it('should call the callback when we subtitles are turned on/off', function () {
-            var callback = jasmine.createSpy('listener1');
-            initialiseBigscreenPlayer();
-            bigscreenPlayer.registerForSubtitleChanges(callback);
+        it('should not attempt to call onError callback if one is not provided', function () {
+          noCallbacks = true;
 
-            expect(callback).not.toHaveBeenCalled();
+          initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
 
-            bigscreenPlayer.setSubtitlesEnabled(true);
+          expect(errorCallback).not.toHaveBeenCalled();
+        });
+      });
 
-            expect(callback).toHaveBeenCalledWith({enabled: true});
+      describe('getPlayerElement', function () {
+        it('Should call through to getPlayerElement on the playback strategy', function () {
+          initialiseBigscreenPlayer();
 
-            bigscreenPlayer.setSubtitlesEnabled(false);
+          var mockedVideo = jasmine.createSpy('mockVideoElement');
 
-            expect(callback).toHaveBeenCalledWith({enabled: false});
-          });
+          mockPlayerComponentInstance.getPlayerElement.and.returnValue(mockedVideo);
 
-          it('should call the callback when init() is called with subtitles enabled', function () {
-            var callback = jasmine.createSpy('listener1');
+          bigscreenPlayer.getPlayerElement();
 
-            bigscreenPlayer.registerForSubtitleChanges(callback);
-            initialiseBigscreenPlayer({ subtitlesEnabled: true });
+          expect(bigscreenPlayer.getPlayerElement()).toBe(mockedVideo);
+        });
+      });
 
-            expect(callback).toHaveBeenCalledWith({enabled: true});
-          });
-
-          it('should not call the callback when init() is called without subtitles enabled', function () {
-            var callback = jasmine.createSpy('listener1');
-
-            bigscreenPlayer.registerForSubtitleChanges(callback);
-            initialiseBigscreenPlayer();
-
-            expect(callback).not.toHaveBeenCalled();
-          });
-
-          it('returns a reference to the callback passed in', function () {
-            var callback = jasmine.createSpy();
-            var reference = bigscreenPlayer.registerForSubtitleChanges(callback);
-
-            expect(reference).toBe(callback);
-          });
+      describe('registerForStateChanges', function () {
+        var callback;
+        beforeEach(function () {
+          callback = jasmine.createSpy();
+          bigscreenPlayer.registerForStateChanges(callback);
+          initialiseBigscreenPlayer();
         });
 
-        describe('unregisterForSubtitleChanges', function () {
-          it('should remove callback from subtitleCallbacks', function () {
-            initialiseBigscreenPlayer();
+        it('should fire the callback when a state event comes back from the strategy', function () {
+          mockEventHook({data: {state: MediaState.PLAYING}});
 
-            var listener1 = jasmine.createSpy('listener1');
-            var listener2 = jasmine.createSpy('listener2');
-            var listener3 = jasmine.createSpy('listener3');
+          expect(callback).toHaveBeenCalledWith({state: MediaState.PLAYING, endOfStream: false});
 
-            bigscreenPlayer.registerForSubtitleChanges(listener1);
-            bigscreenPlayer.registerForSubtitleChanges(listener2);
-            bigscreenPlayer.registerForSubtitleChanges(listener3);
+          callback.calls.reset();
 
-            bigscreenPlayer.setSubtitlesEnabled(true);
+          mockEventHook({data: {state: MediaState.WAITING}});
 
-            bigscreenPlayer.unregisterForSubtitleChanges(listener2);
-
-            bigscreenPlayer.setSubtitlesEnabled(false);
-
-            expect(listener1).toHaveBeenCalledTimes(2);
-            expect(listener2).toHaveBeenCalledTimes(1);
-            expect(listener3).toHaveBeenCalledTimes(2);
-          });
-
-          it('should only remove existing callbacks from subtitleCallbacks', function () {
-            initialiseBigscreenPlayer();
-
-            var listener1 = jasmine.createSpy('listener1');
-            var listener2 = jasmine.createSpy('listener2');
-
-            bigscreenPlayer.registerForSubtitleChanges(listener1);
-            bigscreenPlayer.unregisterForSubtitleChanges(listener2);
-
-            bigscreenPlayer.setSubtitlesEnabled(true);
-
-            expect(listener1).toHaveBeenCalledWith({enabled: true});
-          });
+          expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: false, endOfStream: false});
         });
 
-        describe('setCurrentTime', function () {
-          it('should setCurrentTime on the strategy/playerComponent', function () {
-            initialiseBigscreenPlayer();
+        it('should set the isPaused flag to true when waiting after a setCurrentTime', function () {
+          mockEventHook({data: {state: MediaState.PLAYING}});
 
-            bigscreenPlayer.setCurrentTime(60);
+          expect(callback).toHaveBeenCalledWith({state: MediaState.PLAYING, endOfStream: false});
 
-            expect(mockPlayerComponentInstance.setCurrentTime).toHaveBeenCalledWith(60);
+          callback.calls.reset();
+
+          bigscreenPlayer.setCurrentTime(60);
+          mockEventHook({data: {state: MediaState.WAITING}});
+
+          expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: true, endOfStream: false});
+        });
+
+        it('should set clear the isPaused flag after a waiting event is fired', function () {
+          mockEventHook({data: {state: MediaState.PLAYING}});
+
+          bigscreenPlayer.setCurrentTime(60);
+          mockEventHook({data: {state: MediaState.WAITING}});
+
+          expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: true, endOfStream: false});
+
+          callback.calls.reset();
+
+          mockEventHook({data: {state: MediaState.WAITING}});
+
+          expect(callback).toHaveBeenCalledWith({state: MediaState.WAITING, isSeeking: false, endOfStream: false});
+        });
+
+        it('should set the pause trigger to the one set when a pause event comes back from strategy', function () {
+          bigscreenPlayer.pause();
+
+          mockEventHook({data: {state: MediaState.PAUSED}});
+
+          expect(callback).toHaveBeenCalledWith({state: MediaState.PAUSED, trigger: PauseTriggers.USER, endOfStream: false});
+        });
+
+        it('should set the pause trigger to device when a pause event comes back from strategy and a trigger is not set', function () {
+          mockEventHook({data: {state: MediaState.PAUSED}});
+
+          expect(callback).toHaveBeenCalledWith({state: MediaState.PAUSED, trigger: PauseTriggers.DEVICE, endOfStream: false});
+        });
+
+        it('should set isBufferingTimeoutError when a fatal error event comes back from strategy', function () {
+          mockEventHook({data: {state: MediaState.FATAL_ERROR}, isBufferingTimeoutError: false});
+
+          expect(callback).toHaveBeenCalledWith({state: MediaState.FATAL_ERROR, isBufferingTimeoutError: false, endOfStream: false});
+        });
+
+        it('should return a reference to the callback passed in', function () {
+          var reference = bigscreenPlayer.registerForStateChanges(callback);
+
+          expect(reference).toBe(callback);
+        });
+      });
+
+      describe('unregisterForStateChanges', function () {
+        it('should remove callback from stateChangeCallbacks', function () {
+          var listener1 = jasmine.createSpy('listener1');
+          var listener2 = jasmine.createSpy('listener2');
+          var listener3 = jasmine.createSpy('listener3');
+
+          initialiseBigscreenPlayer();
+
+          bigscreenPlayer.registerForStateChanges(listener1);
+          bigscreenPlayer.registerForStateChanges(listener2);
+          bigscreenPlayer.registerForStateChanges(listener3);
+
+          mockEventHook({data: {state: MediaState.PLAYING}});
+
+          bigscreenPlayer.unregisterForStateChanges(listener2);
+
+          mockEventHook({data: {state: MediaState.PLAYING}});
+
+          expect(listener1).toHaveBeenCalledTimes(2);
+          expect(listener2).toHaveBeenCalledTimes(1);
+          expect(listener3).toHaveBeenCalledTimes(2);
+        });
+
+        it('should only remove existing callbacks from stateChangeCallbacks', function () {
+          initialiseBigscreenPlayer();
+
+          var listener1 = jasmine.createSpy('listener1');
+          var listener2 = jasmine.createSpy('listener2');
+
+          bigscreenPlayer.registerForStateChanges(listener1);
+          bigscreenPlayer.unregisterForStateChanges(listener2);
+
+          mockEventHook({data: {state: MediaState.PLAYING}});
+
+          expect(listener1).toHaveBeenCalledWith({state: MediaState.PLAYING, endOfStream: false});
+        });
+      });
+
+      describe('registerForTimeUpdates', function () {
+        it('should call the callback when we get a timeupdate event from the strategy', function () {
+          var callback = jasmine.createSpy('listener1');
+          initialiseBigscreenPlayer();
+          bigscreenPlayer.registerForTimeUpdates(callback);
+
+          expect(callback).not.toHaveBeenCalled();
+
+          mockEventHook({data: {currentTime: 60}, timeUpdate: true});
+
+          expect(callback).toHaveBeenCalledWith({currentTime: 60, endOfStream: false});
+        });
+
+        it('returns a reference to the callback passed in', function () {
+          var callback = jasmine.createSpy();
+          var reference = bigscreenPlayer.registerForTimeUpdates(callback);
+
+          expect(reference).toBe(callback);
+        });
+      });
+
+      describe('unregisterForTimeUpdates', function () {
+        it('should remove callback from timeUpdateCallbacks', function () {
+          initialiseBigscreenPlayer();
+
+          var listener1 = jasmine.createSpy('listener1');
+          var listener2 = jasmine.createSpy('listener2');
+          var listener3 = jasmine.createSpy('listener3');
+
+          bigscreenPlayer.registerForTimeUpdates(listener1);
+          bigscreenPlayer.registerForTimeUpdates(listener2);
+          bigscreenPlayer.registerForTimeUpdates(listener3);
+
+          mockEventHook({data: {currentTime: 0}, timeUpdate: true});
+
+          bigscreenPlayer.unregisterForTimeUpdates(listener2);
+
+          mockEventHook({data: {currentTime: 1}, timeUpdate: true});
+
+          expect(listener1).toHaveBeenCalledTimes(2);
+          expect(listener2).toHaveBeenCalledTimes(1);
+          expect(listener3).toHaveBeenCalledTimes(2);
+        });
+
+        it('should only remove existing callbacks from timeUpdateCallbacks', function () {
+          initialiseBigscreenPlayer();
+
+          var listener1 = jasmine.createSpy('listener1');
+          var listener2 = jasmine.createSpy('listener2');
+
+          bigscreenPlayer.registerForTimeUpdates(listener1);
+          bigscreenPlayer.unregisterForTimeUpdates(listener2);
+
+          mockEventHook({data: {currentTime: 60}, timeUpdate: true});
+
+          expect(listener1).toHaveBeenCalledWith({currentTime: 60, endOfStream: false});
+        });
+      });
+
+      describe('registerForSubtitleChanges', function () {
+        it('should call the callback when we subtitles are turned on/off', function () {
+          var callback = jasmine.createSpy('listener1');
+          initialiseBigscreenPlayer();
+          bigscreenPlayer.registerForSubtitleChanges(callback);
+
+          expect(callback).not.toHaveBeenCalled();
+
+          bigscreenPlayer.setSubtitlesEnabled(true);
+
+          expect(callback).toHaveBeenCalledWith({enabled: true});
+
+          bigscreenPlayer.setSubtitlesEnabled(false);
+
+          expect(callback).toHaveBeenCalledWith({enabled: false});
+        });
+
+        it('should call the callback when init() is called with subtitles enabled', function () {
+          var callback = jasmine.createSpy('listener1');
+
+          bigscreenPlayer.registerForSubtitleChanges(callback);
+          initialiseBigscreenPlayer({ subtitlesEnabled: true });
+
+          expect(callback).toHaveBeenCalledWith({enabled: true});
+        });
+
+        it('should not call the callback when init() is called without subtitles enabled', function () {
+          var callback = jasmine.createSpy('listener1');
+
+          bigscreenPlayer.registerForSubtitleChanges(callback);
+          initialiseBigscreenPlayer();
+
+          expect(callback).not.toHaveBeenCalled();
+        });
+
+        it('returns a reference to the callback passed in', function () {
+          var callback = jasmine.createSpy();
+          var reference = bigscreenPlayer.registerForSubtitleChanges(callback);
+
+          expect(reference).toBe(callback);
+        });
+      });
+
+      describe('unregisterForSubtitleChanges', function () {
+        it('should remove callback from subtitleCallbacks', function () {
+          initialiseBigscreenPlayer();
+
+          var listener1 = jasmine.createSpy('listener1');
+          var listener2 = jasmine.createSpy('listener2');
+          var listener3 = jasmine.createSpy('listener3');
+
+          bigscreenPlayer.registerForSubtitleChanges(listener1);
+          bigscreenPlayer.registerForSubtitleChanges(listener2);
+          bigscreenPlayer.registerForSubtitleChanges(listener3);
+
+          bigscreenPlayer.setSubtitlesEnabled(true);
+
+          bigscreenPlayer.unregisterForSubtitleChanges(listener2);
+
+          bigscreenPlayer.setSubtitlesEnabled(false);
+
+          expect(listener1).toHaveBeenCalledTimes(2);
+          expect(listener2).toHaveBeenCalledTimes(1);
+          expect(listener3).toHaveBeenCalledTimes(2);
+        });
+
+        it('should only remove existing callbacks from subtitleCallbacks', function () {
+          initialiseBigscreenPlayer();
+
+          var listener1 = jasmine.createSpy('listener1');
+          var listener2 = jasmine.createSpy('listener2');
+
+          bigscreenPlayer.registerForSubtitleChanges(listener1);
+          bigscreenPlayer.unregisterForSubtitleChanges(listener2);
+
+          bigscreenPlayer.setSubtitlesEnabled(true);
+
+          expect(listener1).toHaveBeenCalledWith({enabled: true});
+        });
+      });
+
+      describe('setCurrentTime', function () {
+        it('should setCurrentTime on the strategy/playerComponent', function () {
+          initialiseBigscreenPlayer();
+
+          bigscreenPlayer.setCurrentTime(60);
+
+          expect(mockPlayerComponentInstance.setCurrentTime).toHaveBeenCalledWith(60);
+        });
+
+        it('should not set current time on the strategy/playerComponent if bigscreen player is not initialised', function () {
+          bigscreenPlayer.setCurrentTime(60);
+
+          expect(mockPlayerComponentInstance.setCurrentTime).not.toHaveBeenCalled();
+        });
+
+        it('should set endOfStream to true when seeking to the end of a simulcast', function () {
+          setupManifestData({
+            transferFormat: TransferFormats.DASH,
+            time: {
+              windowStartTime: 10,
+              windowEndTime: 100
+            }
           });
 
-          it('should not set current time on the strategy/playerComponent if bigscreen player is not initialised', function () {
-            bigscreenPlayer.setCurrentTime(60);
+          initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
 
-            expect(mockPlayerComponentInstance.setCurrentTime).not.toHaveBeenCalled();
+          var callback = jasmine.createSpy();
+          var endOfStreamWindow = bigscreenPlayerData.time.windowEndTime - 2;
+
+          bigscreenPlayer.registerForTimeUpdates(callback);
+
+          mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: bigscreenPlayerData.time.windowStartTime, end: bigscreenPlayerData.time.windowEndTime});
+          mockPlayerComponentInstance.getCurrentTime.and.returnValue(endOfStreamWindow);
+
+          bigscreenPlayer.setCurrentTime(endOfStreamWindow);
+
+          mockEventHook({data: {currentTime: endOfStreamWindow}, timeUpdate: true});
+
+          expect(callback).toHaveBeenCalledWith({currentTime: endOfStreamWindow, endOfStream: true});
+        });
+
+        it('should set endOfStream to false when seeking into a simulcast', function () {
+          setupManifestData({
+            transferFormat: TransferFormats.DASH,
+            time: {
+              windowStartTime: 10,
+              windowEndTime: 100
+            }
           });
 
-          it('should set endOfStream to true when seeking to the end of a simulcast', function () {
-            setupManifestData({
-              transferFormat: TransferFormats.DASH,
-              time: {
-                windowStartTime: 10,
-                windowEndTime: 100
-              }
+          initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
+
+          var callback = jasmine.createSpy();
+          bigscreenPlayer.registerForTimeUpdates(callback);
+
+          var middleOfStreamWindow = bigscreenPlayerData.time.windowEndTime / 2;
+
+          mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: bigscreenPlayerData.time.windowStartTime, end: bigscreenPlayerData.time.windowEndTime});
+          mockPlayerComponentInstance.getCurrentTime.and.returnValue(middleOfStreamWindow);
+
+          bigscreenPlayer.setCurrentTime(middleOfStreamWindow);
+
+          mockEventHook({data: {currentTime: middleOfStreamWindow}, timeUpdate: true});
+
+          expect(callback).toHaveBeenCalledWith({currentTime: middleOfStreamWindow, endOfStream: false});
+        });
+      });
+
+      describe('getCurrentTime', function () {
+        it('should return the current time from the strategy', function () {
+          initialiseBigscreenPlayer();
+
+          mockPlayerComponentInstance.getCurrentTime.and.returnValue(10);
+
+          expect(bigscreenPlayer.getCurrentTime()).toBe(10);
+        });
+
+        it('should return 0 if bigscreenPlayer is not initialised', function () {
+          expect(bigscreenPlayer.getCurrentTime()).toBe(0);
+        });
+      });
+
+      describe('getMediaKind', function () {
+        it('should return the media kind', function () {
+          initialiseBigscreenPlayer({mediaKind: 'audio'});
+
+          expect(bigscreenPlayer.getMediaKind()).toBe('audio');
+        });
+      });
+
+      describe('getWindowType', function () {
+        it('should return the window type', function () {
+          initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
+
+          expect(bigscreenPlayer.getWindowType()).toBe(WindowTypes.SLIDING);
+        });
+      });
+
+      describe('getSeekableRange', function () {
+        it('should return the seekable range from the strategy', function () {
+          initialiseBigscreenPlayer();
+
+          mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 10});
+
+          expect(bigscreenPlayer.getSeekableRange().start).toEqual(0);
+          expect(bigscreenPlayer.getSeekableRange().end).toEqual(10);
+        });
+
+        it('should return an empty object when bigscreen player has not been initialised', function () {
+          expect(bigscreenPlayer.getSeekableRange()).toEqual({});
+        });
+      });
+
+      describe('isAtLiveEdge', function () {
+        it('should return false when playing on demand content', function () {
+          initialiseBigscreenPlayer();
+
+          expect(bigscreenPlayer.isPlayingAtLiveEdge()).toEqual(false);
+        });
+
+        it('should return false when bigscreen-player has not been initialised', function () {
+          expect(bigscreenPlayer.isPlayingAtLiveEdge()).toEqual(false);
+        });
+
+        it('should return true when playing live and current time is within tolerance of seekable range end', function () {
+          initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
+
+          mockPlayerComponentInstance.getCurrentTime.and.returnValue(100);
+          mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 105});
+
+          expect(bigscreenPlayer.isPlayingAtLiveEdge()).toEqual(true);
+        });
+
+        it('should return false when playing live and current time is outside the tolerance of seekable range end', function () {
+          initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
+
+          mockPlayerComponentInstance.getCurrentTime.and.returnValue(95);
+          mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 105});
+
+          expect(bigscreenPlayer.isPlayingAtLiveEdge()).toEqual(false);
+        });
+      });
+
+      describe('getLiveWindowData', function () {
+        it('should return undefined values when windowType is static', function () {
+          initialiseBigscreenPlayer({windowType: WindowTypes.STATIC});
+
+          expect(bigscreenPlayer.getLiveWindowData()).toEqual({});
+        });
+
+        it('should return liveWindowData when the windowType is sliding and manifest is loaded', function () {
+          setupManifestData({
+            transferFormat: TransferFormats.DASH,
+            time: {
+              windowStartTime: 1,
+              windowEndTime: 2
+            }
+          });
+
+          var initialisationData = {windowType: WindowTypes.SLIDING, serverDate: new Date(), initialPlaybackTime: new Date().getTime()};
+          initialiseBigscreenPlayer(initialisationData);
+
+          expect(bigscreenPlayer.getLiveWindowData()).toEqual({windowStartTime: 1, windowEndTime: 2, serverDate: initialisationData.serverDate, initialPlaybackTime: initialisationData.initialPlaybackTime});
+        });
+
+        it('should return a subset of liveWindowData when the windowType is sliding and time block is provided', function () {
+          var initialisationData = {windowType: WindowTypes.SLIDING, windowStartTime: 1, windowEndTime: 2, initialPlaybackTime: new Date().getTime()};
+          initialiseBigscreenPlayer(initialisationData);
+
+          expect(bigscreenPlayer.getLiveWindowData()).toEqual({serverDate: undefined, windowStartTime: 1, windowEndTime: 2, initialPlaybackTime: initialisationData.initialPlaybackTime});
+        });
+      });
+
+      describe('getDuration', function () {
+        it('should get the duration from the strategy', function () {
+          initialiseBigscreenPlayer();
+
+          mockPlayerComponentInstance.getDuration.and.returnValue(10);
+
+          expect(bigscreenPlayer.getDuration()).toEqual(10);
+        });
+
+        it('should return undefined when not initialised', function () {
+          expect(bigscreenPlayer.getDuration()).toBeUndefined();
+        });
+      });
+
+      describe('isPaused', function () {
+        it('should get the paused state from the strategy', function () {
+          initialiseBigscreenPlayer();
+
+          mockPlayerComponentInstance.isPaused.and.returnValue(true);
+
+          expect(bigscreenPlayer.isPaused()).toBe(true);
+        });
+
+        it('should return true if bigscreenPlayer has not been initialised', function () {
+          expect(bigscreenPlayer.isPaused()).toBe(true);
+        });
+      });
+
+      describe('isEnded', function () {
+        it('should get the ended state from the strategy', function () {
+          initialiseBigscreenPlayer();
+
+          mockPlayerComponentInstance.isEnded.and.returnValue(true);
+
+          expect(bigscreenPlayer.isEnded()).toBe(true);
+        });
+
+        it('should return false if bigscreenPlayer has not been initialised', function () {
+          expect(bigscreenPlayer.isEnded()).toBe(false);
+        });
+      });
+
+      describe('play', function () {
+        it('should call play on the strategy', function () {
+          initialiseBigscreenPlayer();
+
+          bigscreenPlayer.play();
+
+          expect(mockPlayerComponentInstance.play).toHaveBeenCalledWith();
+        });
+      });
+
+      describe('pause', function () {
+        it('should call pause on the strategy', function () {
+          var opts = {disableAutoResume: true};
+
+          initialiseBigscreenPlayer();
+
+          bigscreenPlayer.pause(opts);
+
+          expect(mockPlayerComponentInstance.pause).toHaveBeenCalledWith(jasmine.objectContaining({disableAutoResume: true}));
+        });
+
+        it('should set pauseTrigger to an app pause if user pause is false', function () {
+          var opts = {userPause: false};
+
+          initialiseBigscreenPlayer();
+
+          var callback = jasmine.createSpy();
+
+          bigscreenPlayer.registerForStateChanges(callback);
+
+          bigscreenPlayer.pause(opts);
+
+          mockEventHook({data: {state: MediaState.PAUSED}});
+
+          expect(callback).toHaveBeenCalledWith(jasmine.objectContaining({trigger: PauseTriggers.APP}));
+        });
+
+        it('should set pauseTrigger to a user pause if user pause is true', function () {
+          var opts = {userPause: true};
+
+          initialiseBigscreenPlayer();
+
+          var callback = jasmine.createSpy();
+
+          bigscreenPlayer.registerForStateChanges(callback);
+
+          bigscreenPlayer.pause(opts);
+
+          mockEventHook({data: {state: MediaState.PAUSED}});
+
+          expect(callback).toHaveBeenCalledWith(jasmine.objectContaining({trigger: PauseTriggers.USER}));
+        });
+      });
+
+      describe('setSubtitlesEnabled', function () {
+        it('should turn subtitles on/off when a value is passed in and they are available', function () {
+          initialiseBigscreenPlayer({ subtitlesAvailable: true });
+
+          bigscreenPlayer.setSubtitlesEnabled(true);
+
+          expect(mockPlayerComponentInstance.setSubtitlesEnabled).toHaveBeenCalledWith(true);
+
+          bigscreenPlayer.setSubtitlesEnabled(false);
+
+          expect(mockPlayerComponentInstance.setSubtitlesEnabled).toHaveBeenCalledWith(false);
+        });
+      });
+
+      describe('isSubtitlesEnabled', function () {
+        it('calls through to playerComponent isSubtitlesEnabled when called', function () {
+          initialiseBigscreenPlayer();
+
+          bigscreenPlayer.isSubtitlesEnabled();
+
+          expect(mockPlayerComponentInstance.isSubtitlesEnabled).toHaveBeenCalledWith();
+        });
+      });
+
+      describe('isSubtitlesAvailable', function () {
+        it('calls through to playerComponent isSubtitlesAvailable when called', function () {
+          initialiseBigscreenPlayer();
+
+          bigscreenPlayer.isSubtitlesAvailable();
+
+          expect(mockPlayerComponentInstance.isSubtitlesAvailable).toHaveBeenCalledWith();
+        });
+      });
+
+      describe('canSeek', function () {
+        it('should return true when in VOD playback', function () {
+          initialiseBigscreenPlayer();
+
+          expect(bigscreenPlayer.canSeek()).toBe(true);
+        });
+
+        describe('live', function () {
+          it('should return true when it can seek', function () {
+            mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 60});
+
+            initialiseBigscreenPlayer({
+              windowType: WindowTypes.SLIDING
             });
-
-            initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
-
-            var callback = jasmine.createSpy();
-            var endOfStreamWindow = bigscreenPlayerData.time.windowEndTime - 2;
-
-            bigscreenPlayer.registerForTimeUpdates(callback);
-
-            mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: bigscreenPlayerData.time.windowStartTime, end: bigscreenPlayerData.time.windowEndTime});
-            mockPlayerComponentInstance.getCurrentTime.and.returnValue(endOfStreamWindow);
-
-            bigscreenPlayer.setCurrentTime(endOfStreamWindow);
-
-            mockEventHook({data: {currentTime: endOfStreamWindow}, timeUpdate: true});
-
-            expect(callback).toHaveBeenCalledWith({currentTime: endOfStreamWindow, endOfStream: true});
-          });
-
-          it('should set endOfStream to false when seeking into a simulcast', function () {
-            setupManifestData({
-              transferFormat: TransferFormats.DASH,
-              time: {
-                windowStartTime: 10,
-                windowEndTime: 100
-              }
-            });
-
-            initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
-
-            var callback = jasmine.createSpy();
-            bigscreenPlayer.registerForTimeUpdates(callback);
-
-            var middleOfStreamWindow = bigscreenPlayerData.time.windowEndTime / 2;
-
-            mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: bigscreenPlayerData.time.windowStartTime, end: bigscreenPlayerData.time.windowEndTime});
-            mockPlayerComponentInstance.getCurrentTime.and.returnValue(middleOfStreamWindow);
-
-            bigscreenPlayer.setCurrentTime(middleOfStreamWindow);
-
-            mockEventHook({data: {currentTime: middleOfStreamWindow}, timeUpdate: true});
-
-            expect(callback).toHaveBeenCalledWith({currentTime: middleOfStreamWindow, endOfStream: false});
-          });
-        });
-
-        describe('getCurrentTime', function () {
-          it('should return the current time from the strategy', function () {
-            initialiseBigscreenPlayer();
-
-            mockPlayerComponentInstance.getCurrentTime.and.returnValue(10);
-
-            expect(bigscreenPlayer.getCurrentTime()).toBe(10);
-          });
-
-          it('should return 0 if bigscreenPlayer is not initialised', function () {
-            expect(bigscreenPlayer.getCurrentTime()).toBe(0);
-          });
-        });
-
-        describe('getMediaKind', function () {
-          it('should return the media kind', function () {
-            initialiseBigscreenPlayer({mediaKind: 'audio'});
-
-            expect(bigscreenPlayer.getMediaKind()).toBe('audio');
-          });
-        });
-
-        describe('getWindowType', function () {
-          it('should return the window type', function () {
-            initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
-
-            expect(bigscreenPlayer.getWindowType()).toBe(WindowTypes.SLIDING);
-          });
-        });
-
-        describe('getSeekableRange', function () {
-          it('should return the seekable range from the strategy', function () {
-            initialiseBigscreenPlayer();
-
-            mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 10});
-
-            expect(bigscreenPlayer.getSeekableRange().start).toEqual(0);
-            expect(bigscreenPlayer.getSeekableRange().end).toEqual(10);
-          });
-
-          it('should return an empty object when bigscreen player has not been initialised', function () {
-            expect(bigscreenPlayer.getSeekableRange()).toEqual({});
-          });
-        });
-
-        describe('isAtLiveEdge', function () {
-          it('should return false when playing on demand content', function () {
-            initialiseBigscreenPlayer();
-
-            expect(bigscreenPlayer.isPlayingAtLiveEdge()).toEqual(false);
-          });
-
-          it('should return false when bigscreen-player has not been initialised', function () {
-            expect(bigscreenPlayer.isPlayingAtLiveEdge()).toEqual(false);
-          });
-
-          it('should return true when playing live and current time is within tolerance of seekable range end', function () {
-            initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
-
-            mockPlayerComponentInstance.getCurrentTime.and.returnValue(100);
-            mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 105});
-
-            expect(bigscreenPlayer.isPlayingAtLiveEdge()).toEqual(true);
-          });
-
-          it('should return false when playing live and current time is outside the tolerance of seekable range end', function () {
-            initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
-
-            mockPlayerComponentInstance.getCurrentTime.and.returnValue(95);
-            mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 105});
-
-            expect(bigscreenPlayer.isPlayingAtLiveEdge()).toEqual(false);
-          });
-        });
-
-        describe('getLiveWindowData', function () {
-          it('should return undefined values when windowType is static', function () {
-            initialiseBigscreenPlayer({windowType: WindowTypes.STATIC});
-
-            expect(bigscreenPlayer.getLiveWindowData()).toEqual({});
-          });
-
-          it('should return liveWindowData when the windowType is sliding and manifest is loaded', function () {
-            setupManifestData({
-              transferFormat: TransferFormats.DASH,
-              time: {
-                windowStartTime: 1,
-                windowEndTime: 2
-              }
-            });
-
-            var initialisationData = {windowType: WindowTypes.SLIDING, serverDate: new Date(), initialPlaybackTime: new Date().getTime()};
-            initialiseBigscreenPlayer(initialisationData);
-
-            expect(bigscreenPlayer.getLiveWindowData()).toEqual({windowStartTime: 1, windowEndTime: 2, serverDate: initialisationData.serverDate, initialPlaybackTime: initialisationData.initialPlaybackTime});
-          });
-
-          it('should return a subset of liveWindowData when the windowType is sliding and time block is provided', function () {
-            var initialisationData = {windowType: WindowTypes.SLIDING, windowStartTime: 1, windowEndTime: 2, initialPlaybackTime: new Date().getTime()};
-            initialiseBigscreenPlayer(initialisationData);
-
-            expect(bigscreenPlayer.getLiveWindowData()).toEqual({serverDate: undefined, windowStartTime: 1, windowEndTime: 2, initialPlaybackTime: initialisationData.initialPlaybackTime});
-          });
-        });
-
-        describe('getDuration', function () {
-          it('should get the duration from the strategy', function () {
-            initialiseBigscreenPlayer();
-
-            mockPlayerComponentInstance.getDuration.and.returnValue(10);
-
-            expect(bigscreenPlayer.getDuration()).toEqual(10);
-          });
-
-          it('should return undefined when not initialised', function () {
-            expect(bigscreenPlayer.getDuration()).toBeUndefined();
-          });
-        });
-
-        describe('isPaused', function () {
-          it('should get the paused state from the strategy', function () {
-            initialiseBigscreenPlayer();
-
-            mockPlayerComponentInstance.isPaused.and.returnValue(true);
-
-            expect(bigscreenPlayer.isPaused()).toBe(true);
-          });
-
-          it('should return true if bigscreenPlayer has not been initialised', function () {
-            expect(bigscreenPlayer.isPaused()).toBe(true);
-          });
-        });
-
-        describe('isEnded', function () {
-          it('should get the ended state from the strategy', function () {
-            initialiseBigscreenPlayer();
-
-            mockPlayerComponentInstance.isEnded.and.returnValue(true);
-
-            expect(bigscreenPlayer.isEnded()).toBe(true);
-          });
-
-          it('should return false if bigscreenPlayer has not been initialised', function () {
-            expect(bigscreenPlayer.isEnded()).toBe(false);
-          });
-        });
-
-        describe('play', function () {
-          it('should call play on the strategy', function () {
-            initialiseBigscreenPlayer();
-
-            bigscreenPlayer.play();
-
-            expect(mockPlayerComponentInstance.play).toHaveBeenCalledWith();
-          });
-        });
-
-        describe('pause', function () {
-          it('should call pause on the strategy', function () {
-            var opts = {disableAutoResume: true};
-
-            initialiseBigscreenPlayer();
-
-            bigscreenPlayer.pause(opts);
-
-            expect(mockPlayerComponentInstance.pause).toHaveBeenCalledWith(jasmine.objectContaining({disableAutoResume: true}));
-          });
-
-          it('should set pauseTrigger to an app pause if user pause is false', function () {
-            var opts = {userPause: false};
-
-            initialiseBigscreenPlayer();
-
-            var callback = jasmine.createSpy();
-
-            bigscreenPlayer.registerForStateChanges(callback);
-
-            bigscreenPlayer.pause(opts);
-
-            mockEventHook({data: {state: MediaState.PAUSED}});
-
-            expect(callback).toHaveBeenCalledWith(jasmine.objectContaining({trigger: PauseTriggers.APP}));
-          });
-
-          it('should set pauseTrigger to a user pause if user pause is true', function () {
-            var opts = {userPause: true};
-
-            initialiseBigscreenPlayer();
-
-            var callback = jasmine.createSpy();
-
-            bigscreenPlayer.registerForStateChanges(callback);
-
-            bigscreenPlayer.pause(opts);
-
-            mockEventHook({data: {state: MediaState.PAUSED}});
-
-            expect(callback).toHaveBeenCalledWith(jasmine.objectContaining({trigger: PauseTriggers.USER}));
-          });
-        });
-
-        describe('setSubtitlesEnabled', function () {
-          it('should turn subtitles on/off when a value is passed in and they are available', function () {
-            initialiseBigscreenPlayer({ subtitlesAvailable: true });
-
-            bigscreenPlayer.setSubtitlesEnabled(true);
-
-            expect(mockPlayerComponentInstance.setSubtitlesEnabled).toHaveBeenCalledWith(true);
-
-            bigscreenPlayer.setSubtitlesEnabled(false);
-
-            expect(mockPlayerComponentInstance.setSubtitlesEnabled).toHaveBeenCalledWith(false);
-          });
-        });
-
-        describe('isSubtitlesEnabled', function () {
-          it('calls through to playerComponent isSubtitlesEnabled when called', function () {
-            initialiseBigscreenPlayer();
-
-            bigscreenPlayer.isSubtitlesEnabled();
-
-            expect(mockPlayerComponentInstance.isSubtitlesEnabled).toHaveBeenCalledWith();
-          });
-        });
-
-        describe('isSubtitlesAvailable', function () {
-          it('calls through to playerComponent isSubtitlesAvailable when called', function () {
-            initialiseBigscreenPlayer();
-
-            bigscreenPlayer.isSubtitlesAvailable();
-
-            expect(mockPlayerComponentInstance.isSubtitlesAvailable).toHaveBeenCalledWith();
-          });
-        });
-
-        describe('canSeek', function () {
-          it('should return true when in VOD playback', function () {
-            initialiseBigscreenPlayer();
 
             expect(bigscreenPlayer.canSeek()).toBe(true);
           });
 
-          describe('live', function () {
-            it('should return true when it can seek', function () {
-              mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 60});
+          it('should return false when seekable range is infinite', function () {
+            mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: Infinity});
 
-              initialiseBigscreenPlayer({
-                windowType: WindowTypes.SLIDING
-              });
-
-              expect(bigscreenPlayer.canSeek()).toBe(true);
+            initialiseBigscreenPlayer({
+              windowType: WindowTypes.SLIDING
             });
 
-            it('should return false when seekable range is infinite', function () {
-              mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: Infinity});
+            expect(bigscreenPlayer.canSeek()).toBe(false);
+          });
 
-              initialiseBigscreenPlayer({
-                windowType: WindowTypes.SLIDING
-              });
+          it('should return false when window length less than four minutes', function () {
+            setupManifestData({
+              transferFormat: 'dash',
+              time: {
+                windowStartTime: 0,
+                windowEndTime: 239999,
+                correction: 0
+              }
+            });
+            mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 60});
 
-              expect(bigscreenPlayer.canSeek()).toBe(false);
+            initialiseBigscreenPlayer({
+              windowType: WindowTypes.SLIDING
             });
 
-            it('should return false when window length less than four minutes', function () {
-              setupManifestData({
-                transferFormat: 'dash',
-                time: {
-                  windowStartTime: 0,
-                  windowEndTime: 239999,
-                  correction: 0
-                }
-              });
-              mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 60});
+            expect(bigscreenPlayer.canSeek()).toBe(false);
+          });
 
-              initialiseBigscreenPlayer({
-                windowType: WindowTypes.SLIDING
-              });
+          it('should return false when device does not support seeking', function () {
+            mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 60});
 
-              expect(bigscreenPlayer.canSeek()).toBe(false);
+            liveSupport = LiveSupport.PLAYABLE;
+
+            initialiseBigscreenPlayer({
+              windowType: WindowTypes.SLIDING
             });
 
-            it('should return false when device does not support seeking', function () {
-              mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 60});
-
-              liveSupport = LiveSupport.PLAYABLE;
-
-              initialiseBigscreenPlayer({
-                windowType: WindowTypes.SLIDING
-              });
-
-              expect(bigscreenPlayer.canSeek()).toBe(false);
-            });
+            expect(bigscreenPlayer.canSeek()).toBe(false);
           });
         });
+      });
 
-        describe('canPause', function () {
-          it('VOD should return true', function () {
-            initialiseBigscreenPlayer();
+      describe('canPause', function () {
+        it('VOD should return true', function () {
+          initialiseBigscreenPlayer();
+
+          expect(bigscreenPlayer.canPause()).toBe(true);
+        });
+
+        describe('LIVE', function () {
+          it('should return true when it can pause', function () {
+            liveSupport = LiveSupport.RESTARTABLE;
+
+            initialiseBigscreenPlayer({
+              windowType: WindowTypes.SLIDING
+            });
 
             expect(bigscreenPlayer.canPause()).toBe(true);
           });
 
-          describe('LIVE', function () {
-            it('should return true when it can pause', function () {
-              liveSupport = LiveSupport.RESTARTABLE;
-
-              initialiseBigscreenPlayer({
-                windowType: WindowTypes.SLIDING
-              });
-
-              expect(bigscreenPlayer.canPause()).toBe(true);
-            });
-
-            it('should be false when window length less than four minutes', function () {
-              setupManifestData({
-                transferFormat: TransferFormats.DASH,
-                time: {
-                  windowStartTime: 0,
-                  windowEndTime: 239999,
-                  correction: 0
-                }
-              });
-              liveSupport = LiveSupport.RESTARTABLE;
-
-              initialiseBigscreenPlayer({
-                windowType: WindowTypes.SLIDING
-              });
-
-              expect(bigscreenPlayer.canPause()).toBe(false);
-            });
-
-            it('should return false when device does not support pausing', function () {
-              liveSupport = LiveSupport.PLAYABLE;
-
-              initialiseBigscreenPlayer({
-                windowType: WindowTypes.SLIDING
-              });
-
-              expect(bigscreenPlayer.canPause()).toBe(false);
-            });
-          });
-        });
-
-        describe('convertVideoTimeSecondsToEpochMs', function () {
-          it('converts video time to epoch time when windowStartTime is supplied', function () {
+          it('should be false when window length less than four minutes', function () {
             setupManifestData({
+              transferFormat: TransferFormats.DASH,
               time: {
-                windowStartTime: 4200,
-                windowEndTime: 150000000
+                windowStartTime: 0,
+                windowEndTime: 239999,
+                correction: 0
               }
             });
+            liveSupport = LiveSupport.RESTARTABLE;
 
             initialiseBigscreenPlayer({
               windowType: WindowTypes.SLIDING
             });
 
-            expect(bigscreenPlayer.convertVideoTimeSecondsToEpochMs(1000)).toBe(4200 + 1000000);
+            expect(bigscreenPlayer.canPause()).toBe(false);
           });
 
-          it('does not convert video time to epoch time when windowStartTime is not supplied', function () {
-            setupManifestData({
-              time: {
-                windowStartTime: undefined,
-                windowEndTime: undefined
-              }
-            });
-
-            initialiseBigscreenPlayer();
-
-            expect(bigscreenPlayer.convertVideoTimeSecondsToEpochMs(1000)).toBeUndefined();
-          });
-        });
-
-        describe('covertEpochMsToVideoTimeSeconds', function () {
-          it('converts epoch time to video time when windowStartTime is available', function () {
-            // windowStartTime - 16 January 2019 12:00:00
-            // windowEndTime - 16 January 2019 14:00:00
-            setupManifestData({
-              time: {
-                windowStartTime: 1547640000000,
-                windowEndTime: 1547647200000
-              }
-            });
+          it('should return false when device does not support pausing', function () {
+            liveSupport = LiveSupport.PLAYABLE;
 
             initialiseBigscreenPlayer({
               windowType: WindowTypes.SLIDING
             });
 
-            // Time to convert - 16 January 2019 13:00:00 - one hour (3600 seconds)
-            expect(bigscreenPlayer.convertEpochMsToVideoTimeSeconds(1547643600000)).toBe(3600);
-          });
-
-          it('does not convert epoch time to video time when windowStartTime is not available', function () {
-            setupManifestData({
-              time: {
-                windowStartTime: undefined,
-                windowEndTime: undefined
-              }
-            });
-
-            initialiseBigscreenPlayer();
-
-            expect(bigscreenPlayer.convertEpochMsToVideoTimeSeconds(1547643600000)).toBeUndefined();
-          });
-        });
-
-        describe('registerPlugin', function () {
-          beforeEach(function () {
-            jasmine.clock().install();
-
-            var callback = jasmine.createSpy(callback);
-            bigscreenPlayer.registerForStateChanges(callback);
-          });
-
-          afterEach(function () {
-            jasmine.clock().uninstall();
-          });
-
-          it('should register a specific plugin', function () {
-            var mockPlugin = jasmine.createSpyObj('plugin', ['onError']);
-            initialiseBigscreenPlayer();
-            bigscreenPlayer.registerPlugin(mockPlugin);
-
-            Plugins.interface.onError();
-
-            expect(mockPlugin.onError).toHaveBeenCalled();
-          });
-        });
-
-        describe('unregister plugin', function () {
-          var mockPlugin;
-          var mockPluginTwo;
-          beforeEach(function () {
-            jasmine.clock().install();
-            mockPlugin = jasmine.createSpyObj('plugin', ['onError']);
-            mockPluginTwo = jasmine.createSpyObj('pluginTwo', ['onError']);
-            initialiseBigscreenPlayer();
-            bigscreenPlayer.registerPlugin(mockPlugin);
-            bigscreenPlayer.registerPlugin(mockPluginTwo);
-          });
-
-          afterEach(function () {
-            jasmine.clock().uninstall();
-            mockPlugin.onError.calls.reset();
-            mockPluginTwo.onError.calls.reset();
-          });
-
-          it('should remove a specific plugin', function () {
-            bigscreenPlayer.unregisterPlugin(mockPlugin);
-
-            Plugins.interface.onError();
-
-            expect(mockPlugin.onError).not.toHaveBeenCalled();
-            expect(mockPluginTwo.onError).toHaveBeenCalled();
-          });
-
-          it('should remove all plugins', function () {
-            bigscreenPlayer.unregisterPlugin();
-
-            Plugins.interface.onError();
-
-            expect(mockPlugin.onError).not.toHaveBeenCalled();
-            expect(mockPluginTwo.onError).not.toHaveBeenCalled();
+            expect(bigscreenPlayer.canPause()).toBe(false);
           });
         });
       });
-    }
-  );
+
+      describe('convertVideoTimeSecondsToEpochMs', function () {
+        it('converts video time to epoch time when windowStartTime is supplied', function () {
+          setupManifestData({
+            time: {
+              windowStartTime: 4200,
+              windowEndTime: 150000000
+            }
+          });
+
+          initialiseBigscreenPlayer({
+            windowType: WindowTypes.SLIDING
+          });
+
+          expect(bigscreenPlayer.convertVideoTimeSecondsToEpochMs(1000)).toBe(4200 + 1000000);
+        });
+
+        it('does not convert video time to epoch time when windowStartTime is not supplied', function () {
+          setupManifestData({
+            time: {
+              windowStartTime: undefined,
+              windowEndTime: undefined
+            }
+          });
+
+          initialiseBigscreenPlayer();
+
+          expect(bigscreenPlayer.convertVideoTimeSecondsToEpochMs(1000)).toBeUndefined();
+        });
+      });
+
+      describe('covertEpochMsToVideoTimeSeconds', function () {
+        it('converts epoch time to video time when windowStartTime is available', function () {
+          // windowStartTime - 16 January 2019 12:00:00
+          // windowEndTime - 16 January 2019 14:00:00
+          setupManifestData({
+            time: {
+              windowStartTime: 1547640000000,
+              windowEndTime: 1547647200000
+            }
+          });
+
+          initialiseBigscreenPlayer({
+            windowType: WindowTypes.SLIDING
+          });
+
+          // Time to convert - 16 January 2019 13:00:00 - one hour (3600 seconds)
+          expect(bigscreenPlayer.convertEpochMsToVideoTimeSeconds(1547643600000)).toBe(3600);
+        });
+
+        it('does not convert epoch time to video time when windowStartTime is not available', function () {
+          setupManifestData({
+            time: {
+              windowStartTime: undefined,
+              windowEndTime: undefined
+            }
+          });
+
+          initialiseBigscreenPlayer();
+
+          expect(bigscreenPlayer.convertEpochMsToVideoTimeSeconds(1547643600000)).toBeUndefined();
+        });
+      });
+
+      describe('registerPlugin', function () {
+        beforeEach(function () {
+          jasmine.clock().install();
+
+          var callback = jasmine.createSpy(callback);
+          bigscreenPlayer.registerForStateChanges(callback);
+        });
+
+        afterEach(function () {
+          jasmine.clock().uninstall();
+        });
+
+        it('should register a specific plugin', function () {
+          var mockPlugin = jasmine.createSpyObj('plugin', ['onError']);
+          initialiseBigscreenPlayer();
+          bigscreenPlayer.registerPlugin(mockPlugin);
+
+          Plugins.interface.onError();
+
+          expect(mockPlugin.onError).toHaveBeenCalled();
+        });
+      });
+
+      describe('unregister plugin', function () {
+        var mockPlugin;
+        var mockPluginTwo;
+        beforeEach(function () {
+          jasmine.clock().install();
+          mockPlugin = jasmine.createSpyObj('plugin', ['onError']);
+          mockPluginTwo = jasmine.createSpyObj('pluginTwo', ['onError']);
+          initialiseBigscreenPlayer();
+          bigscreenPlayer.registerPlugin(mockPlugin);
+          bigscreenPlayer.registerPlugin(mockPluginTwo);
+        });
+
+        afterEach(function () {
+          jasmine.clock().uninstall();
+          mockPlugin.onError.calls.reset();
+          mockPluginTwo.onError.calls.reset();
+        });
+
+        it('should remove a specific plugin', function () {
+          bigscreenPlayer.unregisterPlugin(mockPlugin);
+
+          Plugins.interface.onError();
+
+          expect(mockPlugin.onError).not.toHaveBeenCalled();
+          expect(mockPluginTwo.onError).toHaveBeenCalled();
+        });
+
+        it('should remove all plugins', function () {
+          bigscreenPlayer.unregisterPlugin();
+
+          Plugins.interface.onError();
+
+          expect(mockPlugin.onError).not.toHaveBeenCalled();
+          expect(mockPluginTwo.onError).not.toHaveBeenCalled();
+        });
+      });
+    });
+  }
+);

--- a/script-test/debugger/debugpresentertest.js
+++ b/script-test/debugger/debugpresentertest.js
@@ -3,227 +3,227 @@ require(
     'bigscreenplayer/debugger/debugpresenter',
     'bigscreenplayer/models/mediastate'
   ],
-    function (DebugPresenter, MediaState) {
-      describe('Debug Presenter', function () {
-        var presenter;
-        var viewMock;
+  function (DebugPresenter, MediaState) {
+    describe('Debug Presenter', function () {
+      var presenter;
+      var viewMock;
 
-        beforeEach(function () {
-          viewMock = jasmine.createSpyObj('view', ['render']);
-          presenter = DebugPresenter;
-          presenter.init(viewMock);
-        });
+      beforeEach(function () {
+        viewMock = jasmine.createSpyObj('view', ['render']);
+        presenter = DebugPresenter;
+        presenter.init(viewMock);
+      });
 
-        it('parses static info from an array of chronicle values', function () {
-          presenter.update([{type: 'keyvalue', keyvalue: {key: 'bitrate', value: '1000'}, timestamp: 1518018558259}]);
-          var expectedObject = {
-            static: [
-              {
-                key: 'bitrate',
-                value: '1000'
-              }
-            ],
-            dynamic: [
-            ]
-          };
+      it('parses static info from an array of chronicle values', function () {
+        presenter.update([{type: 'keyvalue', keyvalue: {key: 'bitrate', value: '1000'}, timestamp: 1518018558259}]);
+        var expectedObject = {
+          static: [
+            {
+              key: 'bitrate',
+              value: '1000'
+            }
+          ],
+          dynamic: [
+          ]
+        };
 
-          expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
-        });
+        expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
+      });
 
-        it('converts any static field Date object into human readable time string', function () {
-          var testDate = new Date(1518018558259);
-          presenter.update([{type: 'keyvalue', keyvalue: {key: 'anything', value: testDate}, timestamp: 1518018558259}]);
-          var expectedObject = {
-            static: [
-              {
-                key: 'anything',
-                value: '15:49:18'
-              }
-            ],
-            dynamic: [
-            ]
-          };
+      it('converts any static field Date object into human readable time string', function () {
+        var testDate = new Date(1518018558259);
+        presenter.update([{type: 'keyvalue', keyvalue: {key: 'anything', value: testDate}, timestamp: 1518018558259}]);
+        var expectedObject = {
+          static: [
+            {
+              key: 'anything',
+              value: '15:49:18'
+            }
+          ],
+          dynamic: [
+          ]
+        };
 
-          expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
-        });
+        expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
+      });
 
-        it('parses dynamic info from an array of chronicle values', function () {
-          presenter.update([{type: 'info', message: 'A string info message', timestamp: 1518018558259}]);
-          var expectedObject = {
-            static: [
-            ],
-            dynamic: [
-              '2018-02-07T15:49:18.259Z - Info: A string info message'
-            ]
-          };
+      it('parses dynamic info from an array of chronicle values', function () {
+        presenter.update([{type: 'info', message: 'A string info message', timestamp: 1518018558259}]);
+        var expectedObject = {
+          static: [
+          ],
+          dynamic: [
+            '2018-02-07T15:49:18.259Z - Info: A string info message'
+          ]
+        };
 
-          expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
-        });
+        expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
+      });
 
-        it('parses multiple dynamic events from an array of chronicle values', function () {
-          presenter.update([
-            {type: 'info', message: 'A string info message', timestamp: 1518018558259},
-            {type: 'info', message: 'Another info message', timestamp: 1518018558259}
-          ]);
-          var expectedObject = {
-            static: [
-            ],
-            dynamic: [
-              '2018-02-07T15:49:18.259Z - Info: A string info message',
-              '2018-02-07T15:49:18.259Z - Info: Another info message'
-            ]
-          };
+      it('parses multiple dynamic events from an array of chronicle values', function () {
+        presenter.update([
+          {type: 'info', message: 'A string info message', timestamp: 1518018558259},
+          {type: 'info', message: 'Another info message', timestamp: 1518018558259}
+        ]);
+        var expectedObject = {
+          static: [
+          ],
+          dynamic: [
+            '2018-02-07T15:49:18.259Z - Info: A string info message',
+            '2018-02-07T15:49:18.259Z - Info: Another info message'
+          ]
+        };
 
-          expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
-        });
+        expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
+      });
 
-        it('parses error events to simple string representation', function () {
-          presenter.update([
-            {type: 'error',
-              error: {
-                errorId: '1',
-                message: 'An error has occurred'
-              },
-              timestamp: 1518018558259}
-          ]);
-          var expectedObject = {
-            static: [
-            ],
-            dynamic: [
-              '2018-02-07T15:49:18.259Z - Error: 1 | An error has occurred'
-            ]
-          };
+      it('parses error events to simple string representation', function () {
+        presenter.update([
+          {type: 'error',
+            error: {
+              errorId: '1',
+              message: 'An error has occurred'
+            },
+            timestamp: 1518018558259}
+        ]);
+        var expectedObject = {
+          static: [
+          ],
+          dynamic: [
+            '2018-02-07T15:49:18.259Z - Error: 1 | An error has occurred'
+          ]
+        };
 
-          expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
-        });
+        expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
+      });
 
-        it('parses events to readable representation', function () {
-          presenter.update([
-            {type: 'event', event: {state: MediaState.PLAYING}, timestamp: 1518018558259}
-          ]);
-          var expectedObject = {
-            static: [
-            ],
-            dynamic: [
-              '2018-02-07T15:49:18.259Z - Event: PLAYING'
-            ]
-          };
+      it('parses events to readable representation', function () {
+        presenter.update([
+          {type: 'event', event: {state: MediaState.PLAYING}, timestamp: 1518018558259}
+        ]);
+        var expectedObject = {
+          static: [
+          ],
+          dynamic: [
+            '2018-02-07T15:49:18.259Z - Event: PLAYING'
+          ]
+        };
 
-          expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
-        });
+        expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
+      });
 
-        it('parses time to formatted string representation', function () {
-          presenter.update([
-            {type: 'time', currentTime: 12.3433, timestamp: 1518018558259}
-          ]);
-          var expectedObject = {
-            static: [
-            ],
-            dynamic: [
-              '2018-02-07T15:49:18.259Z - Video time: 12.34'
-            ]
-          };
+      it('parses time to formatted string representation', function () {
+        presenter.update([
+          {type: 'time', currentTime: 12.3433, timestamp: 1518018558259}
+        ]);
+        var expectedObject = {
+          static: [
+          ],
+          dynamic: [
+            '2018-02-07T15:49:18.259Z - Video time: 12.34'
+          ]
+        };
 
-          expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
-        });
+        expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
+      });
 
-        it('parses long time to formatted string representation', function () {
-          presenter.update([
-            {type: 'time', currentTime: 788.9999, timestamp: 1518018558259}
-          ]);
-          var expectedObject = {
-            static: [
-            ],
-            dynamic: [
-              '2018-02-07T15:49:18.259Z - Video time: 789.00'
-            ]
-          };
+      it('parses long time to formatted string representation', function () {
+        presenter.update([
+          {type: 'time', currentTime: 788.9999, timestamp: 1518018558259}
+        ]);
+        var expectedObject = {
+          static: [
+          ],
+          dynamic: [
+            '2018-02-07T15:49:18.259Z - Video time: 789.00'
+          ]
+        };
 
-          expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
-        });
+        expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
+      });
 
-        it('parses apicall to a formatted string representation', function () {
-          presenter.update([
-            {type: 'apicall', calltype: 'Play', timestamp: 1518018558259}
-          ]);
-          var expectedObject = {
-            static: [
-            ],
-            dynamic: [
-              '2018-02-07T15:49:18.259Z - Api call: Play'
-            ]
-          };
+      it('parses apicall to a formatted string representation', function () {
+        presenter.update([
+          {type: 'apicall', calltype: 'Play', timestamp: 1518018558259}
+        ]);
+        var expectedObject = {
+          static: [
+          ],
+          dynamic: [
+            '2018-02-07T15:49:18.259Z - Api call: Play'
+          ]
+        };
 
-          expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
-        });
+        expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
+      });
 
-        it('When the log object does not contain a valid type', function () {
-          presenter.update([
-            {type: 'blah', someobject: {thing: ''}, timestamp: 1518018558259}
-          ]);
-          var expectedObject = {
-            static: [
-            ],
-            dynamic: [
-              '2018-02-07T15:49:18.259Z - Unknown log format'
-            ]
-          };
+      it('When the log object does not contain a valid type', function () {
+        presenter.update([
+          {type: 'blah', someobject: {thing: ''}, timestamp: 1518018558259}
+        ]);
+        var expectedObject = {
+          static: [
+          ],
+          dynamic: [
+            '2018-02-07T15:49:18.259Z - Unknown log format'
+          ]
+        };
 
-          expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
-        });
+        expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
+      });
 
-        it('Only uses the the latest value when updating static fields', function () {
-          presenter.update([
-            {type: 'keyvalue', keyvalue: {key: 'bitrate', value: '1000'}, timestamp: 1518018558259},
-            {type: 'keyvalue', keyvalue: {key: 'bitrate', value: '2000'}, timestamp: 1518018558259}
-          ]);
-          var expectedObject = {
-            static: [
-              {
-                key: 'bitrate',
-                value: '2000'
-              }
-            ],
-            dynamic: [
-            ]
-          };
+      it('Only uses the the latest value when updating static fields', function () {
+        presenter.update([
+          {type: 'keyvalue', keyvalue: {key: 'bitrate', value: '1000'}, timestamp: 1518018558259},
+          {type: 'keyvalue', keyvalue: {key: 'bitrate', value: '2000'}, timestamp: 1518018558259}
+        ]);
+        var expectedObject = {
+          static: [
+            {
+              key: 'bitrate',
+              value: '2000'
+            }
+          ],
+          dynamic: [
+          ]
+        };
 
-          expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
-        });
+        expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
+      });
 
-        it('Only uses the the latest value when updating static fields with multiple fields', function () {
-          presenter.update([
-            {type: 'keyvalue', keyvalue: {key: 'bitrate', value: '1000'}, timestamp: 1518018558259},
-            {type: 'keyvalue', keyvalue: {key: 'duration', value: '12345'}, timestamp: 1518018558259},
-            {type: 'keyvalue', keyvalue: {key: 'bitrate', value: '2000'}, timestamp: 1518018558259},
-            {type: 'keyvalue', keyvalue: {key: 'duration', value: '12346'}, timestamp: 1518018558259},
-            {type: 'keyvalue', keyvalue: {key: 'seekableRangeStart', value: '0'}, timestamp: 1518018558259},
-            {type: 'keyvalue', keyvalue: {key: 'seekableRangeEnd', value: '12346'}, timestamp: 1518018558259}
-          ]);
-          var expectedObject = {
-            static: [
-              {
-                key: 'bitrate',
-                value: '2000'
-              },
-              {
-                key: 'duration',
-                value: '12346'
-              },
-              {
-                key: 'seekable range start',
-                value: '0'
-              },
-              {
-                key: 'seekable range end',
-                value: '12346'
-              }
-            ],
-            dynamic: [
-            ]
-          };
+      it('Only uses the the latest value when updating static fields with multiple fields', function () {
+        presenter.update([
+          {type: 'keyvalue', keyvalue: {key: 'bitrate', value: '1000'}, timestamp: 1518018558259},
+          {type: 'keyvalue', keyvalue: {key: 'duration', value: '12345'}, timestamp: 1518018558259},
+          {type: 'keyvalue', keyvalue: {key: 'bitrate', value: '2000'}, timestamp: 1518018558259},
+          {type: 'keyvalue', keyvalue: {key: 'duration', value: '12346'}, timestamp: 1518018558259},
+          {type: 'keyvalue', keyvalue: {key: 'seekableRangeStart', value: '0'}, timestamp: 1518018558259},
+          {type: 'keyvalue', keyvalue: {key: 'seekableRangeEnd', value: '12346'}, timestamp: 1518018558259}
+        ]);
+        var expectedObject = {
+          static: [
+            {
+              key: 'bitrate',
+              value: '2000'
+            },
+            {
+              key: 'duration',
+              value: '12346'
+            },
+            {
+              key: 'seekable range start',
+              value: '0'
+            },
+            {
+              key: 'seekable range end',
+              value: '12346'
+            }
+          ],
+          dynamic: [
+          ]
+        };
 
-          expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
-        });
+        expect(viewMock.render).toHaveBeenCalledWith(expectedObject);
       });
     });
+  });

--- a/script-test/debugger/debugtooltest.js
+++ b/script-test/debugger/debugtooltest.js
@@ -3,57 +3,57 @@ require(
     'bigscreenplayer/debugger/chronicle',
     'bigscreenplayer/debugger/debugtool'
   ],
-    function (Chronicle, DebugTool) {
-      describe('Debug Tool, when intercepting keyValue calls,', function () {
-        beforeEach(function () {
-          Chronicle.init();
-          spyOn(window, 'Date').and.callFake(function () {
-            return {getTime: function () { return 1234; }};
-          });
-        });
-
-        afterEach(function () {
-          DebugTool.tearDown();
-          Chronicle.tearDown();
-        });
-
-        it('should always add entry to chronicle if the key does not match one of the defined static keys', function () {
-          var testObj1 = {key: 'bitrate', value: '1000'};
-          var testObj2 = {key: 'imNotSpecial', value: 'nobodylovesme'};
-          var testObj3 = {key: 'idontmatch', value: 'pleaseaddme'};
-
-          var expectedArray = [
-            {type: 'keyvalue', keyvalue: testObj1, timestamp: 1234},
-            {type: 'keyvalue', keyvalue: testObj2, timestamp: 1234},
-            {type: 'keyvalue', keyvalue: testObj3, timestamp: 1234}
-          ];
-
-          DebugTool.keyValue(testObj1);
-          DebugTool.keyValue(testObj2);
-          DebugTool.keyValue(testObj3);
-
-          var chronicle = Chronicle.retrieve();
-
-          expect(chronicle).toEqual(expectedArray);
-        });
-
-        it('overwrites a keyvalue entry to the chronicle if that keyvalue already exists', function () {
-          var testObj = {key: 'akey', value: 'something'};
-          var testObj1 = {key: 'bitrate', value: '1000'};
-          var testObj2 = {key: 'bitrate', value: '1001'};
-
-          var expectedArray = [
-            {type: 'keyvalue', keyvalue: {key: 'akey', value: 'something'}, timestamp: 1234},
-            {type: 'keyvalue', keyvalue: {key: 'bitrate', value: '1001'}, timestamp: 1234}
-          ];
-
-          DebugTool.keyValue(testObj);
-          DebugTool.keyValue(testObj1);
-          DebugTool.keyValue(testObj2);
-
-          var chronicle = Chronicle.retrieve();
-
-          expect(chronicle).toEqual(expectedArray);
+  function (Chronicle, DebugTool) {
+    describe('Debug Tool, when intercepting keyValue calls,', function () {
+      beforeEach(function () {
+        Chronicle.init();
+        spyOn(window, 'Date').and.callFake(function () {
+          return {getTime: function () { return 1234; }};
         });
       });
+
+      afterEach(function () {
+        DebugTool.tearDown();
+        Chronicle.tearDown();
+      });
+
+      it('should always add entry to chronicle if the key does not match one of the defined static keys', function () {
+        var testObj1 = {key: 'bitrate', value: '1000'};
+        var testObj2 = {key: 'imNotSpecial', value: 'nobodylovesme'};
+        var testObj3 = {key: 'idontmatch', value: 'pleaseaddme'};
+
+        var expectedArray = [
+          {type: 'keyvalue', keyvalue: testObj1, timestamp: 1234},
+          {type: 'keyvalue', keyvalue: testObj2, timestamp: 1234},
+          {type: 'keyvalue', keyvalue: testObj3, timestamp: 1234}
+        ];
+
+        DebugTool.keyValue(testObj1);
+        DebugTool.keyValue(testObj2);
+        DebugTool.keyValue(testObj3);
+
+        var chronicle = Chronicle.retrieve();
+
+        expect(chronicle).toEqual(expectedArray);
+      });
+
+      it('overwrites a keyvalue entry to the chronicle if that keyvalue already exists', function () {
+        var testObj = {key: 'akey', value: 'something'};
+        var testObj1 = {key: 'bitrate', value: '1000'};
+        var testObj2 = {key: 'bitrate', value: '1001'};
+
+        var expectedArray = [
+          {type: 'keyvalue', keyvalue: {key: 'akey', value: 'something'}, timestamp: 1234},
+          {type: 'keyvalue', keyvalue: {key: 'bitrate', value: '1001'}, timestamp: 1234}
+        ];
+
+        DebugTool.keyValue(testObj);
+        DebugTool.keyValue(testObj1);
+        DebugTool.keyValue(testObj2);
+
+        var chronicle = Chronicle.retrieve();
+
+        expect(chronicle).toEqual(expectedArray);
+      });
     });
+  });

--- a/script-test/dynamicwindowutilstest.js
+++ b/script-test/dynamicwindowutilstest.js
@@ -2,120 +2,120 @@ require(
   [
     'bigscreenplayer/dynamicwindowutils'
   ],
-    function (DynamicWindowUtils) {
-      describe('shouldAutoResume', function () {
-        it('returns true if we are at the beginning of the playback range', function () {
-          var isAtStart = DynamicWindowUtils.shouldAutoResume(10, 10);
+  function (DynamicWindowUtils) {
+    describe('shouldAutoResume', function () {
+      it('returns true if we are at the beginning of the playback range', function () {
+        var isAtStart = DynamicWindowUtils.shouldAutoResume(10, 10);
 
-          expect(isAtStart).toBeTrue();
-        });
-
-        it('returns true if we are at the beginning of the playback range within a threshhold', function () {
-          var isAtStart = DynamicWindowUtils.shouldAutoResume(15, 10);
-
-          expect(isAtStart).toBeTrue();
-        });
-
-        it('returns true if we are at the beginning of the playback range at the threshhold', function () {
-          var isAtStart = DynamicWindowUtils.shouldAutoResume(18, 10);
-
-          expect(isAtStart).toBeTrue();
-        });
-
-        it('returns false if we are after the beginning and the threshhold', function () {
-          var isAtStart = DynamicWindowUtils.shouldAutoResume(20, 10);
-
-          expect(isAtStart).toBeFalse();
-        });
+        expect(isAtStart).toBeTrue();
       });
 
-      describe('autoResumeAtStartOfRange', function () {
-        var resume;
-        var addEventCallback;
-        var removeEventCallback;
-        var checkNotPauseEvent;
-        var currentTime = 20;
-        var seekableRange = {
-          start: 0
-        };
+      it('returns true if we are at the beginning of the playback range within a threshhold', function () {
+        var isAtStart = DynamicWindowUtils.shouldAutoResume(15, 10);
 
-        beforeEach(function () {
-          jasmine.clock().install();
-          resume = jasmine.createSpy('resume');
-          addEventCallback = jasmine.createSpy('addEventCallback');
-          removeEventCallback = jasmine.createSpy('removeEventCallback');
-          checkNotPauseEvent = jasmine.createSpy('checkNotPauseEvent');
-        });
-
-        afterEach(function () {
-          jasmine.clock().uninstall();
-        });
-
-        it('resumes play when the current time is equal to the start of the seekable range', function () {
-          DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, undefined, resume);
-
-          jasmine.clock().tick(20000);
-
-          expect(addEventCallback).toHaveBeenCalledTimes(1);
-          expect(removeEventCallback).toHaveBeenCalledTimes(1);
-          expect(resume).toHaveBeenCalledTimes(1);
-        });
-
-        it('resumes play when the current time at the start of the seekable range within a threshold', function () {
-          DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, undefined, resume);
-
-          jasmine.clock().tick(15000);
-
-          expect(addEventCallback).toHaveBeenCalledTimes(1);
-          expect(removeEventCallback).toHaveBeenCalledTimes(1);
-          expect(resume).toHaveBeenCalledTimes(1);
-        });
-
-        it('resumes play when the current time at the start of the seekable range at the threshold', function () {
-          DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, undefined, resume);
-
-          jasmine.clock().tick(12000);
-
-          expect(addEventCallback).toHaveBeenCalledTimes(1);
-          expect(removeEventCallback).toHaveBeenCalledTimes(1);
-          expect(resume).toHaveBeenCalledTimes(1);
-        });
-
-        it('does not resume play when the current time is past the start of the seekable range plus the threshold', function () {
-          DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, undefined, resume);
-
-          jasmine.clock().tick(10000);
-
-          expect(addEventCallback).toHaveBeenCalledTimes(1);
-          expect(removeEventCallback).toHaveBeenCalledTimes(0);
-          expect(resume).toHaveBeenCalledTimes(0);
-        });
-
-        it('non pause event stops autoresume', function () {
-          checkNotPauseEvent.and.returnValue(true);
-
-          addEventCallback.and.callFake(function (context, callback) { callback(); });
-
-          DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, checkNotPauseEvent, resume);
-
-          jasmine.clock().tick(20000);
-
-          expect(removeEventCallback).toHaveBeenCalledTimes(1);
-          expect(resume).toHaveBeenCalledTimes(0);
-        });
-
-        it('pause event does not stop autoresume', function () {
-          checkNotPauseEvent.and.returnValue(false);
-
-          addEventCallback.and.callFake(function (context, callback) { callback(); });
-
-          DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, checkNotPauseEvent, resume);
-
-          jasmine.clock().tick(20000);
-
-          expect(removeEventCallback).toHaveBeenCalledTimes(1);
-          expect(resume).toHaveBeenCalledTimes(1);
-        });
+        expect(isAtStart).toBeTrue();
       });
-    }
+
+      it('returns true if we are at the beginning of the playback range at the threshhold', function () {
+        var isAtStart = DynamicWindowUtils.shouldAutoResume(18, 10);
+
+        expect(isAtStart).toBeTrue();
+      });
+
+      it('returns false if we are after the beginning and the threshhold', function () {
+        var isAtStart = DynamicWindowUtils.shouldAutoResume(20, 10);
+
+        expect(isAtStart).toBeFalse();
+      });
+    });
+
+    describe('autoResumeAtStartOfRange', function () {
+      var resume;
+      var addEventCallback;
+      var removeEventCallback;
+      var checkNotPauseEvent;
+      var currentTime = 20;
+      var seekableRange = {
+        start: 0
+      };
+
+      beforeEach(function () {
+        jasmine.clock().install();
+        resume = jasmine.createSpy('resume');
+        addEventCallback = jasmine.createSpy('addEventCallback');
+        removeEventCallback = jasmine.createSpy('removeEventCallback');
+        checkNotPauseEvent = jasmine.createSpy('checkNotPauseEvent');
+      });
+
+      afterEach(function () {
+        jasmine.clock().uninstall();
+      });
+
+      it('resumes play when the current time is equal to the start of the seekable range', function () {
+        DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, undefined, resume);
+
+        jasmine.clock().tick(20000);
+
+        expect(addEventCallback).toHaveBeenCalledTimes(1);
+        expect(removeEventCallback).toHaveBeenCalledTimes(1);
+        expect(resume).toHaveBeenCalledTimes(1);
+      });
+
+      it('resumes play when the current time at the start of the seekable range within a threshold', function () {
+        DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, undefined, resume);
+
+        jasmine.clock().tick(15000);
+
+        expect(addEventCallback).toHaveBeenCalledTimes(1);
+        expect(removeEventCallback).toHaveBeenCalledTimes(1);
+        expect(resume).toHaveBeenCalledTimes(1);
+      });
+
+      it('resumes play when the current time at the start of the seekable range at the threshold', function () {
+        DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, undefined, resume);
+
+        jasmine.clock().tick(12000);
+
+        expect(addEventCallback).toHaveBeenCalledTimes(1);
+        expect(removeEventCallback).toHaveBeenCalledTimes(1);
+        expect(resume).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not resume play when the current time is past the start of the seekable range plus the threshold', function () {
+        DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, undefined, resume);
+
+        jasmine.clock().tick(10000);
+
+        expect(addEventCallback).toHaveBeenCalledTimes(1);
+        expect(removeEventCallback).toHaveBeenCalledTimes(0);
+        expect(resume).toHaveBeenCalledTimes(0);
+      });
+
+      it('non pause event stops autoresume', function () {
+        checkNotPauseEvent.and.returnValue(true);
+
+        addEventCallback.and.callFake(function (context, callback) { callback(); });
+
+        DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, checkNotPauseEvent, resume);
+
+        jasmine.clock().tick(20000);
+
+        expect(removeEventCallback).toHaveBeenCalledTimes(1);
+        expect(resume).toHaveBeenCalledTimes(0);
+      });
+
+      it('pause event does not stop autoresume', function () {
+        checkNotPauseEvent.and.returnValue(false);
+
+        addEventCallback.and.callFake(function (context, callback) { callback(); });
+
+        DynamicWindowUtils.autoResumeAtStartOfRange(currentTime, seekableRange, addEventCallback, removeEventCallback, checkNotPauseEvent, resume);
+
+        jasmine.clock().tick(20000);
+
+        expect(removeEventCallback).toHaveBeenCalledTimes(1);
+        expect(resume).toHaveBeenCalledTimes(1);
+      });
+    });
+  }
 );

--- a/script-test/playbackstrategies/growingwindowrefreshertest.js
+++ b/script-test/playbackstrategies/growingwindowrefreshertest.js
@@ -2,51 +2,51 @@ require(
   [
     'bigscreenplayer/playbackstrategy/growingwindowrefresher'
   ],
-    function (GrowingWindowRefresher) {
-      describe('GrowingWindowRefresher', function () {
-        var mediaPlayerSpy;
-        var eventHandlers;
-        var dashEventCallback;
-        var seekCallbacksSpy;
+  function (GrowingWindowRefresher) {
+    describe('GrowingWindowRefresher', function () {
+      var mediaPlayerSpy;
+      var eventHandlers;
+      var dashEventCallback;
+      var seekCallbacksSpy;
 
-        var dashjsMediaPlayerEvents = {
-          ERROR: 'error',
-          MANIFEST_LOADED: 'manifestLoaded'
+      var dashjsMediaPlayerEvents = {
+        ERROR: 'error',
+        MANIFEST_LOADED: 'manifestLoaded'
+      };
+
+      beforeEach(function () {
+        eventHandlers = {};
+        mediaPlayerSpy = jasmine.createSpyObj('mediaPlayer', ['refreshManifest', 'on', 'off']);
+        mediaPlayerSpy.on.and.callFake(function (eventType, handler) {
+          eventHandlers[eventType] = handler;
+        });
+
+        dashEventCallback = function (eventType, event) {
+          eventHandlers[eventType](event);
         };
 
-        beforeEach(function () {
-          eventHandlers = {};
-          mediaPlayerSpy = jasmine.createSpyObj('mediaPlayer', ['refreshManifest', 'on', 'off']);
-          mediaPlayerSpy.on.and.callFake(function (eventType, handler) {
-            eventHandlers[eventType] = handler;
-          });
+        seekCallbacksSpy = jasmine.createSpy('seekCallbacksSpy');
+      });
 
-          dashEventCallback = function (eventType, event) {
-            eventHandlers[eventType](event);
-          };
+      it('should instruct the media player to refresh the manifest', function () {
+        GrowingWindowRefresher(mediaPlayerSpy, seekCallbacksSpy);
 
-          seekCallbacksSpy = jasmine.createSpy('seekCallbacksSpy');
-        });
+        expect(mediaPlayerSpy.refreshManifest).toHaveBeenCalledTimes(1);
+      });
 
-        it('should instruct the media player to refresh the manifest', function () {
-          GrowingWindowRefresher(mediaPlayerSpy, seekCallbacksSpy);
+      it('calls the given callback on media player MANIFEST_LOADED event', function () {
+        GrowingWindowRefresher(mediaPlayerSpy, seekCallbacksSpy);
+        dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {data: {mediaPresentationDuration: 100}});
 
-          expect(mediaPlayerSpy.refreshManifest).toHaveBeenCalledTimes(1);
-        });
+        expect(seekCallbacksSpy).toHaveBeenCalled();
+      });
 
-        it('calls the given callback on media player MANIFEST_LOADED event', function () {
-          GrowingWindowRefresher(mediaPlayerSpy, seekCallbacksSpy);
-          dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {data: {mediaPresentationDuration: 100}});
+      it('removes MANIFEST_LOADED listener following manifest load event', function () {
+        GrowingWindowRefresher(mediaPlayerSpy, seekCallbacksSpy);
+        dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {data: {mediaPresentationDuration: 100}});
 
-          expect(seekCallbacksSpy).toHaveBeenCalled();
-        });
-
-        it('removes MANIFEST_LOADED listener following manifest load event', function () {
-          GrowingWindowRefresher(mediaPlayerSpy, seekCallbacksSpy);
-          dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, {data: {mediaPresentationDuration: 100}});
-
-          expect(mediaPlayerSpy.off).toHaveBeenCalledWith('manifestLoaded', eventHandlers.manifestLoaded);
-        });
+        expect(mediaPlayerSpy.off).toHaveBeenCalledWith('manifestLoaded', eventHandlers.manifestLoaded);
       });
     });
+  });
 

--- a/script-test/playbackstrategies/legacyplayeradaptortest.js
+++ b/script-test/playbackstrategies/legacyplayeradaptortest.js
@@ -8,25 +8,25 @@ require(
   ],
   function (Squire, WindowTypes, MediaState, MediaSources, LiveSupport) {
     var MediaPlayerEvent = {
-      STOPPED: 'stopped',   // Event fired when playback is stopped
+      STOPPED: 'stopped', // Event fired when playback is stopped
       BUFFERING: 'buffering', // Event fired when playback has to suspend due to buffering
-      PLAYING: 'playing',   // Event fired when starting (or resuming) playing of the media
-      PAUSED: 'paused',    // Event fired when media playback pauses
-      COMPLETE: 'complete',  // Event fired when media playback has reached the end of the media
-      ERROR: 'error',     // Event fired when an error condition occurs
-      STATUS: 'status',    // Event fired regularly during play
+      PLAYING: 'playing', // Event fired when starting (or resuming) playing of the media
+      PAUSED: 'paused', // Event fired when media playback pauses
+      COMPLETE: 'complete', // Event fired when media playback has reached the end of the media
+      ERROR: 'error', // Event fired when an error condition occurs
+      STATUS: 'status', // Event fired regularly during play
       SEEK_ATTEMPTED: 'seek-attempted', // Event fired when a device using a seekfinishedemitevent modifier sets the source
-      SEEK_FINISHED: 'seek-finished'    // Event fired when a device using a seekfinishedemitevent modifier has seeked successfully
+      SEEK_FINISHED: 'seek-finished' // Event fired when a device using a seekfinishedemitevent modifier has seeked successfully
     };
 
     var MediaPlayerState = {
-      EMPTY: 'EMPTY',     // No source set
-      STOPPED: 'STOPPED',   // Source set but no playback
+      EMPTY: 'EMPTY', // No source set
+      STOPPED: 'STOPPED', // Source set but no playback
       BUFFERING: 'BUFFERING', // Not enough data to play, waiting to download more
-      PLAYING: 'PLAYING',   // Media is playing
-      PAUSED: 'PAUSED',    // Media is paused
-      COMPLETE: 'COMPLETE',  // Media has reached its end point
-      ERROR: 'ERROR'      // An error occurred
+      PLAYING: 'PLAYING', // Media is playing
+      PAUSED: 'PAUSED', // Media is paused
+      COMPLETE: 'COMPLETE', // Media has reached its end point
+      ERROR: 'ERROR' // An error occurred
     };
 
     describe('Legacy Playback Adapter', function () {

--- a/script-test/playbackstrategies/modifiers/cehtmltests.js
+++ b/script-test/playbackstrategies/modifiers/cehtmltests.js
@@ -3,389 +3,389 @@ require(
     'bigscreenplayer/playbackstrategy/modifiers/cehtml',
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
   ],
-    function (CehtmlMediaPlayer, MediaPlayerBase) {
-      describe('cehtml Base', function () {
-        var player;
-        var mockMediaElement;
-        var sourceContainer;
+  function (CehtmlMediaPlayer, MediaPlayerBase) {
+    describe('cehtml Base', function () {
+      var player;
+      var mockMediaElement;
+      var sourceContainer;
 
-        var recentEvents;
+      var recentEvents;
 
-        function eventCallbackReporter (event) {
-          recentEvents.push(event.type);
-        }
+      function eventCallbackReporter (event) {
+        recentEvents.push(event.type);
+      }
 
-        var config = {
-          streaming: {
-            overrides: {
-              forceBeginPlaybackToEndOfWindow: true
-            }
+      var config = {
+        streaming: {
+          overrides: {
+            forceBeginPlaybackToEndOfWindow: true
           }
-        };
+        }
+      };
 
-        beforeEach(function () {
-          jasmine.clock().install();
-          jasmine.clock().mockDate();
+      beforeEach(function () {
+        jasmine.clock().install();
+        jasmine.clock().mockDate();
 
-          mockMediaElement = jasmine.createSpyObj('mediaElement', ['play', 'seek', 'remove', 'stop']);
-          mockMediaElement.style = {};
-          spyOn(document, 'createElement').and.returnValue(mockMediaElement);
-          spyOn(document, 'getElementsByTagName').and.returnValue([jasmine.createSpyObj('body', ['insertBefore'])]);
+        mockMediaElement = jasmine.createSpyObj('mediaElement', ['play', 'seek', 'remove', 'stop']);
+        mockMediaElement.style = {};
+        spyOn(document, 'createElement').and.returnValue(mockMediaElement);
+        spyOn(document, 'getElementsByTagName').and.returnValue([jasmine.createSpyObj('body', ['insertBefore'])]);
 
-          sourceContainer = document.createElement('div');
+        sourceContainer = document.createElement('div');
+
+        recentEvents = [];
+
+        player = CehtmlMediaPlayer(config);
+        player.addEventCallback(this, eventCallbackReporter);
+        player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+      });
+
+      afterEach(function () {
+        jasmine.clock().uninstall();
+      });
+
+      describe('Seek attempted and finished events', function () {
+        it('Seek Attempted Event Emitted On Initialise Media If The State Is Empty', function () {
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
+        });
+
+        it('Seek Finished Event Emitted On Status Update When Time is Within Sentinel Threshold And The State is Playing', function () {
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
+
+          player.beginPlaybackFrom(0);
+
+          mockMediaElement.playState = 4; // BUFFERING
+          mockMediaElement.onPlayStateChange();
+
+          mockMediaElement.playState = 1; // PLAYING
+          mockMediaElement.onPlayStateChange();
+
+          mockMediaElement.playPosition = 0;
+          for (var i = 0; i < 6; i++) {
+            mockMediaElement.playPosition += 500;
+            jasmine.clock().tick(500);
+          }
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
+        });
+
+        it('Seek Finished Event Is Emitted Only Once', function () {
+          player.beginPlaybackFrom(0);
+
+          mockMediaElement.playState = 4; // BUFFERING
+          mockMediaElement.onPlayStateChange();
+
+          mockMediaElement.playState = 1; // PLAYING
+          mockMediaElement.onPlayStateChange();
+
+          mockMediaElement.playPosition = 0;
+          for (var i = 0; i < 6; i++) {
+            mockMediaElement.playPosition += 500;
+            jasmine.clock().tick(500);
+          }
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
 
           recentEvents = [];
+          mockMediaElement.playPosition += 500;
+          jasmine.clock().tick(500);
 
-          player = CehtmlMediaPlayer(config);
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
+        });
+
+        it('Seek Finished Event Is Emitted After restartTimeout When Enabled', function () {
+          var restartTimeoutConfig = {
+            streaming: {
+              overrides: {
+                forceBeginPlaybackToEndOfWindow: true
+              }
+            },
+            restartTimeout: 10000
+          };
+
+          player = CehtmlMediaPlayer(restartTimeoutConfig);
           player.addEventCallback(this, eventCallbackReporter);
           player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-        });
 
-        afterEach(function () {
-          jasmine.clock().uninstall();
-        });
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
 
-        describe('Seek attempted and finished events', function () {
-          it('Seek Attempted Event Emitted On Initialise Media If The State Is Empty', function () {
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
-          });
+          player.beginPlaybackFrom(0);
 
-          it('Seek Finished Event Emitted On Status Update When Time is Within Sentinel Threshold And The State is Playing', function () {
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
+          mockMediaElement.playState = 4; // BUFFERING
+          mockMediaElement.onPlayStateChange();
 
-            player.beginPlaybackFrom(0);
+          mockMediaElement.playState = 1; // PLAYING
+          mockMediaElement.onPlayStateChange();
 
-            mockMediaElement.playState = 4; // BUFFERING
-            mockMediaElement.onPlayStateChange();
-
-            mockMediaElement.playState = 1; // PLAYING
-            mockMediaElement.onPlayStateChange();
-
-            mockMediaElement.playPosition = 0;
-            for (var i = 0; i < 6; i++) {
-              mockMediaElement.playPosition += 500;
-              jasmine.clock().tick(500);
-            }
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
-          });
-
-          it('Seek Finished Event Is Emitted Only Once', function () {
-            player.beginPlaybackFrom(0);
-
-            mockMediaElement.playState = 4; // BUFFERING
-            mockMediaElement.onPlayStateChange();
-
-            mockMediaElement.playState = 1; // PLAYING
-            mockMediaElement.onPlayStateChange();
-
-            mockMediaElement.playPosition = 0;
-            for (var i = 0; i < 6; i++) {
-              mockMediaElement.playPosition += 500;
-              jasmine.clock().tick(500);
-            }
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
-
-            recentEvents = [];
+          mockMediaElement.playPosition = 0;
+          var numberOfLoops = 10000 / 500;
+          for (var i = 0; i < numberOfLoops - 1; i++) {
             mockMediaElement.playPosition += 500;
             jasmine.clock().tick(500);
 
             expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
-          });
+          }
 
-          it('Seek Finished Event Is Emitted After restartTimeout When Enabled', function () {
-            var restartTimeoutConfig = {
-              streaming: {
-                overrides: {
-                  forceBeginPlaybackToEndOfWindow: true
-                }
-              },
-              restartTimeout: 10000
-            };
+          mockMediaElement.playPosition += 1000;
+          jasmine.clock().tick(1000);
 
-            player = CehtmlMediaPlayer(restartTimeoutConfig);
-            player.addEventCallback(this, eventCallbackReporter);
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
+        });
+      });
 
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
+      describe('addEventCallback', function () {
+        it('should call the callback on update', function () {
+          var spy = jasmine.createSpy('callback');
 
-            player.beginPlaybackFrom(0);
+          player.addEventCallback(this, spy);
+          player.beginPlayback();
 
-            mockMediaElement.playState = 4; // BUFFERING
-            mockMediaElement.onPlayStateChange();
+          expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ type: 'buffering' }));
+        });
+      });
 
-            mockMediaElement.playState = 1; // PLAYING
-            mockMediaElement.onPlayStateChange();
+      describe('removeEventCallback', function () {
+        it('should remove the callback', function () {
+          var spy = jasmine.createSpy('callback');
 
-            mockMediaElement.playPosition = 0;
-            var numberOfLoops = 10000 / 500;
-            for (var i = 0; i < numberOfLoops - 1; i++) {
-              mockMediaElement.playPosition += 500;
-              jasmine.clock().tick(500);
+          player.addEventCallback(this, spy);
+          player.removeEventCallback(this, spy);
+          player.beginPlayback();
 
-              expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
-            }
+          expect(spy).not.toHaveBeenCalled();
+        });
+      });
 
-            mockMediaElement.playPosition += 1000;
-            jasmine.clock().tick(1000);
+      describe('removeAllEventCallbacks', function () {
+        it('should remove all the callbacks', function () {
+          var spy = jasmine.createSpy('callback');
 
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
-          });
+          player.addEventCallback(this, spy);
+          player.removeAllEventCallbacks();
+          player.beginPlayback();
+
+          expect(spy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('resume', function () {
+        it('should call through to play if paused', function () {
+          player.beginPlayback();
+          mockMediaElement.playState = 1;
+          mockMediaElement.onPlayStateChange();
+          player.pause();
+
+          mockMediaElement.play.calls.reset();
+
+          expect(mockMediaElement.play).not.toHaveBeenCalled();
+
+          player.resume();
+
+          expect(mockMediaElement.play).toHaveBeenCalledWith(1);
         });
 
-        describe('addEventCallback', function () {
-          it('should call the callback on update', function () {
-            var spy = jasmine.createSpy('callback');
+        it('should do nothing if playing', function () {
+          player.beginPlayback();
+          mockMediaElement.playState = 1;
+          mockMediaElement.onPlayStateChange();
 
-            player.addEventCallback(this, spy);
-            player.beginPlayback();
+          mockMediaElement.play.calls.reset();
 
-            expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ type: 'buffering' }));
-          });
+          player.resume();
+
+          expect(mockMediaElement.play).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('playFrom', function () {
+        it('should seek to the required time', function () {
+          player.beginPlayback();
+          mockMediaElement.playState = 1;
+          mockMediaElement.onPlayStateChange();
+
+          player.playFrom(10);
+
+          expect(mockMediaElement.seek).toHaveBeenCalledWith(10000);
         });
 
-        describe('removeEventCallback', function () {
-          it('should remove the callback', function () {
-            var spy = jasmine.createSpy('callback');
+        it('should clamp to within the seekable range', function () {
+          player.beginPlayback();
+          mockMediaElement.playState = 1;
+          mockMediaElement.playTime = 10000;
+          mockMediaElement.onPlayStateChange();
 
-            player.addEventCallback(this, spy);
-            player.removeEventCallback(this, spy);
-            player.beginPlayback();
+          player.playFrom(1000000000);
 
-            expect(spy).not.toHaveBeenCalled();
-          });
+          expect(mockMediaElement.seek).toHaveBeenCalledWith(8900);
+        });
+      });
+
+      describe('beginPlayback', function () {
+        it('should call play on the media element', function () {
+          player.beginPlayback();
+
+          expect(mockMediaElement.play).toHaveBeenCalledWith(1);
         });
 
-        describe('removeAllEventCallbacks', function () {
-          it('should remove all the callbacks', function () {
-            var spy = jasmine.createSpy('callback');
+        it('should not call play if playing', function () {
+          player.beginPlayback();
 
-            player.addEventCallback(this, spy);
-            player.removeAllEventCallbacks();
-            player.beginPlayback();
+          mockMediaElement.play.calls.reset();
 
-            expect(spy).not.toHaveBeenCalled();
-          });
+          player.beginPlayback();
+
+          expect(mockMediaElement.play).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('beginPlaybackFrom', function () {
+        it('should call play and then seek on the media element', function () {
+          player.beginPlaybackFrom(10);
+          mockMediaElement.playState = 1;
+          mockMediaElement.onPlayStateChange();
+
+          expect(mockMediaElement.play).toHaveBeenCalledWith(1);
+          expect(mockMediaElement.seek).toHaveBeenCalledWith(10000);
         });
 
-        describe('resume', function () {
-          it('should call through to play if paused', function () {
-            player.beginPlayback();
-            mockMediaElement.playState = 1;
-            mockMediaElement.onPlayStateChange();
-            player.pause();
+        it('should call play or seek if playing', function () {
+          player.beginPlaybackFrom(10);
+          mockMediaElement.playState = 1;
+          mockMediaElement.onPlayStateChange();
 
-            mockMediaElement.play.calls.reset();
+          mockMediaElement.play.calls.reset();
+          mockMediaElement.seek.calls.reset();
 
-            expect(mockMediaElement.play).not.toHaveBeenCalled();
+          player.beginPlaybackFrom(10);
 
-            player.resume();
+          expect(mockMediaElement.play).not.toHaveBeenCalledWith();
+          expect(mockMediaElement.seek).not.toHaveBeenCalledWith();
+        });
+      });
 
-            expect(mockMediaElement.play).toHaveBeenCalledWith(1);
-          });
+      describe('pause', function () {
+        it('should call pause on the media element', function () {
+          player.beginPlayback();
+          mockMediaElement.playState = 1;
+          mockMediaElement.onPlayStateChange();
 
-          it('should do nothing if playing', function () {
-            player.beginPlayback();
-            mockMediaElement.playState = 1;
-            mockMediaElement.onPlayStateChange();
+          mockMediaElement.play.calls.reset();
+          player.pause();
 
-            mockMediaElement.play.calls.reset();
-
-            player.resume();
-
-            expect(mockMediaElement.play).not.toHaveBeenCalled();
-          });
+          expect(mockMediaElement.play).toHaveBeenCalledWith(0);
         });
 
-        describe('playFrom', function () {
-          it('should seek to the required time', function () {
-            player.beginPlayback();
-            mockMediaElement.playState = 1;
-            mockMediaElement.onPlayStateChange();
+        it('should not call pause if paused', function () {
+          player.beginPlayback();
+          mockMediaElement.playState = 1;
+          mockMediaElement.onPlayStateChange();
 
-            player.playFrom(10);
+          player.pause();
 
-            expect(mockMediaElement.seek).toHaveBeenCalledWith(10000);
-          });
+          mockMediaElement.play.calls.reset();
+          player.pause();
 
-          it('should clamp to within the seekable range', function () {
-            player.beginPlayback();
-            mockMediaElement.playState = 1;
-            mockMediaElement.playTime = 10000;
-            mockMediaElement.onPlayStateChange();
+          expect(mockMediaElement.play).not.toHaveBeenCalled();
+        });
+      });
 
-            player.playFrom(1000000000);
+      describe('stop', function () {
+        it('should call stop on the media element', function () {
+          player.beginPlayback();
+          player.stop();
 
-            expect(mockMediaElement.seek).toHaveBeenCalledWith(8900);
-          });
+          expect(mockMediaElement.stop).toHaveBeenCalledWith();
         });
 
-        describe('beginPlayback', function () {
-          it('should call play on the media element', function () {
-            player.beginPlayback();
+        it('should not call stop if playback has not started', function () {
+          player.stop();
 
-            expect(mockMediaElement.play).toHaveBeenCalledWith(1);
-          });
-
-          it('should not call play if playing', function () {
-            player.beginPlayback();
-
-            mockMediaElement.play.calls.reset();
-
-            player.beginPlayback();
-
-            expect(mockMediaElement.play).not.toHaveBeenCalled();
-          });
+          expect(mockMediaElement.stop).not.toHaveBeenCalled();
         });
 
-        describe('beginPlaybackFrom', function () {
-          it('should call play and then seek on the media element', function () {
-            player.beginPlaybackFrom(10);
-            mockMediaElement.playState = 1;
-            mockMediaElement.onPlayStateChange();
+        it('should not call stop if already stopped', function () {
+          player.beginPlayback();
+          player.stop();
 
-            expect(mockMediaElement.play).toHaveBeenCalledWith(1);
-            expect(mockMediaElement.seek).toHaveBeenCalledWith(10000);
-          });
+          mockMediaElement.stop.calls.reset();
+          player.stop();
 
-          it('should call play or seek if playing', function () {
-            player.beginPlaybackFrom(10);
-            mockMediaElement.playState = 1;
-            mockMediaElement.onPlayStateChange();
+          expect(mockMediaElement.stop).not.toHaveBeenCalled();
+        });
+      });
 
-            mockMediaElement.play.calls.reset();
-            mockMediaElement.seek.calls.reset();
+      describe('getSource', function () {
+        it('should return the source', function () {
+          expect(player.getSource()).toBe('testUrl');
+        });
+      });
 
-            player.beginPlaybackFrom(10);
+      describe('getMimeType', function () {
+        it('should return the mimeType', function () {
+          expect(player.getMimeType()).toBe('testMimeType');
+        });
+      });
 
-            expect(mockMediaElement.play).not.toHaveBeenCalledWith();
-            expect(mockMediaElement.seek).not.toHaveBeenCalledWith();
-          });
+      describe('getSeekableRange', function () {
+        it('should return the seekable range', function () {
+          player.beginPlayback();
+          mockMediaElement.playState = 1;
+          mockMediaElement.playTime = 10000;
+          mockMediaElement.onPlayStateChange();
+
+          expect(player.getSeekableRange()).toEqual({start: 0, end: 10});
+        });
+      });
+
+      describe('getMediaDuration', function () {
+        it('should return the media duration', function () {
+          player.beginPlayback();
+          mockMediaElement.playState = 1;
+          mockMediaElement.playTime = 10000;
+          mockMediaElement.onPlayStateChange();
+
+          expect(player.getMediaDuration()).toEqual(10);
+        });
+      });
+
+      describe('getState', function () {
+        it('should return the state', function () {
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
+          player.beginPlayback();
+          mockMediaElement.playState = 1;
+          mockMediaElement.onPlayStateChange();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+        });
+      });
+
+      describe('getPlayerElement', function () {
+        it('should return the media element', function () {
+          expect(player.getPlayerElement()).toBe(mockMediaElement);
+        });
+      });
+
+      describe('getDuration', function () {
+        it('should retrun the media duration for vod', function () {
+          player.beginPlayback();
+          mockMediaElement.playState = 1;
+          mockMediaElement.playTime = 10000;
+          mockMediaElement.onPlayStateChange();
+
+          expect(player.getDuration()).toBe(10);
         });
 
-        describe('pause', function () {
-          it('should call pause on the media element', function () {
-            player.beginPlayback();
-            mockMediaElement.playState = 1;
-            mockMediaElement.onPlayStateChange();
+        it('should retrun the inifinty for live', function () {
+          player.reset();
+          player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+          player.beginPlayback();
+          mockMediaElement.playState = 1;
+          mockMediaElement.playTime = 10000;
+          mockMediaElement.onPlayStateChange();
 
-            mockMediaElement.play.calls.reset();
-            player.pause();
-
-            expect(mockMediaElement.play).toHaveBeenCalledWith(0);
-          });
-
-          it('should not call pause if paused', function () {
-            player.beginPlayback();
-            mockMediaElement.playState = 1;
-            mockMediaElement.onPlayStateChange();
-
-            player.pause();
-
-            mockMediaElement.play.calls.reset();
-            player.pause();
-
-            expect(mockMediaElement.play).not.toHaveBeenCalled();
-          });
-        });
-
-        describe('stop', function () {
-          it('should call stop on the media element', function () {
-            player.beginPlayback();
-            player.stop();
-
-            expect(mockMediaElement.stop).toHaveBeenCalledWith();
-          });
-
-          it('should not call stop if playback has not started', function () {
-            player.stop();
-
-            expect(mockMediaElement.stop).not.toHaveBeenCalled();
-          });
-
-          it('should not call stop if already stopped', function () {
-            player.beginPlayback();
-            player.stop();
-
-            mockMediaElement.stop.calls.reset();
-            player.stop();
-
-            expect(mockMediaElement.stop).not.toHaveBeenCalled();
-          });
-        });
-
-        describe('getSource', function () {
-          it('should return the source', function () {
-            expect(player.getSource()).toBe('testUrl');
-          });
-        });
-
-        describe('getMimeType', function () {
-          it('should return the mimeType', function () {
-            expect(player.getMimeType()).toBe('testMimeType');
-          });
-        });
-
-        describe('getSeekableRange', function () {
-          it('should return the seekable range', function () {
-            player.beginPlayback();
-            mockMediaElement.playState = 1;
-            mockMediaElement.playTime = 10000;
-            mockMediaElement.onPlayStateChange();
-
-            expect(player.getSeekableRange()).toEqual({start: 0, end: 10});
-          });
-        });
-
-        describe('getMediaDuration', function () {
-          it('should return the media duration', function () {
-            player.beginPlayback();
-            mockMediaElement.playState = 1;
-            mockMediaElement.playTime = 10000;
-            mockMediaElement.onPlayStateChange();
-
-            expect(player.getMediaDuration()).toEqual(10);
-          });
-        });
-
-        describe('getState', function () {
-          it('should return the state', function () {
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
-            player.beginPlayback();
-            mockMediaElement.playState = 1;
-            mockMediaElement.onPlayStateChange();
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-          });
-        });
-
-        describe('getPlayerElement', function () {
-          it('should return the media element', function () {
-            expect(player.getPlayerElement()).toBe(mockMediaElement);
-          });
-        });
-
-        describe('getDuration', function () {
-          it('should retrun the media duration for vod', function () {
-            player.beginPlayback();
-            mockMediaElement.playState = 1;
-            mockMediaElement.playTime = 10000;
-            mockMediaElement.onPlayStateChange();
-
-            expect(player.getDuration()).toBe(10);
-          });
-
-          it('should retrun the inifinty for live', function () {
-            player.reset();
-            player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-            player.beginPlayback();
-            mockMediaElement.playState = 1;
-            mockMediaElement.playTime = 10000;
-            mockMediaElement.onPlayStateChange();
-
-            expect(player.getDuration()).toBe(Infinity);
-          });
+          expect(player.getDuration()).toBe(Infinity);
         });
       });
     });
+  });

--- a/script-test/playbackstrategies/modifiers/html5tests.js
+++ b/script-test/playbackstrategies/modifiers/html5tests.js
@@ -3,41 +3,31 @@ require(
     'bigscreenplayer/playbackstrategy/modifiers/html5',
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
   ],
-    function (Html5MediaPlayer, MediaPlayerBase) {
-      describe('HTML5 Base', function () {
-        var sourceContainer;
-        var player;
-        var mockSourceElement;
-        var mockVideoMediaElement;
-        var mockAudioMediaElement;
-        var metaDataCallback;
-        var finishedBufferingCallback;
-        var errorCallback;
-        var endedCallback;
-        var timeupdateCallback;
-        var waitingCallback;
-        var playingCallback;
+  function (Html5MediaPlayer, MediaPlayerBase) {
+    describe('HTML5 Base', function () {
+      var sourceContainer;
+      var player;
+      var mockSourceElement;
+      var mockVideoMediaElement;
+      var mockAudioMediaElement;
+      var metaDataCallback;
+      var finishedBufferingCallback;
+      var errorCallback;
+      var endedCallback;
+      var timeupdateCallback;
+      var waitingCallback;
+      var playingCallback;
 
-        var recentEvents;
+      var recentEvents;
 
-        function eventCallbackReporter (event) {
-          recentEvents.push(event.type);
-        }
+      function eventCallbackReporter (event) {
+        recentEvents.push(event.type);
+      }
 
-        function giveMediaElementMetaData (mediaElement, metadata) {
-          try {
-            spyOnProperty(mediaElement, 'seekable').and.returnValue(
-              {
-                start: function () {
-                  return metadata.start;
-                },
-                end: function () {
-                  return metadata.end;
-                },
-                length: 2
-              });
-          } catch (ex) {
-            mediaElement.seekable = {
+      function giveMediaElementMetaData (mediaElement, metadata) {
+        try {
+          spyOnProperty(mediaElement, 'seekable').and.returnValue(
+            {
               start: function () {
                 return metadata.start;
               },
@@ -45,3126 +35,3136 @@ require(
                 return metadata.end;
               },
               length: 2
-            };
-          }
-        }
-
-        function createPlayer (config) {
-          player = Html5MediaPlayer(config);
-          spyOn(player, 'toPaused').and.callThrough();
-
-          player.addEventCallback(this, eventCallbackReporter);
-        }
-
-        beforeEach(function (done) {
-          var config = {
-            streaming: {
-              overrides: {
-                forceBeginPlaybackToEndOfWindow: true
-              }
-            }
+            });
+        } catch (ex) {
+          mediaElement.seekable = {
+            start: function () {
+              return metadata.start;
+            },
+            end: function () {
+              return metadata.end;
+            },
+            length: 2
           };
-          mockSourceElement = document.createElement('source');
-          mockVideoMediaElement = document.createElement('video');
-          mockAudioMediaElement = document.createElement('audio');
-          sourceContainer = document.createElement('div');
-          recentEvents = [];
+        }
+      }
 
-          spyOn(document, 'createElement').and.callFake(function (type) {
-            if (type === 'source') {
-              return mockSourceElement;
-            } else if (type === 'video') {
-              return mockVideoMediaElement;
-            } else {
-              return mockAudioMediaElement;
+      function createPlayer (config) {
+        player = Html5MediaPlayer(config);
+        spyOn(player, 'toPaused').and.callThrough();
+
+        player.addEventCallback(this, eventCallbackReporter);
+      }
+
+      beforeEach(function (done) {
+        var config = {
+          streaming: {
+            overrides: {
+              forceBeginPlaybackToEndOfWindow: true
             }
-          });
+          }
+        };
+        mockSourceElement = document.createElement('source');
+        mockVideoMediaElement = document.createElement('video');
+        mockAudioMediaElement = document.createElement('audio');
+        sourceContainer = document.createElement('div');
+        recentEvents = [];
 
-          spyOn(mockVideoMediaElement, 'addEventListener').and.callFake(function (name, methodCall) {
-            if (name === 'loadedmetadata') {
-              metaDataCallback = methodCall;
-            } else if (name === 'canplay') {
-              finishedBufferingCallback = methodCall;
-            } else if (name === 'error') {
-              errorCallback = methodCall;
-            } else if (name === 'ended') {
-              endedCallback = methodCall;
-            } else if (name === 'waiting') {
-              waitingCallback = methodCall;
-            } else if (name === 'playing') {
-              playingCallback = methodCall;
-            } else if (name === 'timeupdate') {
-              timeupdateCallback = methodCall;
-            }
-          });
-
-          spyOn(mockAudioMediaElement, 'addEventListener').and.callFake(function (name, methodCall) {
-            if (name === 'loadedmetadata') {
-              metaDataCallback = methodCall;
-            } else if (name === 'canplay') {
-              finishedBufferingCallback = methodCall;
-            } else if (name === 'error') {
-              errorCallback = methodCall;
-            } else if (name === 'ended') {
-              endedCallback = methodCall;
-            } else if (name === 'waiting') {
-              waitingCallback = methodCall;
-            }
-          });
-
-          spyOn(mockVideoMediaElement, 'play');
-          spyOn(mockVideoMediaElement, 'load');
-          spyOn(mockVideoMediaElement, 'pause');
-
-          createPlayer(config);
-          done();
+        spyOn(document, 'createElement').and.callFake(function (type) {
+          if (type === 'source') {
+            return mockSourceElement;
+          } else if (type === 'video') {
+            return mockVideoMediaElement;
+          } else {
+            return mockAudioMediaElement;
+          }
         });
 
-        describe('Media Player Common Tests', function () {
-          describe('Empty State Tests', function () {
-            it('Get Source Returns Undefined In Empty State', function () {
-              expect(player.getSource()).toBe(undefined);
-            });
-
-            it('Get Mime Type Returns Undefined In Empty State', function () {
-              expect(player.getMimeType()).toBe(undefined);
-            });
-
-            it('Get Current Time Returns Undefined In Empty State', function () {
-              expect(player.getCurrentTime()).toBe(undefined);
-            });
-
-            it('Get Seekable Range Returns Undefined In Empty State', function () {
-              expect(player.getSeekableRange()).toBe(undefined);
-            });
-
-            it('Get Duration Returns Undefined In Empty State', function () {
-              expect(player.getDuration()).toBe(undefined);
-            });
-
-            it('Get Source Returns Undefined In Empty State After Reset', function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-              metaDataCallback();
-              finishedBufferingCallback();
-
-              player.reset();
-
-              expect(player.getSource()).toBe(undefined);
-            });
-
-            it('Get Mime Type Returns Undefined In Empty State After Reset', function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-              metaDataCallback();
-              finishedBufferingCallback();
-
-              player.reset();
-
-              expect(player.getMimeType()).toBe(undefined);
-            });
-
-            it('Get Current Time Returns Undefined In Empty State After Reset', function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-              metaDataCallback();
-              finishedBufferingCallback();
-
-              player.reset();
-
-              expect(player.getCurrentTime()).toBe(undefined);
-            });
-
-            it('Get Seekable Range Returns Undefined In Empty State After Reset', function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-              metaDataCallback();
-              finishedBufferingCallback();
-
-              player.reset();
-
-              expect(player.getSeekableRange()).toBe(undefined);
-            });
-
-            it('Get Duration Returns Undefined In Empty State After Reset', function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-              metaDataCallback();
-              finishedBufferingCallback();
-
-              player.reset();
-
-              expect(player.getDuration()).toBe(undefined);
-            });
-
-            it('Calling Begin Playback In Empty State Is An Error', function () {
-              player.beginPlayback();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Begin Playback From In Empty State Is An Error', function () {
-              player.beginPlaybackFrom();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Pause In Empty State Is An Error', function () {
-              player.pause();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Resume In Empty State Is An Error', function () {
-              player.resume();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Stop In Empty State Is An Error', function () {
-              player.stop();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Initialise Media In Empty State Goes To Stopped State', function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
-            });
-
-            it('Calling Reset In Empty State Stays In Empty State', function () {
-              player.reset();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.EMPTY);
-            });
-          });
-
-          describe('Stopped state tests', function () {
-            beforeEach(function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-              recentEvents = [];
-            });
-
-            it('Get Source Returns Correct Value In Stopped State', function () {
-              expect(player.getSource()).toEqual('testUrl');
-            });
-
-            it('Get Mime Type Returns Correct Value In Stopped State', function () {
-              expect(player.getMimeType()).toEqual('testMimeType');
-            });
-
-            it('Get Current Time Returns Undefined In Stopped State', function () {
-              expect(player.getCurrentTime()).toEqual(undefined);
-            });
-
-            it('Get Seekable Range Returns Undefined In Stopped State', function () {
-              expect(player.getSeekableRange()).toEqual(undefined);
-            });
-
-            it('Get Duration Returns Undefined In Stopped State', function () {
-              expect(player.getDuration()).toEqual(undefined);
-            });
-
-            it('Calling Initialise Media In Stopped State Is An Error', function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Play From In Stopped State Is An Error', function () {
-              player.playFrom();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Pause In Stopped State Is An Error', function () {
-              player.pause();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Resume In Stopped State Is An Error', function () {
-              player.resume();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Send Meta Data In Stopped State Stays In Stopped State', function () {
-              metaDataCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
-            });
-
-            it('Finish Buffering In Stopped State Stays In Stopped State', function () {
-              finishedBufferingCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
-            });
-
-            it('Start Buffering In Stopped State Stays In Stopped State', function () {
-              waitingCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
-            });
-
-            it('Player Error In Stopped State Gets Reported', function () {
-              spyOnProperty(mockVideoMediaElement, 'error').and.returnValue({code: 'test'});
-              errorCallback({type: 'testError'});
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Time Passing Does Not Cause Status Event To Be Sent In Stopped State', function () {
-              mockVideoMediaElement.currentTime += 1;
-
-              expect(recentEvents).toEqual([]);
-            });
-
-            it('Calling Reset In Stopped State Goes To Empty State', function () {
-              player.reset();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.EMPTY);
-            });
-
-            it('Calling Begin Playback From In Stopped State Goes To Buffering State', function () {
-              player.beginPlaybackFrom();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-            });
-
-            it('Finish Buffering Then Begin Playback From In Stopped State Goes To Buffering', function () {
-              finishedBufferingCallback();
-
-              player.beginPlaybackFrom();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-            });
-
-            it('Calling Begin Playback In Stopped State Goes To Buffering State', function () {
-              player.beginPlayback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-            });
-
-            it('Calling Stop In Stopped State Stays In Stopped State', function () {
-              player.stop();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
-            });
-          });
-
-          describe('Buffering state tests', function () {
-            beforeEach(function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-              player.beginPlaybackFrom(0);
-              recentEvents = [];
-            });
-
-            it('Get Source Returns Expected Value In Buffering State', function () {
-              expect(player.getSource()).toEqual('testUrl');
-            });
-
-            it('Get Mime Type Returns Expected Value In Buffering State', function () {
-              expect(player.getMimeType()).toEqual('testMimeType');
-            });
-
-            it('Calling Initialise Media In Buffering State Is An Error', function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Begin Playback In Buffering State Is An Error', function () {
-              player.beginPlayback();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Begin Playback From In Buffering State Is An Error', function () {
-              player.beginPlaybackFrom();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Reset In Buffering State Is An Error', function () {
-              player.reset();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Send Meta Data In Buffering State Stays In Buffering State', function () {
-              metaDataCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-            });
-
-            it('Start Buffering In Buffering State Stays In Buffering State', function () {
-              waitingCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-            });
-
-            it('Device Error In Buffering State Gets Reported', function () {
-              spyOnProperty(mockVideoMediaElement, 'error').and.returnValue({code: 'test'});
-              errorCallback();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Time Passing Does Not Cause Status Event To Be Sent In Buffering State', function () {
-              mockVideoMediaElement.currentTime += 1;
-
-              expect(recentEvents).toEqual([]);
-            });
-
-            it('When Buffering Finishes And No Further Api Calls Then We Go To Playing State', function () {
-              finishedBufferingCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-            });
-
-            it('When Pause Called And Buffering Finishes Then We Go To Paused State', function () {
-              player.pause();
-
-              finishedBufferingCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            });
-
-            it('When Pause Then Resume Called Before Buffering Finishes Then We Go To Playing State', function () {
-              player.pause();
-              player.resume();
-
-              finishedBufferingCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-            });
-
-            it('When Begin Playback From Middle Of Media And Buffering Finishes Then We Go To Playing From Specified Point', function () {
-              player.stop();
-              player.beginPlaybackFrom(20);
-
-              finishedBufferingCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-              expect(mockVideoMediaElement.currentTime).toEqual(20);
-            });
-
-            it('Calling Stop In Buffering State Goes To Stopped State', function () {
-              player.stop();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
-            });
-
-            it('Device Buffering Notification In Buffering State Does Not Emit Second Buffering Event', function () {
-              waitingCallback();
-
-              expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.BUFFERING);
-            });
-          });
-
-          describe('Playing State Tests', function () {
-            beforeEach(function () {
-              spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-              player.beginPlaybackFrom(0);
-              finishedBufferingCallback();
-              metaDataCallback();
-
-              jasmine.clock().install();
-            });
-
-            afterEach(function () {
-              jasmine.clock().uninstall();
-              player = null;
-            });
-
-            it('Get Source Returns Expected Value In Playing State', function () {
-              expect(player.getSource()).toEqual('testUrl');
-            });
-
-            it('Get Mime Type Returns Expected Value In Playing State', function () {
-              expect(player.getMimeType()).toEqual('testMimeType');
-            });
-
-            it('Get Current Time Returns Expected Value In Playing State', function () {
-              expect(player.getCurrentTime()).toEqual(0);
-            });
-
-            it('Get Seekable Range Returns Expected Value In Playing State', function () {
-              expect(player.getSeekableRange()).toEqual({ start: 0, end: 100 });
-            });
-
-            it('Get Duration Returns Expected Value In Playing State', function () {
-              expect(player.getDuration()).toEqual(100);
-            });
-
-            it('Calling Begin Playback In Playing State Is An Error', function () {
-              player.beginPlayback();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Begin Playback From In Playing State Is An Error', function () {
-              player.beginPlaybackFrom();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Initialise Media In Playing State Is An Error', function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Reset In Playing State Is An Error', function () {
-              player.reset();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Send Meta Data In Playing State Stays In Playing State', function () {
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-
-              metaDataCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-            });
-
-            it('Finish Buffering In Playing State Stays In Playing State', function () {
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-
-              finishedBufferingCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-            });
-
-            it('Device Error In Playing State Gets Reported', function () {
-              spyOnProperty(mockVideoMediaElement, 'error').and.returnValue({code: 'testError'});
-
-              errorCallback();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('When Call Resume While Already Playing Then Remain In Play State', function () {
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-
-              player.resume();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-            });
-
-            it('When Call Play From While Playing Goes To Buffering State', function () {
-              player.playFrom(90);
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-            });
-
-            it('When Calling Pause While Playing Goes To Paused State', function () {
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-
-              player.pause();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            });
-
-            it('When Media Finishes When Playing Then Goes To Complete State', function () {
-              giveMediaElementMetaData(mockVideoMediaElement, {start: 1, end: 99});
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-
-              mockVideoMediaElement.currentTime = 100;
-              endedCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.COMPLETE);
-            });
-
-            it('When Buffering Starts While Playing Goes To Buffering State', function () {
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-
-              waitingCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-            });
-
-            it('Get Regular Status Event When Playing', function () {
-              timeupdateCallback();
-              jasmine.clock().tick(1000);
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.STATUS);
-
-              recentEvents = [];
-              timeupdateCallback();
-              jasmine.clock().tick(1000);
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.STATUS);
-
-              recentEvents = [];
-              timeupdateCallback();
-              jasmine.clock().tick(1000);
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.STATUS);
-            });
-
-            it('Get Duration Returns Infinity With A Live Video Stream', function () {
-              player.stop();
-              player.reset();
-              player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-              player.beginPlaybackFrom(0);
-              finishedBufferingCallback();
-              metaDataCallback();
-
-              var actualDurations = [0, 'foo', undefined, null, Infinity, 360];
-              for (var i = 0; i < actualDurations.length; i++) {
-                giveMediaElementMetaData(mockVideoMediaElement, { start: 0, end: actualDurations[i] });
-
-                expect(player.getDuration()).toEqual(Infinity);
-              }
-            });
-
-            it('Get Duration Returns Infinity With A Live Audio Stream', function () {
-              player.stop();
-              player.reset();
-              player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_AUDIO, 'testUrl', 'testMimeType', sourceContainer, {});
-              player.beginPlaybackFrom(0);
-              finishedBufferingCallback();
-              metaDataCallback();
-
-              var actualDurations = [0, 'foo', undefined, null, Infinity, 360];
-              for (var i = 0; i < actualDurations.length; i++) {
-                giveMediaElementMetaData(mockAudioMediaElement, { start: 0, end: actualDurations[i] });
-
-                expect(player.getDuration()).toEqual(Infinity);
-              }
-            });
-          });
-
-          describe('Paused state tests', function () {
-            beforeEach(function () {
-              spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-              spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-                start: function () { return 0; },
-                end: function () { return 100; },
-                length: 2
-              });
-
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-              player.beginPlaybackFrom(0);
-              finishedBufferingCallback();
-              metaDataCallback();
-              player.pause();
-
-              jasmine.clock().install();
-            });
-
-            afterEach(function () {
-              jasmine.clock().uninstall();
-              recentEvents = [];
-            });
-
-            it('Get Source Returns Expected Value In Paused State', function () {
-              expect(player.getSource()).toEqual('testUrl');
-            });
-
-            it('Get Mime Type Returns Expected Value In Paused State', function () {
-              expect(player.getMimeType()).toEqual('testMimeType');
-            });
-
-            it('Get Current Time Returns Expected Value In Paused State', function () {
-              expect(player.getCurrentTime()).toEqual(0);
-            });
-
-            it('Get Seekable Range Returns Expected Value In Paused State', function () {
-              expect(player.getSeekableRange()).toEqual({start: 0, end: 100});
-            });
-
-            it('Get Duration Returns Expected Value In Paused State', function () {
-              expect(player.getDuration()).toEqual(100);
-            });
-
-            it('Calling Begin Playback In Paused State Is An Error', function () {
-              player.beginPlayback();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Begin Playback From In Paused State Is An Error', function () {
-              player.beginPlaybackFrom();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Initialise Media In Paused State Is An Error', function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Calling Reset In Paused State Is An Error', function () {
-              player.reset();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Send Meta Data In Paused State Stays In Paused State', function () {
-              metaDataCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            });
-
-            it('Finish Buffering In Paused State Stays In Paused State', function () {
-              finishedBufferingCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            });
-
-            it('Start Buffering In Paused State Stays In Paused State', function () {
-              waitingCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            });
-
-            it('Device Error In Paused State Gets Reported', function () {
-              spyOnProperty(mockVideoMediaElement, 'error').and.returnValue({code: 'testError'});
-
-              errorCallback();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-            });
-
-            it('Time Passing Does Not Cause Status Event To Be Sent In Paused State', function () {
-              jasmine.clock().tick(10000);
-
-              expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.STATUS);
-            });
-
-            it('When Calling Resume While Paused Goes To Playing State', function () {
-              player.resume();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-            });
-
-            it('When Call Play From While Paused Goes To Buffering State', function () {
-              player.playFrom(90);
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-            });
-
-            it('When Call Pause While Already Paused Then Remain In Paused State', function () {
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-
-              player.pause();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            }
-            );
-
-            it('When Calling Stop While Paused Goes To Stopped State', function () {
-              player.stop();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
-            });
-          });
-
-          describe('Complete state tests', function () {
-            beforeEach(function () {
-              spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-              spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-                start: function () { return 0; },
-                end: function () { return 100; },
-                length: 2
-              });
-
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-              player.beginPlaybackFrom(0);
-              finishedBufferingCallback();
-              metaDataCallback();
-              mockVideoMediaElement.currentTime = 100;
-              endedCallback();
-
-              jasmine.clock().install();
-            });
-
-            afterEach(function () {
-              jasmine.clock().uninstall();
-            });
-
-            it('Get Source Returns Expected Value In Complete State', function () {
-              expect(player.getSource()).toEqual('testUrl');
-            });
-
-            it('Get Mime Type Returns Expected Value In Complete State', function () {
-              expect(player.getMimeType()).toEqual('testMimeType');
-            });
-
-            it('Get Seekable Range Returns Expected Value In Complete State', function () {
-              expect(player.getSeekableRange()).toEqual({ start: 0, end: 100 });
-            });
-
-            it('Get Duration Returns Expected Value In Complete State', function () {
-              expect(player.getDuration()).toEqual(100);
-            });
-
-            it('Get Current Time Returns Expected Value In Complete State', function () {
-              expect(player.getCurrentTime()).toEqual(100);
-            });
-
-            it('Calling Begin Playback In Complete State Is An Error', function () {
-              player.beginPlayback();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-
-            it('Calling Begin Playback From In Complete State Is An Error', function () {
-              player.beginPlaybackFrom();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-
-            it('Calling Initialise Media From In Complete State Is An Error', function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-
-            it('Calling Pause From In Complete State Is An Error', function () {
-              player.pause();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-
-            it('Calling Resume From In Complete State Is An Error', function () {
-              player.resume();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-
-            it('Calling Reset From In Complete State Is An Error', function () {
-              player.reset();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            }
-            );
-
-            it('Send Meta Data In Complete State Stays In Complete State', function () {
-              var previousState = player.getState();
-
-              metaDataCallback();
-
-              expect(player.getState()).toEqual(previousState);
-            });
-
-            it('Finish Buffering In Complete State Stays In Complete State', function () {
-              var previousState = player.getState();
-
-              finishedBufferingCallback();
-
-              expect(player.getState()).toEqual(previousState);
-            });
-
-            it('Start Buffering In Complete State Stays In Complete State', function () {
-              var previousState = player.getState();
-
-              waitingCallback();
-
-              expect(player.getState()).toEqual(previousState);
-            });
-
-            it('Time Passing Does Not Cause Status Event To Be Sent In Complete State', function () {
-              timeupdateCallback();
-              jasmine.clock().tick();
-
-              expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.STATUS);
-            });
-
-            it('When Call Play From While Complete Goes To Buffering State', function () {
-              player.playFrom(90);
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-            });
-
-            it('Calling Stop In Complete State Goes To Stopped State', function () {
-              player.stop();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
-            });
-          });
-
-          describe('Error state tests', function () {
-            beforeEach(function () {
-              spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-              spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-                start: function () { return 0; },
-                end: function () { return 100; },
-                length: 2
-              });
-              spyOnProperty(mockVideoMediaElement, 'error').and.returnValue({code: 'testError'});
-
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-              player.beginPlaybackFrom(0);
-              finishedBufferingCallback();
-              metaDataCallback();
-              mockVideoMediaElement.currentTime = 100;
-              player.reset();
-
-              recentEvents = [];
-              jasmine.clock().install();
-            });
-
-            afterEach(function () {
-              jasmine.clock().uninstall();
-            });
-
-            it('Get Source Returns Undefined In Error State', function () {
-              expect(player.getSource()).toBe(undefined);
-            });
-
-            it('Get Mime Type Returns Undefined In Error State', function () {
-              expect(player.getMimeType()).toBe(undefined);
-            });
-
-            it('Get Seekable Range Returns Undefined In Error State', function () {
-              expect(player.getSeekableRange()).toBe(undefined);
-            });
-
-            it('Get Duration Returns Undefined In Error State', function () {
-              expect(player.getDuration()).toBe(undefined);
-            });
-
-            it('Get Current Time Returns Undefined In Error State', function () {
-              expect(player.getCurrentTime()).toBe(undefined);
-            });
-
-            it('Calling Begin Playback In Error State Is An Error', function () {
-              player.beginPlayback();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-
-            it('Calling Begin Playback From In Error State Is An Error', function () {
-              player.beginPlaybackFrom();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-
-            it('Calling Initialise Media In Error State Is An Error', function () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-
-            it('Calling Play From In Error State Is An Error', function () {
-              player.playFrom();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-
-            it('Calling Pause In Error State Is An Error', function () {
-              player.pause();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-
-            it('Calling Resume In Error State Is An Error', function () {
-              player.resume();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-
-            it('Calling Stop From In Error State Is An Error', function () {
-              player.stop();
-
-              expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-
-            it('Calling Reset In Error State Goes To Empty State', function () {
-              player.reset();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.EMPTY);
-            });
-
-            it('When Buffering Finishes During Error We Continue To Be In Error', function () {
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-
-              metaDataCallback();
-              finishedBufferingCallback();
-
-              expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
-            });
-          });
+        spyOn(mockVideoMediaElement, 'addEventListener').and.callFake(function (name, methodCall) {
+          if (name === 'loadedmetadata') {
+            metaDataCallback = methodCall;
+          } else if (name === 'canplay') {
+            finishedBufferingCallback = methodCall;
+          } else if (name === 'error') {
+            errorCallback = methodCall;
+          } else if (name === 'ended') {
+            endedCallback = methodCall;
+          } else if (name === 'waiting') {
+            waitingCallback = methodCall;
+          } else if (name === 'playing') {
+            playingCallback = methodCall;
+          } else if (name === 'timeupdate') {
+            timeupdateCallback = methodCall;
+          }
         });
 
-        describe('Initialise Media', function () {
-          it('Creates a video element when called with type VIDEO', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, null, null, sourceContainer, {});
-
-            expect(document.createElement).toHaveBeenCalledTimes(2);
-            expect(document.createElement).toHaveBeenCalledWith('video', 'mediaPlayerVideo');
-          });
-
-          it('Creates an audio element when called with type AUDIO', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, null, null, sourceContainer, {});
-
-            expect(document.createElement).toHaveBeenCalledTimes(2);
-            expect(document.createElement).toHaveBeenCalledWith('audio', 'mediaPlayerAudio');
-          });
-
-          it('Creates a video element when called with type LIVE_VIDEO', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, null, null, sourceContainer, {});
-
-            expect(document.createElement).toHaveBeenCalledTimes(2);
-            expect(document.createElement).toHaveBeenCalledWith('video', 'mediaPlayerVideo');
-          });
-
-          it('Creates an audio element when called with type LIVE_AUDIO', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_AUDIO, null, null, sourceContainer, {});
-
-            expect(document.createElement).toHaveBeenCalledTimes(2);
-            expect(document.createElement).toHaveBeenCalledWith('audio', 'mediaPlayerAudio');
-          });
-
-          it('The created video element is passed into the source container', function () {
-            spyOn(sourceContainer, 'appendChild');
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, null, null, sourceContainer, {});
-
-            expect(sourceContainer.appendChild).toHaveBeenCalledWith(mockVideoMediaElement);
-          });
-
-          it('The Audio element is passed into the source container', function () {
-            spyOn(sourceContainer, 'appendChild');
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, null, null, sourceContainer, {});
-
-            expect(sourceContainer.appendChild).toHaveBeenCalledWith(mockAudioMediaElement);
-          });
-
-          it('Source url is present on the source element', function () {
-            var url = 'http://url/';
-
-            spyOn(mockVideoMediaElement, 'appendChild').and.callThrough();
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, url, null, sourceContainer, {});
-
-            expect(mockVideoMediaElement.appendChild).toHaveBeenCalledWith(mockSourceElement);
-            expect(mockVideoMediaElement.children[0].src).toBe(url);
-          });
+        spyOn(mockAudioMediaElement, 'addEventListener').and.callFake(function (name, methodCall) {
+          if (name === 'loadedmetadata') {
+            metaDataCallback = methodCall;
+          } else if (name === 'canplay') {
+            finishedBufferingCallback = methodCall;
+          } else if (name === 'error') {
+            errorCallback = methodCall;
+          } else if (name === 'ended') {
+            endedCallback = methodCall;
+          } else if (name === 'waiting') {
+            waitingCallback = methodCall;
+          }
         });
 
-        describe('Reset and Stop', function () {
-          it('Video is removed from the DOM', function () {
-            spyOn(sourceContainer, 'appendChild').and.callThrough();
-            spyOn(sourceContainer, 'removeChild').and.callThrough();
+        spyOn(mockVideoMediaElement, 'play');
+        spyOn(mockVideoMediaElement, 'load');
+        spyOn(mockVideoMediaElement, 'pause');
 
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, null, null, sourceContainer, {});
+        createPlayer(config);
+        done();
+      });
 
-            expect(sourceContainer.appendChild).toHaveBeenCalledWith(mockVideoMediaElement);
-
-            player.reset();
-
-            expect(sourceContainer.removeChild).toHaveBeenCalledWith(mockVideoMediaElement);
-            expect(sourceContainer.children[0]).not.toBe(mockVideoMediaElement);
+      describe('Media Player Common Tests', function () {
+        describe('Empty State Tests', function () {
+          it('Get Source Returns Undefined In Empty State', function () {
+            expect(player.getSource()).toBe(undefined);
           });
 
-          it('Audio is removed from the DOM', function () {
-            spyOn(sourceContainer, 'appendChild').and.callThrough();
-            spyOn(sourceContainer, 'removeChild').and.callThrough();
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, null, null, sourceContainer, {});
-
-            expect(sourceContainer.appendChild).toHaveBeenCalledWith(mockAudioMediaElement);
-
-            player.reset();
-
-            expect(sourceContainer.removeChild).toHaveBeenCalledWith(mockAudioMediaElement);
-            expect(sourceContainer.children[0]).not.toBe(mockAudioMediaElement);
+          it('Get Mime Type Returns Undefined In Empty State', function () {
+            expect(player.getMimeType()).toBe(undefined);
           });
 
-          it('Source element is removed from the media element', function () {
-            spyOn(mockVideoMediaElement, 'removeChild').and.callThrough();
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, null, null, sourceContainer, {});
-
-            player.reset();
-
-            expect(mockVideoMediaElement.removeChild).toHaveBeenCalledWith(mockSourceElement);
+          it('Get Current Time Returns Undefined In Empty State', function () {
+            expect(player.getCurrentTime()).toBe(undefined);
           });
 
-          it(' Reset Unloads Media Element Source As Per Guidelines', function () {
-                // Guidelines in HTML5 video spec, section 4.8.10.15:
-                // http://www.w3.org/TR/2011/WD-html5-20110405/video.html#best-practices-for-authors-using-media-elements
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            mockVideoMediaElement.load.calls.reset();
-            spyOn(mockVideoMediaElement, 'removeAttribute');
-
-            player.reset();
-
-            expect(mockVideoMediaElement.removeAttribute).toHaveBeenCalledWith('src');
-            expect(mockVideoMediaElement.removeAttribute).toHaveBeenCalledTimes(1);
-            expect(mockVideoMediaElement.load).toHaveBeenCalledTimes(1);
+          it('Get Seekable Range Returns Undefined In Empty State', function () {
+            expect(player.getSeekableRange()).toBe(undefined);
           });
 
-          it(' Calling Stop In Stopped State Does Not Call Pause On The Device', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            player.stop();
-
-            expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
+          it('Get Duration Returns Undefined In Empty State', function () {
+            expect(player.getDuration()).toBe(undefined);
           });
-        });
 
-        describe('seekable range', function () {
-          it('If duration and seekable range is missing get seekable range returns undefined and logs a warning', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
+          it('Get Source Returns Undefined In Empty State After Reset', function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
             metaDataCallback();
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(undefined);
+            finishedBufferingCallback();
 
-            player.beginPlayback();
+            player.reset();
+
+            expect(player.getSource()).toBe(undefined);
+          });
+
+          it('Get Mime Type Returns Undefined In Empty State After Reset', function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+            metaDataCallback();
+            finishedBufferingCallback();
+
+            player.reset();
+
+            expect(player.getMimeType()).toBe(undefined);
+          });
+
+          it('Get Current Time Returns Undefined In Empty State After Reset', function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+            metaDataCallback();
+            finishedBufferingCallback();
+
+            player.reset();
+
+            expect(player.getCurrentTime()).toBe(undefined);
+          });
+
+          it('Get Seekable Range Returns Undefined In Empty State After Reset', function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+            metaDataCallback();
+            finishedBufferingCallback();
+
+            player.reset();
 
             expect(player.getSeekableRange()).toBe(undefined);
           });
 
-          it('Seekable Range Takes Precedence Over Duration On Media Element', function () {
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(60);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
+          it('Get Duration Returns Undefined In Empty State After Reset', function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+            metaDataCallback();
             finishedBufferingCallback();
 
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 10;
-              },
-              end: function () {
-                return 30;
-              },
-              length: 2
-            });
+            player.reset();
 
-            metaDataCallback({start: 10, end: 30});
-
-            expect(player.getSeekableRange()).toEqual({ start: 10, end: 30 });
-            expect(mockVideoMediaElement.duration).toBe(60);
+            expect(player.getDuration()).toBe(undefined);
           });
 
-          it('Seekable Is Not Used Until Metadata Is Set', function () {
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(undefined);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          it('Calling Begin Playback In Empty State Is An Error', function () {
             player.beginPlayback();
 
-            expect(player.getSeekableRange()).toEqual(undefined);
-
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 10;
-              },
-              end: function () {
-                return 30;
-              },
-              length: 2
-            });
-
-            metaDataCallback({start: 10, end: 30});
-
-            expect(player.getSeekableRange()).toEqual({ start: 10, end: 30 });
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
           });
 
-          it(' Get Seekable Range Gets End Time From Duration When No Seekable Property', function () {
-            metaDataCallback();
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(60);
+          it('Calling Begin Playback From In Empty State Is An Error', function () {
+            player.beginPlaybackFrom();
 
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlayback();
-            metaDataCallback({start: 0, end: 30});
-
-            expect(player.getSeekableRange()).toEqual({start: 0, end: 60});
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
           });
 
-          it(' Get Seekable Range Gets End Time From First Time Range In Seekable Property', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
+          it('Calling Pause In Empty State Is An Error', function () {
+            player.pause();
 
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 10;
-              },
-              end: function () {
-                return 30;
-              },
-              length: 2
-            });
-            metaDataCallback({start: 10, end: 30});
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
 
-            expect(player.getSeekableRange()).toEqual({ start: 10, end: 30 });
+          it('Calling Resume In Empty State Is An Error', function () {
+            player.resume();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Calling Stop In Empty State Is An Error', function () {
+            player.stop();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Calling Initialise Media In Empty State Goes To Stopped State', function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
+          });
+
+          it('Calling Reset In Empty State Stays In Empty State', function () {
+            player.reset();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.EMPTY);
           });
         });
 
-        describe('Media Element', function () {
-          it('Video Element Is Full Screen', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            expect(mockVideoMediaElement.style.position).toEqual('absolute');
-            expect(mockVideoMediaElement.style.top).toEqual('0px');
-            expect(mockVideoMediaElement.style.left).toEqual('0px');
-            expect(mockVideoMediaElement.style.width).toEqual('100%');
-            expect(mockVideoMediaElement.style.height).toEqual('100%');
-            expect(mockVideoMediaElement.style.zIndex).toEqual('');
+        describe('Stopped state tests', function () {
+          beforeEach(function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+            recentEvents = [];
           });
 
-          it(' Autoplay Is Turned Off On Media Element Creation', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            expect(mockVideoMediaElement.autoplay).toEqual(false);
+          it('Get Source Returns Correct Value In Stopped State', function () {
+            expect(player.getSource()).toEqual('testUrl');
           });
 
-          it(' Error Event From Media Element Causes Error Log With Code And Error Message In Event', function () {
-            var errorMessage = 'This is a test error';
+          it('Get Mime Type Returns Correct Value In Stopped State', function () {
+            expect(player.getMimeType()).toEqual('testMimeType');
+          });
 
-            spyOnProperty(mockVideoMediaElement, 'error').and.returnValue({code: errorMessage});
+          it('Get Current Time Returns Undefined In Stopped State', function () {
+            expect(player.getCurrentTime()).toEqual(undefined);
+          });
 
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          it('Get Seekable Range Returns Undefined In Stopped State', function () {
+            expect(player.getSeekableRange()).toEqual(undefined);
+          });
+
+          it('Get Duration Returns Undefined In Stopped State', function () {
+            expect(player.getDuration()).toEqual(undefined);
+          });
+
+          it('Calling Initialise Media In Stopped State Is An Error', function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Calling Play From In Stopped State Is An Error', function () {
+            player.playFrom();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Calling Pause In Stopped State Is An Error', function () {
+            player.pause();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Calling Resume In Stopped State Is An Error', function () {
+            player.resume();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Send Meta Data In Stopped State Stays In Stopped State', function () {
+            metaDataCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
+          });
+
+          it('Finish Buffering In Stopped State Stays In Stopped State', function () {
+            finishedBufferingCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
+          });
+
+          it('Start Buffering In Stopped State Stays In Stopped State', function () {
+            waitingCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
+          });
+
+          it('Player Error In Stopped State Gets Reported', function () {
+            spyOnProperty(mockVideoMediaElement, 'error').and.returnValue({code: 'test'});
+            errorCallback({type: 'testError'});
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Time Passing Does Not Cause Status Event To Be Sent In Stopped State', function () {
+            mockVideoMediaElement.currentTime += 1;
+
+            expect(recentEvents).toEqual([]);
+          });
+
+          it('Calling Reset In Stopped State Goes To Empty State', function () {
+            player.reset();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.EMPTY);
+          });
+
+          it('Calling Begin Playback From In Stopped State Goes To Buffering State', function () {
+            player.beginPlaybackFrom();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+          });
+
+          it('Finish Buffering Then Begin Playback From In Stopped State Goes To Buffering', function () {
+            finishedBufferingCallback();
+
+            player.beginPlaybackFrom();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+          });
+
+          it('Calling Begin Playback In Stopped State Goes To Buffering State', function () {
+            player.beginPlayback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+          });
+
+          it('Calling Stop In Stopped State Stays In Stopped State', function () {
+            player.stop();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
+          });
+        });
+
+        describe('Buffering state tests', function () {
+          beforeEach(function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+            player.beginPlaybackFrom(0);
+            recentEvents = [];
+          });
+
+          it('Get Source Returns Expected Value In Buffering State', function () {
+            expect(player.getSource()).toEqual('testUrl');
+          });
+
+          it('Get Mime Type Returns Expected Value In Buffering State', function () {
+            expect(player.getMimeType()).toEqual('testMimeType');
+          });
+
+          it('Calling Initialise Media In Buffering State Is An Error', function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Calling Begin Playback In Buffering State Is An Error', function () {
+            player.beginPlayback();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Calling Begin Playback From In Buffering State Is An Error', function () {
+            player.beginPlaybackFrom();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Calling Reset In Buffering State Is An Error', function () {
+            player.reset();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Send Meta Data In Buffering State Stays In Buffering State', function () {
+            metaDataCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+          });
+
+          it('Start Buffering In Buffering State Stays In Buffering State', function () {
+            waitingCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+          });
+
+          it('Device Error In Buffering State Gets Reported', function () {
+            spyOnProperty(mockVideoMediaElement, 'error').and.returnValue({code: 'test'});
+            errorCallback();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Time Passing Does Not Cause Status Event To Be Sent In Buffering State', function () {
+            mockVideoMediaElement.currentTime += 1;
+
+            expect(recentEvents).toEqual([]);
+          });
+
+          it('When Buffering Finishes And No Further Api Calls Then We Go To Playing State', function () {
+            finishedBufferingCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+          });
+
+          it('When Pause Called And Buffering Finishes Then We Go To Paused State', function () {
+            player.pause();
+
+            finishedBufferingCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+          });
+
+          it('When Pause Then Resume Called Before Buffering Finishes Then We Go To Playing State', function () {
+            player.pause();
+            player.resume();
+
+            finishedBufferingCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+          });
+
+          it('When Begin Playback From Middle Of Media And Buffering Finishes Then We Go To Playing From Specified Point', function () {
+            player.stop();
+            player.beginPlaybackFrom(20);
+
+            finishedBufferingCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+            expect(mockVideoMediaElement.currentTime).toEqual(20);
+          });
+
+          it('Calling Stop In Buffering State Goes To Stopped State', function () {
+            player.stop();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
+          });
+
+          it('Device Buffering Notification In Buffering State Does Not Emit Second Buffering Event', function () {
+            waitingCallback();
+
+            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.BUFFERING);
+          });
+        });
+
+        describe('Playing State Tests', function () {
+          beforeEach(function () {
+            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+            player.beginPlaybackFrom(0);
+            finishedBufferingCallback();
+            metaDataCallback();
+
+            jasmine.clock().install();
+          });
+
+          afterEach(function () {
+            jasmine.clock().uninstall();
+            player = null;
+          });
+
+          it('Get Source Returns Expected Value In Playing State', function () {
+            expect(player.getSource()).toEqual('testUrl');
+          });
+
+          it('Get Mime Type Returns Expected Value In Playing State', function () {
+            expect(player.getMimeType()).toEqual('testMimeType');
+          });
+
+          it('Get Current Time Returns Expected Value In Playing State', function () {
+            expect(player.getCurrentTime()).toEqual(0);
+          });
+
+          it('Get Seekable Range Returns Expected Value In Playing State', function () {
+            expect(player.getSeekableRange()).toEqual({ start: 0, end: 100 });
+          });
+
+          it('Get Duration Returns Expected Value In Playing State', function () {
+            expect(player.getDuration()).toEqual(100);
+          });
+
+          it('Calling Begin Playback In Playing State Is An Error', function () {
+            player.beginPlayback();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Calling Begin Playback From In Playing State Is An Error', function () {
+            player.beginPlaybackFrom();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Calling Initialise Media In Playing State Is An Error', function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Calling Reset In Playing State Is An Error', function () {
+            player.reset();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Send Meta Data In Playing State Stays In Playing State', function () {
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+
+            metaDataCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+          });
+
+          it('Finish Buffering In Playing State Stays In Playing State', function () {
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+
+            finishedBufferingCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+          });
+
+          it('Device Error In Playing State Gets Reported', function () {
+            spyOnProperty(mockVideoMediaElement, 'error').and.returnValue({code: 'testError'});
 
             errorCallback();
 
             expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
           });
 
-          it(' Error Event From Source Element Causes Error Log And Error Message In Event', function () {
-            var sourceError;
-            spyOn(mockSourceElement, 'addEventListener').and.callFake(function (name, methodCall) {
-              if (name === 'error') {
-                sourceError = methodCall;
-              }
+          it('When Call Resume While Already Playing Then Remain In Play State', function () {
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+
+            player.resume();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+          });
+
+          it('When Call Play From While Playing Goes To Buffering State', function () {
+            player.playFrom(90);
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+          });
+
+          it('When Calling Pause While Playing Goes To Paused State', function () {
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+
+            player.pause();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+          });
+
+          it('When Media Finishes When Playing Then Goes To Complete State', function () {
+            giveMediaElementMetaData(mockVideoMediaElement, {start: 1, end: 99});
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+
+            mockVideoMediaElement.currentTime = 100;
+            endedCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.COMPLETE);
+          });
+
+          it('When Buffering Starts While Playing Goes To Buffering State', function () {
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+
+            waitingCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+          });
+
+          it('Get Regular Status Event When Playing', function () {
+            timeupdateCallback();
+            jasmine.clock().tick(1000);
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.STATUS);
+
+            recentEvents = [];
+            timeupdateCallback();
+            jasmine.clock().tick(1000);
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.STATUS);
+
+            recentEvents = [];
+            timeupdateCallback();
+            jasmine.clock().tick(1000);
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.STATUS);
+          });
+
+          it('Get Duration Returns Infinity With A Live Video Stream', function () {
+            player.stop();
+            player.reset();
+            player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+            player.beginPlaybackFrom(0);
+            finishedBufferingCallback();
+            metaDataCallback();
+
+            var actualDurations = [0, 'foo', undefined, null, Infinity, 360];
+            for (var i = 0; i < actualDurations.length; i++) {
+              giveMediaElementMetaData(mockVideoMediaElement, { start: 0, end: actualDurations[i] });
+
+              expect(player.getDuration()).toEqual(Infinity);
+            }
+          });
+
+          it('Get Duration Returns Infinity With A Live Audio Stream', function () {
+            player.stop();
+            player.reset();
+            player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_AUDIO, 'testUrl', 'testMimeType', sourceContainer, {});
+            player.beginPlaybackFrom(0);
+            finishedBufferingCallback();
+            metaDataCallback();
+
+            var actualDurations = [0, 'foo', undefined, null, Infinity, 360];
+            for (var i = 0; i < actualDurations.length; i++) {
+              giveMediaElementMetaData(mockAudioMediaElement, { start: 0, end: actualDurations[i] });
+
+              expect(player.getDuration()).toEqual(Infinity);
+            }
+          });
+        });
+
+        describe('Paused state tests', function () {
+          beforeEach(function () {
+            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+              start: function () { return 0; },
+              end: function () { return 100; },
+              length: 2
             });
 
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+            player.beginPlaybackFrom(0);
+            finishedBufferingCallback();
+            metaDataCallback();
+            player.pause();
 
-            sourceError();
+            jasmine.clock().install();
+          });
+
+          afterEach(function () {
+            jasmine.clock().uninstall();
+            recentEvents = [];
+          });
+
+          it('Get Source Returns Expected Value In Paused State', function () {
+            expect(player.getSource()).toEqual('testUrl');
+          });
+
+          it('Get Mime Type Returns Expected Value In Paused State', function () {
+            expect(player.getMimeType()).toEqual('testMimeType');
+          });
+
+          it('Get Current Time Returns Expected Value In Paused State', function () {
+            expect(player.getCurrentTime()).toEqual(0);
+          });
+
+          it('Get Seekable Range Returns Expected Value In Paused State', function () {
+            expect(player.getSeekableRange()).toEqual({start: 0, end: 100});
+          });
+
+          it('Get Duration Returns Expected Value In Paused State', function () {
+            expect(player.getDuration()).toEqual(100);
+          });
+
+          it('Calling Begin Playback In Paused State Is An Error', function () {
+            player.beginPlayback();
 
             expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
           });
 
-          it(' Pause Passed Through To Media Element When In Playing State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          it('Calling Begin Playback From In Paused State Is An Error', function () {
+            player.beginPlaybackFrom();
 
-            metaDataCallback({});
-
-            player.beginPlayback();
-            player.pause();
-
-            expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
           });
 
-          it(' Pause Not Passed From Media Element To Media Player On User Pause From Buffering', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          it('Calling Initialise Media In Paused State Is An Error', function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
 
-            // We dont fire the metadata ready callback so it stays in the buffering state
-            player.beginPlayback();
-
-            mockVideoMediaElement.pause();
-
-            expect(player.toPaused).toHaveBeenCalledTimes(0);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
           });
 
-          it(' Pause Not Passed From Media Element To Media Player On User Pause From Playing', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          it('Calling Reset In Paused State Is An Error', function () {
+            player.reset();
 
-            metaDataCallback({});
-
-            player.beginPlayback();
-
-            mockVideoMediaElement.pause();
-
-            expect(player.toPaused).toHaveBeenCalledTimes(0);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
           });
 
-          it(' Pause Not Passed From Media Element To Media Player On Stop', function () {
-            // Initialise media terminates in the stopped state
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          it('Send Meta Data In Paused State Stays In Paused State', function () {
+            metaDataCallback();
 
-            mockVideoMediaElement.pause();
-
-            expect(player.toPaused).toHaveBeenCalledTimes(0);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
           });
 
-          it(' Play Called On Media Element When Resume In Paused State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-            player.pause();
-
-            metaDataCallback({});
+          it('Finish Buffering In Paused State Stays In Paused State', function () {
             finishedBufferingCallback();
 
             expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            mockVideoMediaElement.play.calls.reset();
+          });
 
+          it('Start Buffering In Paused State Stays In Paused State', function () {
+            waitingCallback();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+          });
+
+          it('Device Error In Paused State Gets Reported', function () {
+            spyOnProperty(mockVideoMediaElement, 'error').and.returnValue({code: 'testError'});
+
+            errorCallback();
+
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+          });
+
+          it('Time Passing Does Not Cause Status Event To Be Sent In Paused State', function () {
+            jasmine.clock().tick(10000);
+
+            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.STATUS);
+          });
+
+          it('When Calling Resume While Paused Goes To Playing State', function () {
             player.resume();
 
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
           });
 
-          it(' Play Called On Media Element When Resume In Buffering State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
+          it('When Call Play From While Paused Goes To Buffering State', function () {
+            player.playFrom(90);
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+          });
+
+          it('When Call Pause While Already Paused Then Remain In Paused State', function () {
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+
             player.pause();
 
-            metaDataCallback({});
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+          }
+          );
 
-            mockVideoMediaElement.play.calls.reset();
+          it('When Calling Stop While Paused Goes To Stopped State', function () {
+            player.stop();
 
-            player.resume();
-
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
-          });
-
-          it(' Play Not Called On Media Element When Resume In Buffering State Before Metadata', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-            player.pause();
-
-            mockVideoMediaElement.play.calls.reset();
-
-            player.resume();
-
-            expect(mockVideoMediaElement.play).not.toHaveBeenCalled();
-          });
-
-          it(' Pause Passed Through To Media Element When In Buffered State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-            player.pause();
-
-            metaDataCallback({});
-
-            expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
-          });
-
-          it(' Load Called On Media Element When Initialise Media Is Called', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            expect(mockVideoMediaElement.load).toHaveBeenCalledTimes(1);
-          });
-
-          it(' Media Element Preload Attribute Is Set To Auto', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            expect(mockVideoMediaElement.preload).toEqual('auto');
-          });
-
-          it(' Play From Sets Current Time And Calls Play On Media Element When In Playing State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback({});
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.play.calls.reset();
-
-            player.playFrom(10);
-
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
-            expect(mockVideoMediaElement.currentTime).toEqual(10);
-          });
-
-          it(' Get Player Element Returns Video Element For Video', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            expect(player.getPlayerElement()).toEqual(mockVideoMediaElement);
-          });
-
-          it(' Get Player Element Returns Audio Element For Audio', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            expect(player.getPlayerElement()).toEqual(mockAudioMediaElement);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
           });
         });
 
-        describe('Time features', function () {
+        describe('Complete state tests', function () {
           beforeEach(function () {
             spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-            mockVideoMediaElement.play.calls.reset();
-          });
+            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+              start: function () { return 0; },
+              end: function () { return 100; },
+              length: 2
+            });
 
-          it(' Play From Clamps When Called In Playing State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
             player.beginPlaybackFrom(0);
-
-            metaDataCallback({start: 0, end: 100});
             finishedBufferingCallback();
-
-            player.playFrom(110);
-
-            expect(mockVideoMediaElement.currentTime).toEqual(98.9);
-          });
-
-          it(' Play From Sets Current Time And Calls Play On Media Element When In Complete State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            finishedBufferingCallback();
-            metaDataCallback({start: 0, end: 100});
-
-            mockVideoMediaElement.play.calls.reset();
-
-            player.playFrom(10);
-
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
-            expect(mockVideoMediaElement.currentTime).toEqual(10);
-          });
-
-          it(' Play From Sets Current Time And Calls Play On Media Element When In Paused State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            player.pause();
-
-            mockVideoMediaElement.play.calls.reset();
-
-            player.playFrom(10);
-
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
-            expect(mockVideoMediaElement.currentTime).toEqual(10);
-          });
-
-          it(' Begin Playback From After Metadata', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
             metaDataCallback();
+            mockVideoMediaElement.currentTime = 100;
+            endedCallback();
 
-            player.beginPlaybackFrom(50);
-            finishedBufferingCallback();
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+            jasmine.clock().install();
           });
 
-          it(' Get Duration Returns Undefined Before Metadata Is Set', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
+          afterEach(function () {
+            jasmine.clock().uninstall();
+          });
 
-            expect(player.getDuration()).toBe(undefined);
+          it('Get Source Returns Expected Value In Complete State', function () {
+            expect(player.getSource()).toEqual('testUrl');
+          });
 
-            metaDataCallback();
+          it('Get Mime Type Returns Expected Value In Complete State', function () {
+            expect(player.getMimeType()).toEqual('testMimeType');
+          });
 
+          it('Get Seekable Range Returns Expected Value In Complete State', function () {
+            expect(player.getSeekableRange()).toEqual({ start: 0, end: 100 });
+          });
+
+          it('Get Duration Returns Expected Value In Complete State', function () {
             expect(player.getDuration()).toEqual(100);
           });
 
-          it(' Get Duration Returns Device Duration With An On Demand Audio Stream', function () {
-            spyOnProperty(mockAudioMediaElement, 'duration').and.returnValue(100);
+          it('Get Current Time Returns Expected Value In Complete State', function () {
+            expect(player.getCurrentTime()).toEqual(100);
+          });
 
-            player.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, 'http://url/', 'video/mp4', sourceContainer, {});
+          it('Calling Begin Playback In Complete State Is An Error', function () {
             player.beginPlayback();
 
-            metaDataCallback();
-
-            expect(player.getDuration()).toBe(100);
-          });
-        });
-
-        describe('Current Time', function () {
-          it(' Play From Sets Current Time And Calls Play On Media Element When In Stopped State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            player.beginPlaybackFrom(50);
-
-            expect(mockVideoMediaElement.play).not.toHaveBeenCalled();
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-
-            mockVideoMediaElement.play.calls.reset();
-            metaDataCallback({ start: 0, end: 100 });
-
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
-
-            finishedBufferingCallback();
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
 
-          it(' Begin Playback From Sets Current Time And Calls Play On Media Element When In Stopped State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(10);
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
+          it('Calling Begin Playback From In Complete State Is An Error', function () {
+            player.beginPlaybackFrom();
 
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
-            expect(mockVideoMediaElement.currentTime).toEqual(10);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
 
-          it(' Play From Clamps When Called In Stopped State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(110);
+          it('Calling Initialise Media From In Complete State Is An Error', function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
 
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 10;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            metaDataCallback({ start: 10, end: 100 });
-
-            expect(mockVideoMediaElement.currentTime).toEqual(98.9);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
 
-          it(' Play From Then Pause Sets Current Time And Calls Pause On Media Element When In Stopped State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(50);
+          it('Calling Pause From In Complete State Is An Error', function () {
             player.pause();
 
-            expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
-            expect(mockVideoMediaElement.play).not.toHaveBeenCalled();
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 10;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-
-            metaDataCallback({ start: 0, end: 100 });
-
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
-
-            finishedBufferingCallback();
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
 
-          it(' Play From Zero Then Pause Defers Call To Pause On Media Element When In Stopped State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          it('Calling Resume From In Complete State Is An Error', function () {
+            player.resume();
 
-            player.beginPlaybackFrom(0);
-            player.pause();
-
-            expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
 
-          it(' Play From Defers Setting Current Time And Calling Play On Media Element Until We Have Metadata', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            player.beginPlaybackFrom(0);
-            player.playFrom(10);
-
-            expect(mockVideoMediaElement.play).not.toHaveBeenCalled();
-
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 10;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-
-            metaDataCallback({ start: 0, end: 100 });
-
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
-            expect(mockVideoMediaElement.currentTime).toEqual(10);
-          });
-
-          it(' Play From Clamps When Called In Buffering State And Dont Have Metadata', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            player.beginPlaybackFrom(0);
-            player.playFrom(110);
-
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 10;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            metaDataCallback({ start: 0, end: 100 });
-
-            finishedBufferingCallback();
-
-            expect(mockVideoMediaElement.currentTime).toEqual(98.9);
-          });
-
-          it(' Play From Sets Current Time And Calls Play On Media Element When In Buffering State And Has Metadata', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            player.beginPlaybackFrom(0);
-
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 10;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            metaDataCallback({ start: 0, end: 100 });
-
-            mockVideoMediaElement.play.calls.reset();
-
-            player.playFrom(10);
-
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
-            expect(mockVideoMediaElement.currentTime).toEqual(10);
-          });
-
-          it(' Play From Clamps When Called In Buffering State And Has Metadata', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            player.beginPlaybackFrom(0);
-
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 10;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            metaDataCallback({ start: 0, end: 100 });
-
-            player.playFrom(110);
-            finishedBufferingCallback();
-
-            expect(mockVideoMediaElement.currentTime).toEqual(98.9);
-          });
-
-          it(' Play From Current Time When Playing Goes To Buffering Then To Playing', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            player.beginPlaybackFrom(0);
-            metaDataCallback();
-            finishedBufferingCallback();
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-
-            waitingCallback();
-
-            mockVideoMediaElement.currentTime = 20;
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-
-            player.playFrom(30);
-            finishedBufferingCallback();
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-          });
-
-          it(' Play From Just Before Current Time When Playing Goes To Buffering Then To Playing', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            player.beginPlaybackFrom(0);
-            metaDataCallback();
-            finishedBufferingCallback();
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-
-            waitingCallback();
-
-            mockVideoMediaElement.currentTime = 50.999;
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-
-            player.playFrom(50);
-            finishedBufferingCallback();
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-          });
-
-          it(' Begin Playback From Current Time When Played Then Stopped Goes To Buffering Then To Playing', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            metaDataCallback();
-
-            player.beginPlaybackFrom(50);
-
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
-
-            player.stop();
-
-            mockVideoMediaElement.play.calls.reset();
-
-            player.beginPlaybackFrom(50);
-
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-
-            finishedBufferingCallback();
-            mockVideoMediaElement.play();
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-          });
-
-          it(' Play From Current Time When Paused Goes To Buffering Then To Playing', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback();
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.play.calls.reset();
-            mockVideoMediaElement.currentTime = 50;
-
-            player.pause();
-
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-
-            player.playFrom(50);
-
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
-
-            finishedBufferingCallback();
-            mockVideoMediaElement.play();
-
-            expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(2);
-            expect(player.getState()).toEqual(MediaPlayerBase.EVENT.PLAYING.toUpperCase());
-          });
-
-          it(' Begin Playback From Sets Current Time After Finish Buffering But No Metadata', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(50);
-
-            metaDataCallback({ start: 0, end: 100 });
-            finishedBufferingCallback();
-
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
-          });
-
-          it(' Play From Near Current Time Will Not Cause Finish Buffering To Perform Seek Later', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(0);
-
-            mockVideoMediaElement.currentTime = 50;
-            player.playFrom(50.999);
-
-            mockVideoMediaElement.currentTime = 70;
-            finishedBufferingCallback();
-
-            expect(mockVideoMediaElement.currentTime).toEqual(70);
-          });
-        });
-
-        describe('Media Element Stop', function () {
-          it(' Stop When In Buffering State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            player.beginPlaybackFrom(0);
-            player.stop();
-
-            expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
-          });
-
-          it(' Stop When In Playing State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback();
-            finishedBufferingCallback();
-
-            player.stop();
-
-            expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
-          });
-
-          it(' Stop When In Complete State', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback();
-            finishedBufferingCallback();
-
-            endedCallback();
-            player.stop();
-
-            expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
-          });
-
-          it(' Reset Remove All Event Listeners From The Media Element', function () {
-            var listeners = ['canplay', 'seeked', 'playing', 'error', 'ended', 'waiting',
-              'timeupdate', 'loadedMetaData', 'pause'];
-
-            spyOn(mockVideoMediaElement, 'removeEventListener');
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          it('Calling Reset From In Complete State Is An Error', function () {
             player.reset();
 
-            expect(mockVideoMediaElement.removeEventListener).toHaveBeenCalledTimes(listeners.length);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
+          }
+          );
+
+          it('Send Meta Data In Complete State Stays In Complete State', function () {
+            var previousState = player.getState();
+
+            metaDataCallback();
+
+            expect(player.getState()).toEqual(previousState);
           });
 
-          it('Remove all event callbacks works correctly', function () {
-            function playAndEmitAfterRemoveAllCallbacks () {
-              player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-              player.beginPlaybackFrom(0);
-              player.removeAllEventCallbacks();
-              endedCallback();
-            }
+          it('Finish Buffering In Complete State Stays In Complete State', function () {
+            var previousState = player.getState();
 
-            expect(playAndEmitAfterRemoveAllCallbacks).not.toThrowError();
-          });
-        });
+            finishedBufferingCallback();
 
-        describe('Events', function () {
-          beforeEach(function () {
-            jasmine.clock().install();
+            expect(player.getState()).toEqual(previousState);
           });
 
-          afterEach(function () {
-            jasmine.clock().uninstall();
-          });
+          it('Start Buffering In Complete State Stays In Complete State', function () {
+            var previousState = player.getState();
 
-          it(' Waiting Html5 Event While Buffering Only Gives Single Buffering Event', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            player.beginPlaybackFrom(0);
             waitingCallback();
+
+            expect(player.getState()).toEqual(previousState);
+          });
+
+          it('Time Passing Does Not Cause Status Event To Be Sent In Complete State', function () {
+            timeupdateCallback();
+            jasmine.clock().tick();
+
+            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.STATUS);
+          });
+
+          it('When Call Play From While Complete Goes To Buffering State', function () {
+            player.playFrom(90);
 
             expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
           });
 
-          it(' Seek Attempted Event Emitted On Initialise Media If The State Is Empty', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
-          });
-
-          it('Seek Finished Event Emitted On Status Update When Time is Within Sentinel Threshold And The State is Playing', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
-
-            player.beginPlaybackFrom(0);
-            waitingCallback();
-            playingCallback();
-
-            timeupdateCallback();
-            timeupdateCallback();
-            timeupdateCallback();
-            timeupdateCallback();
-            timeupdateCallback();
-            timeupdateCallback();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
-          });
-
-          it('Seek Finished Event Is Emitted Only Once', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
-
-            player.beginPlaybackFrom(0);
-            waitingCallback();
-            playingCallback();
-
-            timeupdateCallback();
-            timeupdateCallback();
-            timeupdateCallback();
-            timeupdateCallback();
-            timeupdateCallback();
-            timeupdateCallback();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
-            recentEvents = [];
-            timeupdateCallback();
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
-          });
-
-          it(' Seek Finished Event Is Emitted After restartTimeout When Enabled', function () {
-            var restartTimeoutConfig = {
-              streaming: {
-                overrides: {
-                  forceBeginPlaybackToEndOfWindow: true
-                }
-              },
-              restartTimeout: 10000
-            };
-
-            createPlayer(restartTimeoutConfig);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
-
-            player.beginPlaybackFrom(0);
-            waitingCallback();
-            playingCallback();
-
-            timeupdateCallback();
-            timeupdateCallback();
-            timeupdateCallback();
-            timeupdateCallback();
-            timeupdateCallback();
-
-            jasmine.clock().tick(10000);
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
-
-            jasmine.clock().tick(1100);
-            timeupdateCallback();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
-          });
-        });
-
-        describe('Sentinels', function () {
-          function waitForSentinels () {
-            jasmine.clock().tick(1100);
-          }
-
-          beforeEach(function () {
-            jasmine.clock().install();
-            jasmine.clock().mockDate();
-          });
-
-          afterEach(function () {
-            jasmine.clock().uninstall();
-          });
-
-          it(' Enter Buffering Sentinel Causes Transition To Buffering When Playback Halts For More Than One Sentinel Iteration Since State Changed', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime += 1;
-            mockVideoMediaElement.currentTime += 1;
-
-            recentEvents = [];
-            waitForSentinels();
-            waitForSentinels();
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.BUFFERING);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-          });
-
-          it(' Enter Buffering Sentinel Not Fired When Sentinels Disabled', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: true});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime += 1;
-            mockVideoMediaElement.currentTime += 1;
-
-            recentEvents = [];
-            waitForSentinels();
-            waitForSentinels();
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-          });
-
-          it(' No Sentinels Activate When Current Time Runs Normally Then Jumps Backwards', function () {
-            var INITIAL_TIME = 30;
-            var SEEK_SENTINEL_TOLERANCE = 15;
-            var AFTER_JUMP_TIME = INITIAL_TIME - (SEEK_SENTINEL_TOLERANCE + 5);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: true});
-            player.beginPlaybackFrom(INITIAL_TIME);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            recentEvents = [];
-
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-
-            mockVideoMediaElement.currentTime = AFTER_JUMP_TIME;
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-          });
-
-          it(' No Sentinels Activate When Current Time Runs Normally Then Jumps Backwards Near End Of Media', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(95);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            recentEvents = [];
-
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-
-            mockVideoMediaElement.currentTime = 100;
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-          });
-
-          it(' Pause Sentinel Activates When Current Time Runs Normally Then Jumps Backwards When Paused', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(10);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-
-            player.pause();
-            recentEvents = [];
-
-            mockVideoMediaElement.currentTime = 0;
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
-          });
-
-          it(' Enter Buffering Sentinel Does Not Activate When Playback Halts When Only One Sentinel Iteration Since State Changed', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(10);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime += 1;
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-          });
-
-          it(' Enter Buffering Sentinel Does Nothing When Playback Is Working', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(10);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime += 1;
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-          });
-
-          it(' Enter Buffering Sentinel Does Nothing When Device Reports Buffering Correctly', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(10);
-
-            waitingCallback();
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-          });
-
-          it(' Enter Buffering Sentinel Does Nothing When Device Is Paused', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(10);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime += 1;
-
-            player.pause();
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-          });
-          function ensureEnterBufferingSentinelIsNotCalledWhenZeroesCannotBeTrusted () {
-            var i;
-            for (i = 0; i < 3; i++) {
-              mockVideoMediaElement.currentTime += 1;
-              waitForSentinels();
-            }
-
-            for (i = 0; i < 2; i++) {
-              mockVideoMediaElement.currentTime = 0;
-              waitForSentinels();
-            }
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-          }
-
-          function ensureEnterBufferingSentinelIsCalledWhenZeroesCanBeTrusted () {
-            for (var i = 0; i < 2; i++) {
-              mockVideoMediaElement.currentTime = 0;
-              waitForSentinels();
-            }
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-          }
-
-          function ForThreeIntervalsOfNormalPlaybackTwoIntervalsOfZeroesAndOneIntervalOfTimeIncreaseBelowSentinelTolerance () {
-            var i;
-
-            for (i = 0; i < 3; i++) {
-              mockVideoMediaElement.currentTime += 1;
-              waitForSentinels();
-            }
-
-            for (i = 0; i < 2; i++) {
-              mockVideoMediaElement.currentTime = 0;
-              waitForSentinels();
-            }
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
-
-            mockVideoMediaElement.currentTime = 0.01;
-            waitForSentinels();
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
-          }
-
-          it(' Enter Buffering Sentinel Does Nothing When Device Time Is Reported As Zero During Playback', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(10);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            recentEvents = [];
-            ensureEnterBufferingSentinelIsNotCalledWhenZeroesCannotBeTrusted();
-          });
-
-          it(' Enter Buffering Sentinel Does Nothing When Begin Playback Is Called And Device Time Is Reported As Zero For At Least Two Intervals', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(20);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            recentEvents = [];
-            ensureEnterBufferingSentinelIsNotCalledWhenZeroesCannotBeTrusted();
-          });
-
-          it(' Enter Buffering Sentinel Fires When Begin Playback From Zero Is Called And Device Time Does Not Advance', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            recentEvents = [];
-            ensureEnterBufferingSentinelIsCalledWhenZeroesCanBeTrusted();
-          });
-
-          it(' Enter Buffering Sentinel Fires When Begin Playback Is Called And Device Time Does Not Advance', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            recentEvents = [];
-            ensureEnterBufferingSentinelIsCalledWhenZeroesCanBeTrusted();
-          });
-
-          it(' Enter Buffering Sentinel Fires When Seeked To Zero And Device Time Is Reported As Zero For At Least Two Intervals', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(20);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            recentEvents = [];
-
-            player.playFrom(0);
-            finishedBufferingCallback();
-            waitForSentinels();
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
-          });
-
-          it(' Enter Buffering Sentinel Only Fires On Second Attempt When Device Reports Time As Not Changing Within Tolerance', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-            recentEvents = [];
-
-            ForThreeIntervalsOfNormalPlaybackTwoIntervalsOfZeroesAndOneIntervalOfTimeIncreaseBelowSentinelTolerance();
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
-
-            mockVideoMediaElement.currentTime = 0.01;
-            waitForSentinels();
-
-            mockVideoMediaElement.currentTime = 0.01;
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
-          });
-
-          it(' Enter Buffering Sentinel Does Not Fire On Two Non Consecutive Occurrences Of Device Reporting Time As Not Changing Within Tolerance', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-            recentEvents = [];
-
-            ForThreeIntervalsOfNormalPlaybackTwoIntervalsOfZeroesAndOneIntervalOfTimeIncreaseBelowSentinelTolerance();
-            ForThreeIntervalsOfNormalPlaybackTwoIntervalsOfZeroesAndOneIntervalOfTimeIncreaseBelowSentinelTolerance();
-          });
-
-          it(' Exit Buffering Sentinel Causes Transition To Playing When Playback Starts', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback({start: 0, end: 100});
-
-            mockVideoMediaElement.currentTime += 1;
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([MediaPlayerBase.EVENT.SENTINEL_EXIT_BUFFERING, MediaPlayerBase.EVENT.PLAYING]);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-          });
-
-          it(' Exit Buffering Sentinel Not Fired When Sentinels Disabled', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: true});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback({start: 0, end: 100});
-
-            mockVideoMediaElement.currentTime += 1;
-
-            recentEvents = [];
-            waitForSentinels();
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
-          });
-
-          it(' Exit Buffering Sentinel Causes Transition To Paused When Device Reports Paused', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-            metaDataCallback({start: 0, end: 100});
-
-            player.pause();
-
-            recentEvents = [];
-            mockVideoMediaElement.paused = true;
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([MediaPlayerBase.EVENT.SENTINEL_EXIT_BUFFERING, MediaPlayerBase.EVENT.PAUSED]);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-          });
-
-          it(' Exit Buffering Sentinel Is Not Fired When Device Is Paused And Metadata Has Been Not Been Loaded', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(0);
-
-              // Meta Data is not loaded at this point
-            mockVideoMediaElement.paused = true;
-            waitForSentinels();
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_EXIT_BUFFERING);
-          });
-
-          it('Seek Sentinel Sets Current Time', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(50);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime = 0;
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
-          });
-
-          it(' Seek Sentinel Sets Current Time Not Fired When Sentinels Disabled', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: true});
-            player.beginPlaybackFrom(50);
-
-            metaDataCallback({start: 0, end: 100});
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime = 0;
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(mockVideoMediaElement.currentTime).toEqual(0);
-          });
-
-          it(' Seek Sentinel Clamps Target Seek Time When Required', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            player.beginPlaybackFrom(110);
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime = 0;
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
-            expect(mockVideoMediaElement.currentTime).toEqual(98.9);
-          });
-
-          it(' Seek Sentinel Does Not Reseek To Initial Seek Time After 15s', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
-
-            player.beginPlaybackFrom(10);
-            finishedBufferingCallback();
-
-            recentEvents = [];
-            for (var i = 0; i < 20; i++) {
-              mockVideoMediaElement.currentTime += 1;
-              waitForSentinels();
-            }
-
-            expect(recentEvents).toEqual([]);
-            expect(mockVideoMediaElement.currentTime).toEqual(30);
-          });
-
-          it(' Seek Sentinel Does Not Reseek To Initial Seek Time After15s When Playback Leaves Seekable Range', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
-
-            player.beginPlaybackFrom(95);
-            finishedBufferingCallback();
-
-            recentEvents = [];
-            for (var i = 0; i < 20; i++) {
-              mockVideoMediaElement.currentTime += 1;
-              waitForSentinels();
-            }
-
-            expect(recentEvents).toEqual([]);
-            expect(mockVideoMediaElement.currentTime).toEqual(115);
-          });
-
-          it(' Seek Sentinel Sets Current Time When Paused', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
-
-            player.beginPlaybackFrom(50);
-            finishedBufferingCallback();
-
-            player.pause();
-            mockVideoMediaElement.currentTime = 0;
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
-          });
-
-          it(' Seek Sentinel Does Not Seek When Begin Playback Called', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
-
-            player.beginPlaybackFrom(0);
-            finishedBufferingCallback();
-
-            recentEvents = [];
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(mockVideoMediaElement.currentTime).toEqual(1);
-          });
-
-          it(' Seek Sentinel Does Not Seek When Begin Playback Starts Playing Half Way Through Media', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
-
-            player.beginPlaybackFrom(50);
-            finishedBufferingCallback();
-
-            recentEvents = [];
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(mockVideoMediaElement.currentTime).toEqual(51);
-          });
-
-          it(' Seek Sentinel Does Not Seek When Begin Playback After Previously Seeking', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
-
-            player.beginPlaybackFrom(50);
-            finishedBufferingCallback();
-
+          it('Calling Stop In Complete State Goes To Stopped State', function () {
             player.stop();
+
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.STOPPED);
+          });
+        });
+
+        describe('Error state tests', function () {
+          beforeEach(function () {
+            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+              start: function () { return 0; },
+              end: function () { return 100; },
+              length: 2
+            });
+            spyOnProperty(mockVideoMediaElement, 'error').and.returnValue({code: 'testError'});
+
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
+            player.beginPlaybackFrom(0);
+            finishedBufferingCallback();
+            metaDataCallback();
+            mockVideoMediaElement.currentTime = 100;
+            player.reset();
+
+            recentEvents = [];
+            jasmine.clock().install();
+          });
+
+          afterEach(function () {
+            jasmine.clock().uninstall();
+          });
+
+          it('Get Source Returns Undefined In Error State', function () {
+            expect(player.getSource()).toBe(undefined);
+          });
+
+          it('Get Mime Type Returns Undefined In Error State', function () {
+            expect(player.getMimeType()).toBe(undefined);
+          });
+
+          it('Get Seekable Range Returns Undefined In Error State', function () {
+            expect(player.getSeekableRange()).toBe(undefined);
+          });
+
+          it('Get Duration Returns Undefined In Error State', function () {
+            expect(player.getDuration()).toBe(undefined);
+          });
+
+          it('Get Current Time Returns Undefined In Error State', function () {
+            expect(player.getCurrentTime()).toBe(undefined);
+          });
+
+          it('Calling Begin Playback In Error State Is An Error', function () {
             player.beginPlayback();
-            mockVideoMediaElement.currentTime = 0;
-            finishedBufferingCallback();
 
-            recentEvents = [];
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(mockVideoMediaElement.currentTime).toEqual(1);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
 
-          it(' Seek Sentinel Activates When Device Reports New Position Then Reverts To Old Position', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
+          it('Calling Begin Playback From In Error State Is An Error', function () {
+            player.beginPlaybackFrom();
 
-            player.beginPlaybackFrom(50);
-            finishedBufferingCallback();
-
-            waitForSentinels();
-            mockVideoMediaElement.currentTime = 0;
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
 
-          it(' Seek Sentinel Does Not Fire In Live When Device Jumps Back Less Than Thirty Seconds', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
+          it('Calling Initialise Media In Error State Is An Error', function () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'testUrl', 'testMimeType', sourceContainer, {});
 
-            player.beginPlaybackFrom(29.9);
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime = 0;
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
 
-          it(' Seek Sentinel Fires In Live When Device Jumps Back More Than Thirty Seconds', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
+          it('Calling Play From In Error State Is An Error', function () {
+            player.playFrom();
 
-            player.beginPlaybackFrom(30.1);
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime = 0;
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
 
-          it(' Pause Sentinel Retries Pause If Pause Fails', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
-
-            player.beginPlaybackFrom(0);
-            finishedBufferingCallback();
+          it('Calling Pause In Error State Is An Error', function () {
             player.pause();
 
-            mockVideoMediaElement.currentTime += 1;
-            recentEvents = [];
-            mockVideoMediaElement.pause.calls.reset();
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
-            expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
 
-          it(' Pause Sentinel Not Fired When Sentinels Disabled', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: true});
-            metaDataCallback({start: 0, end: 100});
-
-            player.beginPlaybackFrom(0);
-            finishedBufferingCallback();
-            player.pause();
-
-            mockVideoMediaElement.currentTime += 1;
-            recentEvents = [];
-            mockVideoMediaElement.pause.calls.reset();
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-          });
-
-          it(' Pause Sentinel Does Not Retry Pause If Pause Succeeds', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
-
-            player.beginPlaybackFrom(0);
-            finishedBufferingCallback();
-            player.pause();
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-          });
-
-          it(' Pause Sentinel Does Not Retry Pause If Pause Succeeds', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-            metaDataCallback({start: 0, end: 100});
-
-            player.beginPlaybackFrom(0);
-            finishedBufferingCallback();
-            player.pause();
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-          });
-
-          it(' End Of Media Sentinel Goes To Complete If Time Is Not Advancing And No Complete Event Fired', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(98);
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime = 99;
-            waitForSentinels();
-
-            mockVideoMediaElement.currentTime = 100;
-            waitForSentinels();
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_COMPLETE, MediaPlayerBase.EVENT.COMPLETE);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.COMPLETE);
-          });
-
-          it(' End Of Media Sentinel Not Fired When Sentinels Disabled', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: true});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(98);
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime = 99;
-            waitForSentinels();
-
-            mockVideoMediaElement.currentTime = 100;
-            waitForSentinels();
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_COMPLETE, MediaPlayerBase.EVENT.COMPLETE);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
-          });
-
-          it('EndOf Media Sentinel Does Not Activate If Time Is Not Advancing When Outside A Second Of End And No Complete Event Fired', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(98);
-            finishedBufferingCallback();
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_COMPLETE);
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.COMPLETE);
-          });
-
-          it(' End Of Media Sentinel Does Not Activate If Time Is Not Advancing When Outside Seekable Range But Within Duration', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(98);
-            finishedBufferingCallback();
-            mockVideoMediaElement.duration = 150;
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_COMPLETE);
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.COMPLETE);
-          });
-
-          it(' End Of Media Sentinel Does Not Activate If Reach End Of Media Normally', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(100);
-            finishedBufferingCallback();
-            endedCallback();
-
-            recentEvents = [];
-            waitForSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.COMPLETE);
-          });
-
-          it(' End Of Media Sentinel Does Not Activate If Time Is Advancing Near End Of Media And No Complete Event Fired', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(100);
-            finishedBufferingCallback();
-
-            recentEvents = [];
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_COMPLETE);
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.COMPLETE);
-          });
-
-          it(' Only One Sentinel Fired At A Time When Both Seek And Pause Sentinels Are Needed', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(0);
-            player.playFrom(30);
-
-            mockVideoMediaElement.currentTime = 0;
-            finishedBufferingCallback();
-            player.pause();
-
-            recentEvents = [];
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-
-            recentEvents = [];
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-          });
-
-          function resetStubsThenAdvanceTimeThenRunSentinels () {
-            recentEvents = [];
-            mockVideoMediaElement.pause.calls.reset();
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-          }
-
-          it(' Pause Sentinel Retries Pause Twice', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(0);
-            finishedBufferingCallback();
-            player.pause();
-
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
-
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
-          });
-
-          it(' Pause Sentinel Emits Failure Event And Gives Up On Third Attempt', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(0);
-            finishedBufferingCallback();
-            player.pause();
-
-            resetStubsThenAdvanceTimeThenRunSentinels();
-            resetStubsThenAdvanceTimeThenRunSentinels();
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
-
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).toEqual([]);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
-          });
-
-          it(' Pause Sentinel Attempt Count Is Not Reset By Calling Pause When Already Paused', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(0);
-            finishedBufferingCallback();
-
-            player.pause();
-            resetStubsThenAdvanceTimeThenRunSentinels();
-            player.pause();
-
-            resetStubsThenAdvanceTimeThenRunSentinels();
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
-          });
-
-          it(' Pause Sentinel Attempt Count Is Reset By Calling Pause When Not Paused', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(0);
-            finishedBufferingCallback();
-            player.pause();
-
-            resetStubsThenAdvanceTimeThenRunSentinels();
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
+          it('Calling Resume In Error State Is An Error', function () {
             player.resume();
-            player.pause();
 
-            resetStubsThenAdvanceTimeThenRunSentinels();
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-            expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
 
-          it(' Seek Sentinel Retries Seek Twice', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(50);
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime = 0;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
-
-            mockVideoMediaElement.currentTime = 0;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
-          });
-
-          it(' Seek Sentinel Emits Failure Event And Gives Up On Third Attempt When Device Does Not Enter Buffering Upon Seek', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(50);
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime = 0;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            mockVideoMediaElement.currentTime = 0;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            mockVideoMediaElement.currentTime = 0;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE);
-            expect(mockVideoMediaElement.currentTime).toEqual(1);
-
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE);
-            expect(mockVideoMediaElement.currentTime).toEqual(2);
-          });
-
-          it(' Seek Sentinel Giving Up Does Not Prevent Pause Sentinel Activation', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(50);
-            finishedBufferingCallback();
-
-            player.pause();
-
-            mockVideoMediaElement.currentTime = 0;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-            mockVideoMediaElement.currentTime = 0;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
-            expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
-
-            mockVideoMediaElement.currentTime = 0;
-            mockVideoMediaElement.currentTime += 1;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
-            expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
-
-            mockVideoMediaElement.currentTime = 0;
-            mockVideoMediaElement.currentTime += 1;
-            mockVideoMediaElement.currentTime += 1;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-              // Ensure that pause has a second attempt (rather than seek returning, etc)
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
-            expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
-          });
-
-          it(' Seek Sentinel Attempt Count Is Reset By Calling Play From', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(0);
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime = 0;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            mockVideoMediaElement.currentTime = 0;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-            mockVideoMediaElement.currentTime = 0;
-
-            player.playFrom(50);
-            finishedBufferingCallback();
-            mockVideoMediaElement.currentTime = 0;
-
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
-          });
-
-          it(' Seek Sentinel Attempt Count Is Reset By Calling Begin Playback From', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
-
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(0);
-            finishedBufferingCallback();
-
-            mockVideoMediaElement.currentTime = 0;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            mockVideoMediaElement.currentTime = 0;
-            resetStubsThenAdvanceTimeThenRunSentinels();
-            mockVideoMediaElement.currentTime = 0;
-
+          it('Calling Stop From In Error State Is An Error', function () {
             player.stop();
-            player.beginPlaybackFrom(50);
-            finishedBufferingCallback();
-            mockVideoMediaElement.currentTime = 0;
 
-            resetStubsThenAdvanceTimeThenRunSentinels();
-
-            expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
+            expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
 
-          it(' Exit Buffering Sentinel Performs Deferred Seek If No Loaded Metadata Event', function () {
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
-            player.beginPlaybackFrom(50);
+          it('Calling Reset In Error State Goes To Empty State', function () {
+            player.reset();
 
-            mockVideoMediaElement.currentTime += 1;
-            waitForSentinels();
-
-            expect(mockVideoMediaElement.currentTime).toEqual(50);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.EMPTY);
           });
 
-          it(' Pause Sentinel Does Not Fire When Device Time Advances By Less Than Sentinel Tolerance', function () {
-            spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
-              start: function () {
-                return 0;
-              },
-              end: function () {
-                return 100;
-              },
-              length: 2
-            });
-            spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+          it('When Buffering Finishes During Error We Continue To Be In Error', function () {
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
 
-            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
-
-            metaDataCallback({start: 0, end: 100});
-            player.beginPlaybackFrom(20);
+            metaDataCallback();
             finishedBufferingCallback();
 
-            recentEvents = [];
-
-            player.pause();
-            mockVideoMediaElement.currentTime += 0.01;
-            waitForSentinels();
-
-            expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
+            expect(player.getState()).toEqual(MediaPlayerBase.STATE.ERROR);
           });
         });
       });
+
+      describe('Initialise Media', function () {
+        it('Creates a video element when called with type VIDEO', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, null, null, sourceContainer, {});
+
+          expect(document.createElement).toHaveBeenCalledTimes(2);
+          expect(document.createElement).toHaveBeenCalledWith('video', 'mediaPlayerVideo');
+        });
+
+        it('Creates an audio element when called with type AUDIO', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, null, null, sourceContainer, {});
+
+          expect(document.createElement).toHaveBeenCalledTimes(2);
+          expect(document.createElement).toHaveBeenCalledWith('audio', 'mediaPlayerAudio');
+        });
+
+        it('Creates a video element when called with type LIVE_VIDEO', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, null, null, sourceContainer, {});
+
+          expect(document.createElement).toHaveBeenCalledTimes(2);
+          expect(document.createElement).toHaveBeenCalledWith('video', 'mediaPlayerVideo');
+        });
+
+        it('Creates an audio element when called with type LIVE_AUDIO', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_AUDIO, null, null, sourceContainer, {});
+
+          expect(document.createElement).toHaveBeenCalledTimes(2);
+          expect(document.createElement).toHaveBeenCalledWith('audio', 'mediaPlayerAudio');
+        });
+
+        it('The created video element is passed into the source container', function () {
+          spyOn(sourceContainer, 'appendChild');
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, null, null, sourceContainer, {});
+
+          expect(sourceContainer.appendChild).toHaveBeenCalledWith(mockVideoMediaElement);
+        });
+
+        it('The Audio element is passed into the source container', function () {
+          spyOn(sourceContainer, 'appendChild');
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, null, null, sourceContainer, {});
+
+          expect(sourceContainer.appendChild).toHaveBeenCalledWith(mockAudioMediaElement);
+        });
+
+        it('Source url is present on the source element', function () {
+          var url = 'http://url/';
+
+          spyOn(mockVideoMediaElement, 'appendChild').and.callThrough();
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, url, null, sourceContainer, {});
+
+          expect(mockVideoMediaElement.appendChild).toHaveBeenCalledWith(mockSourceElement);
+          expect(mockVideoMediaElement.children[0].src).toBe(url);
+        });
+      });
+
+      describe('Reset and Stop', function () {
+        it('Video is removed from the DOM', function () {
+          spyOn(sourceContainer, 'appendChild').and.callThrough();
+          spyOn(sourceContainer, 'removeChild').and.callThrough();
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, null, null, sourceContainer, {});
+
+          expect(sourceContainer.appendChild).toHaveBeenCalledWith(mockVideoMediaElement);
+
+          player.reset();
+
+          expect(sourceContainer.removeChild).toHaveBeenCalledWith(mockVideoMediaElement);
+          expect(sourceContainer.children[0]).not.toBe(mockVideoMediaElement);
+        });
+
+        it('Audio is removed from the DOM', function () {
+          spyOn(sourceContainer, 'appendChild').and.callThrough();
+          spyOn(sourceContainer, 'removeChild').and.callThrough();
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, null, null, sourceContainer, {});
+
+          expect(sourceContainer.appendChild).toHaveBeenCalledWith(mockAudioMediaElement);
+
+          player.reset();
+
+          expect(sourceContainer.removeChild).toHaveBeenCalledWith(mockAudioMediaElement);
+          expect(sourceContainer.children[0]).not.toBe(mockAudioMediaElement);
+        });
+
+        it('Source element is removed from the media element', function () {
+          spyOn(mockVideoMediaElement, 'removeChild').and.callThrough();
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, null, null, sourceContainer, {});
+
+          player.reset();
+
+          expect(mockVideoMediaElement.removeChild).toHaveBeenCalledWith(mockSourceElement);
+        });
+
+        it(' Reset Unloads Media Element Source As Per Guidelines', function () {
+          // Guidelines in HTML5 video spec, section 4.8.10.15:
+          // http://www.w3.org/TR/2011/WD-html5-20110405/video.html#best-practices-for-authors-using-media-elements
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          mockVideoMediaElement.load.calls.reset();
+          spyOn(mockVideoMediaElement, 'removeAttribute');
+
+          player.reset();
+
+          expect(mockVideoMediaElement.removeAttribute).toHaveBeenCalledWith('src');
+          expect(mockVideoMediaElement.removeAttribute).toHaveBeenCalledTimes(1);
+          expect(mockVideoMediaElement.load).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Calling Stop In Stopped State Does Not Call Pause On The Device', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          player.stop();
+
+          expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('seekable range', function () {
+        it('If duration and seekable range is missing get seekable range returns undefined and logs a warning', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          metaDataCallback();
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(undefined);
+
+          player.beginPlayback();
+
+          expect(player.getSeekableRange()).toBe(undefined);
+        });
+
+        it('Seekable Range Takes Precedence Over Duration On Media Element', function () {
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(60);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+          finishedBufferingCallback();
+
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 10;
+            },
+            end: function () {
+              return 30;
+            },
+            length: 2
+          });
+
+          metaDataCallback({start: 10, end: 30});
+
+          expect(player.getSeekableRange()).toEqual({ start: 10, end: 30 });
+          expect(mockVideoMediaElement.duration).toBe(60);
+        });
+
+        it('Seekable Is Not Used Until Metadata Is Set', function () {
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(undefined);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlayback();
+
+          expect(player.getSeekableRange()).toEqual(undefined);
+
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 10;
+            },
+            end: function () {
+              return 30;
+            },
+            length: 2
+          });
+
+          metaDataCallback({start: 10, end: 30});
+
+          expect(player.getSeekableRange()).toEqual({ start: 10, end: 30 });
+        });
+
+        it(' Get Seekable Range Gets End Time From Duration When No Seekable Property', function () {
+          metaDataCallback();
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(60);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlayback();
+          metaDataCallback({start: 0, end: 30});
+
+          expect(player.getSeekableRange()).toEqual({start: 0, end: 60});
+        });
+
+        it(' Get Seekable Range Gets End Time From First Time Range In Seekable Property', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 10;
+            },
+            end: function () {
+              return 30;
+            },
+            length: 2
+          });
+          metaDataCallback({start: 10, end: 30});
+
+          expect(player.getSeekableRange()).toEqual({ start: 10, end: 30 });
+        });
+      });
+
+      describe('Media Element', function () {
+        it('Video Element Is Full Screen', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          expect(mockVideoMediaElement.style.position).toEqual('absolute');
+          expect(mockVideoMediaElement.style.top).toEqual('0px');
+          expect(mockVideoMediaElement.style.left).toEqual('0px');
+          expect(mockVideoMediaElement.style.width).toEqual('100%');
+          expect(mockVideoMediaElement.style.height).toEqual('100%');
+          expect(mockVideoMediaElement.style.zIndex).toEqual('');
+        });
+
+        it(' Autoplay Is Turned Off On Media Element Creation', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          expect(mockVideoMediaElement.autoplay).toEqual(false);
+        });
+
+        it(' Error Event From Media Element Causes Error Log With Code And Error Message In Event', function () {
+          var errorMessage = 'This is a test error';
+
+          spyOnProperty(mockVideoMediaElement, 'error').and.returnValue({code: errorMessage});
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          errorCallback();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+        });
+
+        it(' Error Event From Source Element Causes Error Log And Error Message In Event', function () {
+          var sourceError;
+          spyOn(mockSourceElement, 'addEventListener').and.callFake(function (name, methodCall) {
+            if (name === 'error') {
+              sourceError = methodCall;
+            }
+          });
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          sourceError();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.ERROR);
+        });
+
+        it(' Pause Passed Through To Media Element When In Playing State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          metaDataCallback({});
+
+          player.beginPlayback();
+          player.pause();
+
+          expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Pause Not Passed From Media Element To Media Player On User Pause From Buffering', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          // We dont fire the metadata ready callback so it stays in the buffering state
+          player.beginPlayback();
+
+          mockVideoMediaElement.pause();
+
+          expect(player.toPaused).toHaveBeenCalledTimes(0);
+        });
+
+        it(' Pause Not Passed From Media Element To Media Player On User Pause From Playing', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          metaDataCallback({});
+
+          player.beginPlayback();
+
+          mockVideoMediaElement.pause();
+
+          expect(player.toPaused).toHaveBeenCalledTimes(0);
+        });
+
+        it(' Pause Not Passed From Media Element To Media Player On Stop', function () {
+          // Initialise media terminates in the stopped state
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          mockVideoMediaElement.pause();
+
+          expect(player.toPaused).toHaveBeenCalledTimes(0);
+        });
+
+        it(' Play Called On Media Element When Resume In Paused State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+          player.pause();
+
+          metaDataCallback({});
+          finishedBufferingCallback();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+          mockVideoMediaElement.play.calls.reset();
+
+          player.resume();
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Play Called On Media Element When Resume In Buffering State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+          player.pause();
+
+          metaDataCallback({});
+
+          mockVideoMediaElement.play.calls.reset();
+
+          player.resume();
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Play Not Called On Media Element When Resume In Buffering State Before Metadata', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+          player.pause();
+
+          mockVideoMediaElement.play.calls.reset();
+
+          player.resume();
+
+          expect(mockVideoMediaElement.play).not.toHaveBeenCalled();
+        });
+
+        it(' Pause Passed Through To Media Element When In Buffered State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+          player.pause();
+
+          metaDataCallback({});
+
+          expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Load Called On Media Element When Initialise Media Is Called', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          expect(mockVideoMediaElement.load).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Media Element Preload Attribute Is Set To Auto', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          expect(mockVideoMediaElement.preload).toEqual('auto');
+        });
+
+        it(' Play From Sets Current Time And Calls Play On Media Element When In Playing State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback({});
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.play.calls.reset();
+
+          player.playFrom(10);
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+          expect(mockVideoMediaElement.currentTime).toEqual(10);
+        });
+
+        it(' Get Player Element Returns Video Element For Video', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          expect(player.getPlayerElement()).toEqual(mockVideoMediaElement);
+        });
+
+        it(' Get Player Element Returns Audio Element For Audio', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          expect(player.getPlayerElement()).toEqual(mockAudioMediaElement);
+        });
+      });
+
+      describe('Time features', function () {
+        beforeEach(function () {
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+          mockVideoMediaElement.play.calls.reset();
+        });
+
+        it(' Play From Clamps When Called In Playing State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          player.playFrom(110);
+
+          expect(mockVideoMediaElement.currentTime).toEqual(98.9);
+        });
+
+        it(' Play From Sets Current Time And Calls Play On Media Element When In Complete State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          finishedBufferingCallback();
+          metaDataCallback({start: 0, end: 100});
+
+          mockVideoMediaElement.play.calls.reset();
+
+          player.playFrom(10);
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+          expect(mockVideoMediaElement.currentTime).toEqual(10);
+        });
+
+        it(' Play From Sets Current Time And Calls Play On Media Element When In Paused State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          player.pause();
+
+          mockVideoMediaElement.play.calls.reset();
+
+          player.playFrom(10);
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+          expect(mockVideoMediaElement.currentTime).toEqual(10);
+        });
+
+        it(' Begin Playback From After Metadata', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          metaDataCallback();
+
+          player.beginPlaybackFrom(50);
+          finishedBufferingCallback();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Get Duration Returns Undefined Before Metadata Is Set', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          expect(player.getDuration()).toBe(undefined);
+
+          metaDataCallback();
+
+          expect(player.getDuration()).toEqual(100);
+        });
+
+        it(' Get Duration Returns Device Duration With An On Demand Audio Stream', function () {
+          spyOnProperty(mockAudioMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlayback();
+
+          metaDataCallback();
+
+          expect(player.getDuration()).toBe(100);
+        });
+      });
+
+      describe('Current Time', function () {
+        it(' Play From Sets Current Time And Calls Play On Media Element When In Stopped State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          player.beginPlaybackFrom(50);
+
+          expect(mockVideoMediaElement.play).not.toHaveBeenCalled();
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+
+          mockVideoMediaElement.play.calls.reset();
+          metaDataCallback({ start: 0, end: 100 });
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+
+          finishedBufferingCallback();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+        });
+
+        it(' Begin Playback From Sets Current Time And Calls Play On Media Element When In Stopped State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(10);
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+          expect(mockVideoMediaElement.currentTime).toEqual(10);
+        });
+
+        it(' Play From Clamps When Called In Stopped State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(110);
+
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 10;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          metaDataCallback({ start: 10, end: 100 });
+
+          expect(mockVideoMediaElement.currentTime).toEqual(98.9);
+        });
+
+        it(' Play From Then Pause Sets Current Time And Calls Pause On Media Element When In Stopped State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(50);
+          player.pause();
+
+          expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
+          expect(mockVideoMediaElement.play).not.toHaveBeenCalled();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 10;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+
+          metaDataCallback({ start: 0, end: 100 });
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+
+          finishedBufferingCallback();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+        });
+
+        it(' Play From Zero Then Pause Defers Call To Pause On Media Element When In Stopped State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          player.beginPlaybackFrom(0);
+          player.pause();
+
+          expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
+        });
+
+        it(' Play From Defers Setting Current Time And Calling Play On Media Element Until We Have Metadata', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          player.beginPlaybackFrom(0);
+          player.playFrom(10);
+
+          expect(mockVideoMediaElement.play).not.toHaveBeenCalled();
+
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 10;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+
+          metaDataCallback({ start: 0, end: 100 });
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+          expect(mockVideoMediaElement.currentTime).toEqual(10);
+        });
+
+        it(' Play From Clamps When Called In Buffering State And Dont Have Metadata', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          player.beginPlaybackFrom(0);
+          player.playFrom(110);
+
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 10;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          metaDataCallback({ start: 0, end: 100 });
+
+          finishedBufferingCallback();
+
+          expect(mockVideoMediaElement.currentTime).toEqual(98.9);
+        });
+
+        it(' Play From Sets Current Time And Calls Play On Media Element When In Buffering State And Has Metadata', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          player.beginPlaybackFrom(0);
+
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 10;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          metaDataCallback({ start: 0, end: 100 });
+
+          mockVideoMediaElement.play.calls.reset();
+
+          player.playFrom(10);
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+          expect(mockVideoMediaElement.currentTime).toEqual(10);
+        });
+
+        it(' Play From Clamps When Called In Buffering State And Has Metadata', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          player.beginPlaybackFrom(0);
+
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 10;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          metaDataCallback({ start: 0, end: 100 });
+
+          player.playFrom(110);
+          finishedBufferingCallback();
+
+          expect(mockVideoMediaElement.currentTime).toEqual(98.9);
+        });
+
+        it(' Play From Current Time When Playing Goes To Buffering Then To Playing', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          player.beginPlaybackFrom(0);
+          metaDataCallback();
+          finishedBufferingCallback();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+
+          waitingCallback();
+
+          mockVideoMediaElement.currentTime = 20;
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+
+          player.playFrom(30);
+          finishedBufferingCallback();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+        });
+
+        it(' Play From Just Before Current Time When Playing Goes To Buffering Then To Playing', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          player.beginPlaybackFrom(0);
+          metaDataCallback();
+          finishedBufferingCallback();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+
+          waitingCallback();
+
+          mockVideoMediaElement.currentTime = 50.999;
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+
+          player.playFrom(50);
+          finishedBufferingCallback();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+        });
+
+        it(' Begin Playback From Current Time When Played Then Stopped Goes To Buffering Then To Playing', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          metaDataCallback();
+
+          player.beginPlaybackFrom(50);
+
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+
+          player.stop();
+
+          mockVideoMediaElement.play.calls.reset();
+
+          player.beginPlaybackFrom(50);
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+
+          finishedBufferingCallback();
+          mockVideoMediaElement.play();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+        });
+
+        it(' Play From Current Time When Paused Goes To Buffering Then To Playing', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback();
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.play.calls.reset();
+          mockVideoMediaElement.currentTime = 50;
+
+          player.pause();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+
+          player.playFrom(50);
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(1);
+
+          finishedBufferingCallback();
+          mockVideoMediaElement.play();
+
+          expect(mockVideoMediaElement.play).toHaveBeenCalledTimes(2);
+          expect(player.getState()).toEqual(MediaPlayerBase.EVENT.PLAYING.toUpperCase());
+        });
+
+        it(' Begin Playback From Sets Current Time After Finish Buffering But No Metadata', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(50);
+
+          metaDataCallback({ start: 0, end: 100 });
+          finishedBufferingCallback();
+
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+        });
+
+        it(' Play From Near Current Time Will Not Cause Finish Buffering To Perform Seek Later', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(0);
+
+          mockVideoMediaElement.currentTime = 50;
+          player.playFrom(50.999);
+
+          mockVideoMediaElement.currentTime = 70;
+          finishedBufferingCallback();
+
+          expect(mockVideoMediaElement.currentTime).toEqual(70);
+        });
+      });
+
+      describe('Media Element Stop', function () {
+        it(' Stop When In Buffering State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          player.beginPlaybackFrom(0);
+          player.stop();
+
+          expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Stop When In Playing State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback();
+          finishedBufferingCallback();
+
+          player.stop();
+
+          expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Stop When In Complete State', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback();
+          finishedBufferingCallback();
+
+          endedCallback();
+          player.stop();
+
+          expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Reset Remove All Event Listeners From The Media Element', function () {
+          var listeners = ['canplay', 'seeked', 'playing', 'error', 'ended', 'waiting',
+            'timeupdate', 'loadedMetaData', 'pause'];
+
+          spyOn(mockVideoMediaElement, 'removeEventListener');
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.reset();
+
+          expect(mockVideoMediaElement.removeEventListener).toHaveBeenCalledTimes(listeners.length);
+        });
+
+        it('Remove all event callbacks works correctly', function () {
+          function playAndEmitAfterRemoveAllCallbacks () {
+            player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+            player.beginPlaybackFrom(0);
+            player.removeAllEventCallbacks();
+            endedCallback();
+          }
+
+          expect(playAndEmitAfterRemoveAllCallbacks).not.toThrowError();
+        });
+      });
+
+      describe('Events', function () {
+        beforeEach(function () {
+          jasmine.clock().install();
+        });
+
+        afterEach(function () {
+          jasmine.clock().uninstall();
+        });
+
+        it(' Waiting Html5 Event While Buffering Only Gives Single Buffering Event', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          player.beginPlaybackFrom(0);
+          waitingCallback();
+
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+        });
+
+        it(' Seek Attempted Event Emitted On Initialise Media If The State Is Empty', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
+        });
+
+        it('Seek Finished Event Emitted On Status Update When Time is Within Sentinel Threshold And The State is Playing', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
+
+          player.beginPlaybackFrom(0);
+          waitingCallback();
+          playingCallback();
+
+          timeupdateCallback();
+          timeupdateCallback();
+          timeupdateCallback();
+          timeupdateCallback();
+          timeupdateCallback();
+          timeupdateCallback();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
+        });
+
+        it('Seek Finished Event Is Emitted Only Once', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
+
+          player.beginPlaybackFrom(0);
+          waitingCallback();
+          playingCallback();
+
+          timeupdateCallback();
+          timeupdateCallback();
+          timeupdateCallback();
+          timeupdateCallback();
+          timeupdateCallback();
+          timeupdateCallback();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
+          recentEvents = [];
+          timeupdateCallback();
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
+        });
+
+        it(' Seek Finished Event Is Emitted After restartTimeout When Enabled', function () {
+          var restartTimeoutConfig = {
+            streaming: {
+              overrides: {
+                forceBeginPlaybackToEndOfWindow: true
+              }
+            },
+            restartTimeout: 10000
+          };
+
+          createPlayer(restartTimeoutConfig);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
+
+          player.beginPlaybackFrom(0);
+          waitingCallback();
+          playingCallback();
+
+          timeupdateCallback();
+          timeupdateCallback();
+          timeupdateCallback();
+          timeupdateCallback();
+          timeupdateCallback();
+
+          jasmine.clock().tick(10000);
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
+
+          jasmine.clock().tick(1100);
+          timeupdateCallback();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SEEK_FINISHED);
+        });
+      });
+
+      describe('Sentinels', function () {
+        function waitForSentinels () {
+          jasmine.clock().tick(1100);
+        }
+
+        beforeEach(function () {
+          jasmine.clock().install();
+          jasmine.clock().mockDate();
+        });
+
+        afterEach(function () {
+          jasmine.clock().uninstall();
+        });
+
+        it(' Enter Buffering Sentinel Causes Transition To Buffering When Playback Halts For More Than One Sentinel Iteration Since State Changed', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime += 1;
+          mockVideoMediaElement.currentTime += 1;
+
+          recentEvents = [];
+          waitForSentinels();
+          waitForSentinels();
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.BUFFERING);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+        });
+
+        it(' Enter Buffering Sentinel Not Fired When Sentinels Disabled', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: true});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime += 1;
+          mockVideoMediaElement.currentTime += 1;
+
+          recentEvents = [];
+          waitForSentinels();
+          waitForSentinels();
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+        });
+
+        it(' No Sentinels Activate When Current Time Runs Normally Then Jumps Backwards', function () {
+          var INITIAL_TIME = 30;
+          var SEEK_SENTINEL_TOLERANCE = 15;
+          var AFTER_JUMP_TIME = INITIAL_TIME - (SEEK_SENTINEL_TOLERANCE + 5);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: true});
+          player.beginPlaybackFrom(INITIAL_TIME);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          recentEvents = [];
+
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+
+          mockVideoMediaElement.currentTime = AFTER_JUMP_TIME;
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+        });
+
+        it(' No Sentinels Activate When Current Time Runs Normally Then Jumps Backwards Near End Of Media', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(95);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          recentEvents = [];
+
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+
+          mockVideoMediaElement.currentTime = 100;
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+        });
+
+        it(' Pause Sentinel Activates When Current Time Runs Normally Then Jumps Backwards When Paused', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(10);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+
+          player.pause();
+          recentEvents = [];
+
+          mockVideoMediaElement.currentTime = 0;
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
+        });
+
+        it(' Enter Buffering Sentinel Does Not Activate When Playback Halts When Only One Sentinel Iteration Since State Changed', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(10);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime += 1;
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+        });
+
+        it(' Enter Buffering Sentinel Does Nothing When Playback Is Working', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(10);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime += 1;
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+        });
+
+        it(' Enter Buffering Sentinel Does Nothing When Device Reports Buffering Correctly', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(10);
+
+          waitingCallback();
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+        });
+
+        it(' Enter Buffering Sentinel Does Nothing When Device Is Paused', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(10);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime += 1;
+
+          player.pause();
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+        });
+        function ensureEnterBufferingSentinelIsNotCalledWhenZeroesCannotBeTrusted () {
+          var i;
+          for (i = 0; i < 3; i++) {
+            mockVideoMediaElement.currentTime += 1;
+            waitForSentinels();
+          }
+
+          for (i = 0; i < 2; i++) {
+            mockVideoMediaElement.currentTime = 0;
+            waitForSentinels();
+          }
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+        }
+
+        function ensureEnterBufferingSentinelIsCalledWhenZeroesCanBeTrusted () {
+          for (var i = 0; i < 2; i++) {
+            mockVideoMediaElement.currentTime = 0;
+            waitForSentinels();
+          }
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+        }
+
+        function ForThreeIntervalsOfNormalPlaybackTwoIntervalsOfZeroesAndOneIntervalOfTimeIncreaseBelowSentinelTolerance () {
+          var i;
+
+          for (i = 0; i < 3; i++) {
+            mockVideoMediaElement.currentTime += 1;
+            waitForSentinels();
+          }
+
+          for (i = 0; i < 2; i++) {
+            mockVideoMediaElement.currentTime = 0;
+            waitForSentinels();
+          }
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
+
+          mockVideoMediaElement.currentTime = 0.01;
+          waitForSentinels();
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
+        }
+
+        it(' Enter Buffering Sentinel Does Nothing When Device Time Is Reported As Zero During Playback', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(10);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          recentEvents = [];
+          ensureEnterBufferingSentinelIsNotCalledWhenZeroesCannotBeTrusted();
+        });
+
+        it(' Enter Buffering Sentinel Does Nothing When Begin Playback Is Called And Device Time Is Reported As Zero For At Least Two Intervals', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(20);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          recentEvents = [];
+          ensureEnterBufferingSentinelIsNotCalledWhenZeroesCannotBeTrusted();
+        });
+
+        it(' Enter Buffering Sentinel Fires When Begin Playback From Zero Is Called And Device Time Does Not Advance', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          recentEvents = [];
+          ensureEnterBufferingSentinelIsCalledWhenZeroesCanBeTrusted();
+        });
+
+        it(' Enter Buffering Sentinel Fires When Begin Playback Is Called And Device Time Does Not Advance', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          recentEvents = [];
+          ensureEnterBufferingSentinelIsCalledWhenZeroesCanBeTrusted();
+        });
+
+        it(' Enter Buffering Sentinel Fires When Seeked To Zero And Device Time Is Reported As Zero For At Least Two Intervals', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(20);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          recentEvents = [];
+
+          player.playFrom(0);
+          finishedBufferingCallback();
+          waitForSentinels();
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
+        });
+
+        it(' Enter Buffering Sentinel Only Fires On Second Attempt When Device Reports Time As Not Changing Within Tolerance', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+          recentEvents = [];
+
+          ForThreeIntervalsOfNormalPlaybackTwoIntervalsOfZeroesAndOneIntervalOfTimeIncreaseBelowSentinelTolerance();
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
+
+          mockVideoMediaElement.currentTime = 0.01;
+          waitForSentinels();
+
+          mockVideoMediaElement.currentTime = 0.01;
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
+        });
+
+        it(' Enter Buffering Sentinel Does Not Fire On Two Non Consecutive Occurrences Of Device Reporting Time As Not Changing Within Tolerance', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+          recentEvents = [];
+
+          ForThreeIntervalsOfNormalPlaybackTwoIntervalsOfZeroesAndOneIntervalOfTimeIncreaseBelowSentinelTolerance();
+          ForThreeIntervalsOfNormalPlaybackTwoIntervalsOfZeroesAndOneIntervalOfTimeIncreaseBelowSentinelTolerance();
+        });
+
+        it(' Exit Buffering Sentinel Causes Transition To Playing When Playback Starts', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback({start: 0, end: 100});
+
+          mockVideoMediaElement.currentTime += 1;
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([MediaPlayerBase.EVENT.SENTINEL_EXIT_BUFFERING, MediaPlayerBase.EVENT.PLAYING]);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+        });
+
+        it(' Exit Buffering Sentinel Not Fired When Sentinels Disabled', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: true});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback({start: 0, end: 100});
+
+          mockVideoMediaElement.currentTime += 1;
+
+          recentEvents = [];
+          waitForSentinels();
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.BUFFERING);
+        });
+
+        it(' Exit Buffering Sentinel Causes Transition To Paused When Device Reports Paused', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          metaDataCallback({start: 0, end: 100});
+
+          player.pause();
+
+          recentEvents = [];
+          mockVideoMediaElement.paused = true;
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([MediaPlayerBase.EVENT.SENTINEL_EXIT_BUFFERING, MediaPlayerBase.EVENT.PAUSED]);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+        });
+
+        it(' Exit Buffering Sentinel Is Not Fired When Device Is Paused And Metadata Has Been Not Been Loaded', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(0);
+
+          // Meta Data is not loaded at this point
+          mockVideoMediaElement.paused = true;
+          waitForSentinels();
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_EXIT_BUFFERING);
+        });
+
+        it('Seek Sentinel Sets Current Time', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(50);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime = 0;
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+        });
+
+        it(' Seek Sentinel Sets Current Time Not Fired When Sentinels Disabled', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: true});
+          player.beginPlaybackFrom(50);
+
+          metaDataCallback({start: 0, end: 100});
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime = 0;
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(mockVideoMediaElement.currentTime).toEqual(0);
+        });
+
+        it(' Seek Sentinel Clamps Target Seek Time When Required', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          player.beginPlaybackFrom(110);
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime = 0;
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+          expect(mockVideoMediaElement.currentTime).toEqual(98.9);
+        });
+
+        it(' Seek Sentinel Does Not Reseek To Initial Seek Time After 15s', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(10);
+          finishedBufferingCallback();
+
+          recentEvents = [];
+          for (var i = 0; i < 20; i++) {
+            mockVideoMediaElement.currentTime += 1;
+            waitForSentinels();
+          }
+
+          expect(recentEvents).toEqual([]);
+          expect(mockVideoMediaElement.currentTime).toEqual(30);
+        });
+
+        it(' Seek Sentinel Does Not Reseek To Initial Seek Time After15s When Playback Leaves Seekable Range', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(95);
+          finishedBufferingCallback();
+
+          recentEvents = [];
+          for (var i = 0; i < 20; i++) {
+            mockVideoMediaElement.currentTime += 1;
+            waitForSentinels();
+          }
+
+          expect(recentEvents).toEqual([]);
+          expect(mockVideoMediaElement.currentTime).toEqual(115);
+        });
+
+        it(' Seek Sentinel Sets Current Time When Paused', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(50);
+          finishedBufferingCallback();
+
+          player.pause();
+          mockVideoMediaElement.currentTime = 0;
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+        });
+
+        it(' Seek Sentinel Does Not Seek When Begin Playback Called', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(0);
+          finishedBufferingCallback();
+
+          recentEvents = [];
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(mockVideoMediaElement.currentTime).toEqual(1);
+        });
+
+        it(' Seek Sentinel Does Not Seek When Begin Playback Starts Playing Half Way Through Media', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(50);
+          finishedBufferingCallback();
+
+          recentEvents = [];
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(mockVideoMediaElement.currentTime).toEqual(51);
+        });
+
+        it(' Seek Sentinel Does Not Seek When Begin Playback After Previously Seeking', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(50);
+          finishedBufferingCallback();
+
+          player.stop();
+          player.beginPlayback();
+          mockVideoMediaElement.currentTime = 0;
+          finishedBufferingCallback();
+
+          recentEvents = [];
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(mockVideoMediaElement.currentTime).toEqual(1);
+        });
+
+        it(' Seek Sentinel Activates When Device Reports New Position Then Reverts To Old Position', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(50);
+          finishedBufferingCallback();
+
+          waitForSentinels();
+          mockVideoMediaElement.currentTime = 0;
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+        });
+
+        it(' Seek Sentinel Does Not Fire In Live When Device Jumps Back Less Than Thirty Seconds', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(29.9);
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime = 0;
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+        });
+
+        it(' Seek Sentinel Fires In Live When Device Jumps Back More Than Thirty Seconds', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(30.1);
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime = 0;
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+        });
+
+        it(' Pause Sentinel Retries Pause If Pause Fails', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(0);
+          finishedBufferingCallback();
+          player.pause();
+
+          mockVideoMediaElement.currentTime += 1;
+          recentEvents = [];
+          mockVideoMediaElement.pause.calls.reset();
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
+          expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+        });
+
+        it(' Pause Sentinel Not Fired When Sentinels Disabled', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: true});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(0);
+          finishedBufferingCallback();
+          player.pause();
+
+          mockVideoMediaElement.currentTime += 1;
+          recentEvents = [];
+          mockVideoMediaElement.pause.calls.reset();
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+        });
+
+        it(' Pause Sentinel Does Not Retry Pause If Pause Succeeds', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(0);
+          finishedBufferingCallback();
+          player.pause();
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+        });
+
+        it(' Pause Sentinel Does Not Retry Pause If Pause Succeeds', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+          metaDataCallback({start: 0, end: 100});
+
+          player.beginPlaybackFrom(0);
+          finishedBufferingCallback();
+          player.pause();
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+        });
+
+        it(' End Of Media Sentinel Goes To Complete If Time Is Not Advancing And No Complete Event Fired', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(98);
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime = 99;
+          waitForSentinels();
+
+          mockVideoMediaElement.currentTime = 100;
+          waitForSentinels();
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_COMPLETE, MediaPlayerBase.EVENT.COMPLETE);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.COMPLETE);
+        });
+
+        it(' End Of Media Sentinel Not Fired When Sentinels Disabled', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: true});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(98);
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime = 99;
+          waitForSentinels();
+
+          mockVideoMediaElement.currentTime = 100;
+          waitForSentinels();
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_COMPLETE, MediaPlayerBase.EVENT.COMPLETE);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PLAYING);
+        });
+
+        it('EndOf Media Sentinel Does Not Activate If Time Is Not Advancing When Outside A Second Of End And No Complete Event Fired', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(98);
+          finishedBufferingCallback();
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_COMPLETE);
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.COMPLETE);
+        });
+
+        it(' End Of Media Sentinel Does Not Activate If Time Is Not Advancing When Outside Seekable Range But Within Duration', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(98);
+          finishedBufferingCallback();
+          mockVideoMediaElement.duration = 150;
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_COMPLETE);
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.COMPLETE);
+        });
+
+        it(' End Of Media Sentinel Does Not Activate If Reach End Of Media Normally', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(100);
+          finishedBufferingCallback();
+          endedCallback();
+
+          recentEvents = [];
+          waitForSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.COMPLETE);
+        });
+
+        it(' End Of Media Sentinel Does Not Activate If Time Is Advancing Near End Of Media And No Complete Event Fired', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(100);
+          finishedBufferingCallback();
+
+          recentEvents = [];
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_COMPLETE);
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.COMPLETE);
+        });
+
+        it(' Only One Sentinel Fired At A Time When Both Seek And Pause Sentinels Are Needed', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(0);
+          player.playFrom(30);
+
+          mockVideoMediaElement.currentTime = 0;
+          finishedBufferingCallback();
+          player.pause();
+
+          recentEvents = [];
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+
+          recentEvents = [];
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+        });
+
+        function resetStubsThenAdvanceTimeThenRunSentinels () {
+          recentEvents = [];
+          mockVideoMediaElement.pause.calls.reset();
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+        }
+
+        it(' Pause Sentinel Retries Pause Twice', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(0);
+          finishedBufferingCallback();
+          player.pause();
+
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+          expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+          expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Pause Sentinel Emits Failure Event And Gives Up On Third Attempt', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(0);
+          finishedBufferingCallback();
+          player.pause();
+
+          resetStubsThenAdvanceTimeThenRunSentinels();
+          resetStubsThenAdvanceTimeThenRunSentinels();
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+          expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
+
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).toEqual([]);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+          expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
+        });
+
+        it(' Pause Sentinel Attempt Count Is Not Reset By Calling Pause When Already Paused', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(0);
+          finishedBufferingCallback();
+
+          player.pause();
+          resetStubsThenAdvanceTimeThenRunSentinels();
+          player.pause();
+
+          resetStubsThenAdvanceTimeThenRunSentinels();
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+          expect(mockVideoMediaElement.pause).not.toHaveBeenCalled();
+        });
+
+        it(' Pause Sentinel Attempt Count Is Reset By Calling Pause When Not Paused', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(0);
+          finishedBufferingCallback();
+          player.pause();
+
+          resetStubsThenAdvanceTimeThenRunSentinels();
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          player.resume();
+          player.pause();
+
+          resetStubsThenAdvanceTimeThenRunSentinels();
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+          expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Seek Sentinel Retries Seek Twice', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(50);
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime = 0;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+
+          mockVideoMediaElement.currentTime = 0;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+        });
+
+        it(' Seek Sentinel Emits Failure Event And Gives Up On Third Attempt When Device Does Not Enter Buffering Upon Seek', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(50);
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime = 0;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          mockVideoMediaElement.currentTime = 0;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          mockVideoMediaElement.currentTime = 0;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE);
+          expect(mockVideoMediaElement.currentTime).toEqual(1);
+
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE);
+          expect(mockVideoMediaElement.currentTime).toEqual(2);
+        });
+
+        it(' Seek Sentinel Giving Up Does Not Prevent Pause Sentinel Activation', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(50);
+          finishedBufferingCallback();
+
+          player.pause();
+
+          mockVideoMediaElement.currentTime = 0;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+          mockVideoMediaElement.currentTime = 0;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
+          expect(player.getState()).toEqual(MediaPlayerBase.STATE.PAUSED);
+
+          mockVideoMediaElement.currentTime = 0;
+          mockVideoMediaElement.currentTime += 1;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
+          expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+
+          mockVideoMediaElement.currentTime = 0;
+          mockVideoMediaElement.currentTime += 1;
+          mockVideoMediaElement.currentTime += 1;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          // Ensure that pause has a second attempt (rather than seek returning, etc)
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
+          expect(mockVideoMediaElement.pause).toHaveBeenCalledTimes(1);
+        });
+
+        it(' Seek Sentinel Attempt Count Is Reset By Calling Play From', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(0);
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime = 0;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          mockVideoMediaElement.currentTime = 0;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+          mockVideoMediaElement.currentTime = 0;
+
+          player.playFrom(50);
+          finishedBufferingCallback();
+          mockVideoMediaElement.currentTime = 0;
+
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+        });
+
+        it(' Seek Sentinel Attempt Count Is Reset By Calling Begin Playback From', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(0);
+          finishedBufferingCallback();
+
+          mockVideoMediaElement.currentTime = 0;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          mockVideoMediaElement.currentTime = 0;
+          resetStubsThenAdvanceTimeThenRunSentinels();
+          mockVideoMediaElement.currentTime = 0;
+
+          player.stop();
+          player.beginPlaybackFrom(50);
+          finishedBufferingCallback();
+          mockVideoMediaElement.currentTime = 0;
+
+          resetStubsThenAdvanceTimeThenRunSentinels();
+
+          expect(recentEvents).toContain(MediaPlayerBase.EVENT.SENTINEL_SEEK);
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+        });
+
+        it(' Exit Buffering Sentinel Performs Deferred Seek If No Loaded Metadata Event', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.beginPlaybackFrom(50);
+
+          mockVideoMediaElement.currentTime += 1;
+          waitForSentinels();
+
+          expect(mockVideoMediaElement.currentTime).toEqual(50);
+        });
+
+        it(' Pause Sentinel Does Not Fire When Device Time Advances By Less Than Sentinel Tolerance', function () {
+          spyOnProperty(mockVideoMediaElement, 'seekable').and.returnValue({
+            start: function () {
+              return 0;
+            },
+            end: function () {
+              return 100;
+            },
+            length: 2
+          });
+          spyOnProperty(mockVideoMediaElement, 'duration').and.returnValue(100);
+
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {disableSentinels: false});
+
+          metaDataCallback({start: 0, end: 100});
+          player.beginPlaybackFrom(20);
+          finishedBufferingCallback();
+
+          recentEvents = [];
+
+          player.pause();
+          mockVideoMediaElement.currentTime += 0.01;
+          waitForSentinels();
+
+          expect(recentEvents).not.toContain(MediaPlayerBase.EVENT.SENTINEL_PAUSE);
+        });
+      });
     });
+  });

--- a/script-test/playbackstrategies/modifiers/live/playabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/playabletest.js
@@ -9,128 +9,128 @@ require(
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
     'bigscreenplayer/playbackstrategy/modifiers/live/playable'
   ],
-    function (MediaPlayerBase, PlayableMediaPlayer) {
-      var sourceContainer = document.createElement('div');
-      var player;
-      var playableMediaPlayer;
+  function (MediaPlayerBase, PlayableMediaPlayer) {
+    var sourceContainer = document.createElement('div');
+    var player;
+    var playableMediaPlayer;
 
-      function wrapperTests (action, expectedReturn) {
-        if (expectedReturn) {
-          player[action].and.returnValue(expectedReturn);
+    function wrapperTests (action, expectedReturn) {
+      if (expectedReturn) {
+        player[action].and.returnValue(expectedReturn);
 
-          expect(playableMediaPlayer[action]()).toBe(expectedReturn);
-        } else {
-          playableMediaPlayer[action]();
+        expect(playableMediaPlayer[action]()).toBe(expectedReturn);
+      } else {
+        playableMediaPlayer[action]();
 
-          expect(player[action]).toHaveBeenCalledTimes(1);
-        }
+        expect(player[action]).toHaveBeenCalledTimes(1);
       }
+    }
 
-      function isUndefined (action) {
-        expect(playableMediaPlayer[action]).not.toBeDefined();
-      }
+    function isUndefined (action) {
+      expect(playableMediaPlayer[action]).not.toBeDefined();
+    }
 
-      describe('Playable HMTL5 Live Player', function () {
-        beforeEach(function () {
-          player = jasmine.createSpyObj('player',
-            ['beginPlayback', 'initialiseMedia', 'stop', 'reset', 'getState', 'getSource', 'getMimeType',
-              'addEventCallback', 'removeEventCallback', 'removeAllEventCallbacks', 'getPlayerElement']);
+    describe('Playable HMTL5 Live Player', function () {
+      beforeEach(function () {
+        player = jasmine.createSpyObj('player',
+          ['beginPlayback', 'initialiseMedia', 'stop', 'reset', 'getState', 'getSource', 'getMimeType',
+            'addEventCallback', 'removeEventCallback', 'removeAllEventCallbacks', 'getPlayerElement']);
 
-          playableMediaPlayer = PlayableMediaPlayer(player);
+        playableMediaPlayer = PlayableMediaPlayer(player);
+      });
+
+      it('calls beginPlayback on the media player', function () {
+        wrapperTests('beginPlayback');
+      });
+
+      it('calls initialiseMedia on the media player', function () {
+        wrapperTests('initialiseMedia');
+      });
+
+      it('calls stop on the media player', function () {
+        wrapperTests('stop');
+      });
+
+      it('calls reset on the media player', function () {
+        wrapperTests('reset');
+      });
+
+      it('calls getState on the media player', function () {
+        wrapperTests('getState', 'thisState');
+      });
+
+      it('calls getSource on the media player', function () {
+        wrapperTests('getSource', 'thisSource');
+      });
+
+      it('calls getMimeType on the media player', function () {
+        wrapperTests('getMimeType', 'thisMimeType');
+      });
+
+      it('calls addEventCallback on the media player', function () {
+        var thisArg = 'arg';
+        var callback = function () { return; };
+        playableMediaPlayer.addEventCallback(thisArg, callback);
+
+        expect(player.addEventCallback).toHaveBeenCalledWith(thisArg, callback);
+      });
+
+      it('calls removeEventCallback on the media player', function () {
+        var thisArg = 'arg';
+        var callback = function () { return; };
+        playableMediaPlayer.removeEventCallback(thisArg, callback);
+
+        expect(player.removeEventCallback).toHaveBeenCalledWith(thisArg, callback);
+      });
+
+      it('calls removeAllEventCallbacks on the media player', function () {
+        wrapperTests('removeAllEventCallbacks');
+      });
+
+      it('calls getPlayerElement on the media player', function () {
+        wrapperTests('getPlayerElement', 'thisPlayerElement');
+      });
+
+      describe('should not have methods for', function () {
+        it('beginPlaybackFrom', function () {
+          isUndefined('beginPlaybackFrom');
         });
 
-        it('calls beginPlayback on the media player', function () {
-          wrapperTests('beginPlayback');
+        it('playFrom', function () {
+          isUndefined('playFrom');
         });
 
-        it('calls initialiseMedia on the media player', function () {
-          wrapperTests('initialiseMedia');
+        it('pause', function () {
+          isUndefined('pause');
         });
 
-        it('calls stop on the media player', function () {
-          wrapperTests('stop');
+        it('resume', function () {
+          isUndefined('resume');
         });
 
-        it('calls reset on the media player', function () {
-          wrapperTests('reset');
+        it('getCurrentTime', function () {
+          isUndefined('getCurrentTime');
         });
 
-        it('calls getState on the media player', function () {
-          wrapperTests('getState', 'thisState');
+        it('getSeekableRange', function () {
+          isUndefined('getSeekableRange');
+        });
+      });
+
+      describe('calls the mediaplayer with the correct media Type', function () {
+        it('when is an audio stream', function () {
+          var mediaType = MediaPlayerBase.TYPE.AUDIO;
+          playableMediaPlayer.initialiseMedia(mediaType, null, null, sourceContainer, null);
+
+          expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_AUDIO, null, null, sourceContainer, null);
         });
 
-        it('calls getSource on the media player', function () {
-          wrapperTests('getSource', 'thisSource');
-        });
+        it('when is an video stream', function () {
+          var mediaType = MediaPlayerBase.TYPE.VIDEO;
+          playableMediaPlayer.initialiseMedia(mediaType, null, null, sourceContainer, null);
 
-        it('calls getMimeType on the media player', function () {
-          wrapperTests('getMimeType', 'thisMimeType');
-        });
-
-        it('calls addEventCallback on the media player', function () {
-          var thisArg = 'arg';
-          var callback = function () { return; };
-          playableMediaPlayer.addEventCallback(thisArg, callback);
-
-          expect(player.addEventCallback).toHaveBeenCalledWith(thisArg, callback);
-        });
-
-        it('calls removeEventCallback on the media player', function () {
-          var thisArg = 'arg';
-          var callback = function () { return; };
-          playableMediaPlayer.removeEventCallback(thisArg, callback);
-
-          expect(player.removeEventCallback).toHaveBeenCalledWith(thisArg, callback);
-        });
-
-        it('calls removeAllEventCallbacks on the media player', function () {
-          wrapperTests('removeAllEventCallbacks');
-        });
-
-        it('calls getPlayerElement on the media player', function () {
-          wrapperTests('getPlayerElement', 'thisPlayerElement');
-        });
-
-        describe('should not have methods for', function () {
-          it('beginPlaybackFrom', function () {
-            isUndefined('beginPlaybackFrom');
-          });
-
-          it('playFrom', function () {
-            isUndefined('playFrom');
-          });
-
-          it('pause', function () {
-            isUndefined('pause');
-          });
-
-          it('resume', function () {
-            isUndefined('resume');
-          });
-
-          it('getCurrentTime', function () {
-            isUndefined('getCurrentTime');
-          });
-
-          it('getSeekableRange', function () {
-            isUndefined('getSeekableRange');
-          });
-        });
-
-        describe('calls the mediaplayer with the correct media Type', function () {
-          it('when is an audio stream', function () {
-            var mediaType = MediaPlayerBase.TYPE.AUDIO;
-            playableMediaPlayer.initialiseMedia(mediaType, null, null, sourceContainer, null);
-
-            expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_AUDIO, null, null, sourceContainer, null);
-          });
-
-          it('when is an video stream', function () {
-            var mediaType = MediaPlayerBase.TYPE.VIDEO;
-            playableMediaPlayer.initialiseMedia(mediaType, null, null, sourceContainer, null);
-
-            expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, null, null, sourceContainer, null);
-          });
+          expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, null, null, sourceContainer, null);
         });
       });
     });
+  });

--- a/script-test/playbackstrategies/modifiers/live/restartabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/restartabletest.js
@@ -4,423 +4,423 @@ require(
     'bigscreenplayer/playbackstrategy/modifiers/live/restartable',
     'bigscreenplayer/models/windowtypes'
   ],
-      function (MediaPlayerBase, RestartableMediaPlayer, WindowTypes) {
-        var sourceContainer = document.createElement('div');
-        var player;
-        var restartableMediaPlayer;
-        var testTime = {
-          windowStartTime: 0,
-          windowEndTime: 100000,
-          correction: 0
-        };
+  function (MediaPlayerBase, RestartableMediaPlayer, WindowTypes) {
+    var sourceContainer = document.createElement('div');
+    var player;
+    var restartableMediaPlayer;
+    var testTime = {
+      windowStartTime: 0,
+      windowEndTime: 100000,
+      correction: 0
+    };
 
-        var mockMediaSources = {
-          time: function () {
-            return testTime;
-          },
-          refresh: function (successCallback, errorCallback) {
-            successCallback();
-          }
-        };
+    var mockMediaSources = {
+      time: function () {
+        return testTime;
+      },
+      refresh: function (successCallback, errorCallback) {
+        successCallback();
+      }
+    };
 
-        function initialiseRestartableMediaPlayer (config, windowType) {
-          windowType = windowType || WindowTypes.SLIDING;
-          restartableMediaPlayer = RestartableMediaPlayer(player, config, windowType, mockMediaSources);
+    function initialiseRestartableMediaPlayer (config, windowType) {
+      windowType = windowType || WindowTypes.SLIDING;
+      restartableMediaPlayer = RestartableMediaPlayer(player, config, windowType, mockMediaSources);
+    }
+
+    describe('restartable HMTL5 Live Player', function () {
+      function wrapperTests (action, expectedReturn) {
+        if (expectedReturn) {
+          player[action].and.returnValue(expectedReturn);
+
+          expect(restartableMediaPlayer[action]()).toBe(expectedReturn);
+        } else {
+          restartableMediaPlayer[action]();
+
+          expect(player[action]).toHaveBeenCalledTimes(1);
+        }
+      }
+
+      beforeEach(function () {
+        player = jasmine.createSpyObj('player',
+          ['beginPlayback', 'initialiseMedia', 'stop', 'reset', 'getState', 'getSource', 'getMimeType',
+            'addEventCallback', 'removeEventCallback', 'removeAllEventCallbacks', 'getPlayerElement', 'pause',
+            'resume', 'beginPlaybackFrom']);
+      });
+
+      describe('methods call the appropriate media player methods', function () {
+        beforeEach(function () {
+          initialiseRestartableMediaPlayer();
+        });
+
+        it('calls beginPlayback on the media player', function () {
+          wrapperTests('beginPlayback');
+        });
+
+        it('calls initialiseMedia on the media player', function () {
+          wrapperTests('initialiseMedia');
+        });
+
+        it('calls stop on the media player', function () {
+          wrapperTests('stop');
+        });
+
+        it('calls reset on the media player', function () {
+          wrapperTests('reset');
+        });
+
+        it('calls getState on the media player', function () {
+          wrapperTests('getState', 'thisState');
+        });
+
+        it('calls getSource on the media player', function () {
+          wrapperTests('getSource', 'thisSource');
+        });
+
+        it('calls getMimeType on the media player', function () {
+          wrapperTests('getMimeType', 'thisMimeType');
+        });
+
+        it('calls addEventCallback on the media player', function () {
+          var thisArg = 'arg';
+          var callback = function () { return; };
+          restartableMediaPlayer.addEventCallback(thisArg, callback);
+
+          expect(player.addEventCallback).toHaveBeenCalledWith(thisArg, jasmine.any(Function));
+        });
+
+        it('calls removeEventCallback on the media player', function () {
+          var thisArg = 'arg';
+          var callback = function () { return; };
+          restartableMediaPlayer.addEventCallback(thisArg, callback);
+          restartableMediaPlayer.removeEventCallback(thisArg, callback);
+
+          expect(player.removeEventCallback).toHaveBeenCalledWith(thisArg, jasmine.any(Function));
+        });
+
+        it('calls removeAllEventCallbacks on the media player', function () {
+          wrapperTests('removeAllEventCallbacks');
+        });
+
+        it('calls getPlayerElement on the media player', function () {
+          wrapperTests('getPlayerElement', 'thisPlayerElement');
+        });
+
+        it('calls pause on the media player', function () {
+          wrapperTests('pause');
+        });
+      });
+
+      describe('should not have methods for', function () {
+        function isUndefined (action) {
+          expect(restartableMediaPlayer[action]).not.toBeDefined();
         }
 
-        describe('restartable HMTL5 Live Player', function () {
-          function wrapperTests (action, expectedReturn) {
-            if (expectedReturn) {
-              player[action].and.returnValue(expectedReturn);
+        beforeEach(function () {
+          initialiseRestartableMediaPlayer();
+        });
 
-              expect(restartableMediaPlayer[action]()).toBe(expectedReturn);
-            } else {
-              restartableMediaPlayer[action]();
+        it('playFrom', function () {
+          isUndefined('playFrom');
+        });
+      });
 
-              expect(player[action]).toHaveBeenCalledTimes(1);
-            }
-          }
+      describe('should use fake time for', function () {
+        var timeUpdates = [];
+        function timeUpdate (opts) {
+          timeUpdates.forEach(function (fn) { fn(opts); });
+        }
 
-          beforeEach(function () {
-            player = jasmine.createSpyObj('player',
-              ['beginPlayback', 'initialiseMedia', 'stop', 'reset', 'getState', 'getSource', 'getMimeType',
-                'addEventCallback', 'removeEventCallback', 'removeAllEventCallbacks', 'getPlayerElement', 'pause',
-                'resume', 'beginPlaybackFrom']);
+        beforeEach(function () {
+          jasmine.clock().install();
+          jasmine.clock().mockDate();
+
+          player.addEventCallback.and.callFake(function (self, callback) {
+            timeUpdates.push(callback);
           });
 
-          describe('methods call the appropriate media player methods', function () {
-            beforeEach(function () {
-              initialiseRestartableMediaPlayer();
-            });
+          initialiseRestartableMediaPlayer();
+        });
 
-            it('calls beginPlayback on the media player', function () {
-              wrapperTests('beginPlayback');
-            });
+        afterEach(function () {
+          jasmine.clock().uninstall();
+        });
 
-            it('calls initialiseMedia on the media player', function () {
-              wrapperTests('initialiseMedia');
-            });
+        describe('getCurrentTime', function () {
+          it('should be set on to the window length on beginPlayback', function () {
+            restartableMediaPlayer.beginPlayback();
 
-            it('calls stop on the media player', function () {
-              wrapperTests('stop');
-            });
-
-            it('calls reset on the media player', function () {
-              wrapperTests('reset');
-            });
-
-            it('calls getState on the media player', function () {
-              wrapperTests('getState', 'thisState');
-            });
-
-            it('calls getSource on the media player', function () {
-              wrapperTests('getSource', 'thisSource');
-            });
-
-            it('calls getMimeType on the media player', function () {
-              wrapperTests('getMimeType', 'thisMimeType');
-            });
-
-            it('calls addEventCallback on the media player', function () {
-              var thisArg = 'arg';
-              var callback = function () { return; };
-              restartableMediaPlayer.addEventCallback(thisArg, callback);
-
-              expect(player.addEventCallback).toHaveBeenCalledWith(thisArg, jasmine.any(Function));
-            });
-
-            it('calls removeEventCallback on the media player', function () {
-              var thisArg = 'arg';
-              var callback = function () { return; };
-              restartableMediaPlayer.addEventCallback(thisArg, callback);
-              restartableMediaPlayer.removeEventCallback(thisArg, callback);
-
-              expect(player.removeEventCallback).toHaveBeenCalledWith(thisArg, jasmine.any(Function));
-            });
-
-            it('calls removeAllEventCallbacks on the media player', function () {
-              wrapperTests('removeAllEventCallbacks');
-            });
-
-            it('calls getPlayerElement on the media player', function () {
-              wrapperTests('getPlayerElement', 'thisPlayerElement');
-            });
-
-            it('calls pause on the media player', function () {
-              wrapperTests('pause');
-            });
+            expect(restartableMediaPlayer.getCurrentTime()).toBe(100);
           });
 
-          describe('should not have methods for', function () {
-            function isUndefined (action) {
-              expect(restartableMediaPlayer[action]).not.toBeDefined();
-            }
+          it('should start at supplied time', function () {
+            restartableMediaPlayer.beginPlaybackFrom(10);
 
-            beforeEach(function () {
-              initialiseRestartableMediaPlayer();
-            });
-
-            it('playFrom', function () {
-              isUndefined('playFrom');
-            });
+            expect(restartableMediaPlayer.getCurrentTime()).toBe(10);
           });
 
-          describe('should use fake time for', function () {
-            var timeUpdates = [];
-            function timeUpdate (opts) {
-              timeUpdates.forEach(function (fn) { fn(opts); });
-            }
+          it('should increase when playing', function () {
+            restartableMediaPlayer.beginPlaybackFrom(10);
 
-            beforeEach(function () {
-              jasmine.clock().install();
-              jasmine.clock().mockDate();
+            timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
 
-              player.addEventCallback.and.callFake(function (self, callback) {
-                timeUpdates.push(callback);
-              });
+            jasmine.clock().tick(1000);
 
-              initialiseRestartableMediaPlayer();
-            });
+            timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
 
-            afterEach(function () {
-              jasmine.clock().uninstall();
-            });
-
-            describe('getCurrentTime', function () {
-              it('should be set on to the window length on beginPlayback', function () {
-                restartableMediaPlayer.beginPlayback();
-
-                expect(restartableMediaPlayer.getCurrentTime()).toBe(100);
-              });
-
-              it('should start at supplied time', function () {
-                restartableMediaPlayer.beginPlaybackFrom(10);
-
-                expect(restartableMediaPlayer.getCurrentTime()).toBe(10);
-              });
-
-              it('should increase when playing', function () {
-                restartableMediaPlayer.beginPlaybackFrom(10);
-
-                timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
-
-                jasmine.clock().tick(1000);
-
-                timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
-
-                expect(restartableMediaPlayer.getCurrentTime()).toBe(11);
-              });
-
-              it('should not increase when paused', function () {
-                restartableMediaPlayer.beginPlaybackFrom(10);
-                timeUpdate({ state: MediaPlayerBase.STATE.PAUSED });
-
-                jasmine.clock().tick(1000);
-
-                timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
-
-                expect(restartableMediaPlayer.getCurrentTime()).toBe(10);
-              });
-            });
-
-            describe('getSeekableRange', function () {
-              it('should start at the window time', function () {
-                restartableMediaPlayer.beginPlaybackFrom(0);
-
-                timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
-
-                expect(restartableMediaPlayer.getSeekableRange()).toEqual({ start: 0, end: 100 });
-              });
-
-              it('should increase start and end for a sliding window', function () {
-                restartableMediaPlayer.beginPlaybackFrom(0);
-
-                timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
-
-                jasmine.clock().tick(1000);
-
-                expect(restartableMediaPlayer.getSeekableRange()).toEqual({ start: 1, end: 101 });
-              });
-
-              it('should only increase end for a growing window', function () {
-                initialiseRestartableMediaPlayer({}, WindowTypes.GROWING);
-                restartableMediaPlayer.beginPlaybackFrom(0);
-                timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
-                jasmine.clock().tick(1000);
-
-                expect(restartableMediaPlayer.getSeekableRange()).toEqual({ start: 0, end: 101 });
-              });
-            });
+            expect(restartableMediaPlayer.getCurrentTime()).toBe(11);
           });
 
-          describe('calls the mediaplayer with the correct media Type', function () {
-            beforeEach(function () {
-              initialiseRestartableMediaPlayer();
-            });
+          it('should not increase when paused', function () {
+            restartableMediaPlayer.beginPlaybackFrom(10);
+            timeUpdate({ state: MediaPlayerBase.STATE.PAUSED });
 
-            it('for static video', function () {
-              restartableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, '', '', sourceContainer);
+            jasmine.clock().tick(1000);
 
-              expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer, undefined);
-            });
+            timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
 
-            it('for live video', function () {
-              restartableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer);
+            expect(restartableMediaPlayer.getCurrentTime()).toBe(10);
+          });
+        });
 
-              expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer, undefined);
-            });
+        describe('getSeekableRange', function () {
+          it('should start at the window time', function () {
+            restartableMediaPlayer.beginPlaybackFrom(0);
 
-            it('for static audio', function () {
-              restartableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, '', '', sourceContainer);
+            timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
 
-              expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_AUDIO, '', '', sourceContainer, undefined);
-            });
+            expect(restartableMediaPlayer.getSeekableRange()).toEqual({ start: 0, end: 100 });
           });
 
-          describe('Restartable features', function () {
-            it('begins playback with the desired offset', function () {
-              initialiseRestartableMediaPlayer();
-              var offset = 10;
+          it('should increase start and end for a sliding window', function () {
+            restartableMediaPlayer.beginPlaybackFrom(0);
 
-              restartableMediaPlayer.beginPlaybackFrom(offset);
+            timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
 
-              expect(player.beginPlaybackFrom).toHaveBeenCalledWith(offset);
-            });
+            jasmine.clock().tick(1000);
 
-            it('should respect config forcing playback from the end of the window', function () {
-              var config = {
-                streaming: {
-                  overrides: {
-                    forceBeginPlaybackToEndOfWindow: true
-                  }
-                }
-              };
-              initialiseRestartableMediaPlayer(config);
-
-              restartableMediaPlayer.beginPlayback();
-
-              expect(player.beginPlaybackFrom).toHaveBeenCalledWith(Infinity);
-            });
+            expect(restartableMediaPlayer.getSeekableRange()).toEqual({ start: 1, end: 101 });
           });
 
-          describe('Pausing and Auto-Resume', function () {
-            var mockCallback = [];
+          it('should only increase end for a growing window', function () {
+            initialiseRestartableMediaPlayer({}, WindowTypes.GROWING);
+            restartableMediaPlayer.beginPlaybackFrom(0);
+            timeUpdate({ state: MediaPlayerBase.STATE.PLAYING });
+            jasmine.clock().tick(1000);
 
-            function startPlaybackAndPause (startTime, disableAutoResume) {
-              restartableMediaPlayer.beginPlaybackFrom(startTime);
-
-              for (var index = 0; index < mockCallback.length; index++) {
-                mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING});
-              }
-
-              restartableMediaPlayer.pause({disableAutoResume: disableAutoResume});
-
-              for (index = 0; index < mockCallback.length; index++) {
-                mockCallback[index]({state: MediaPlayerBase.STATE.PAUSED});
-              }
-            }
-
-            beforeEach(function () {
-              jasmine.clock().install();
-              jasmine.clock().mockDate();
-
-              player.addEventCallback.and.callFake(function (self, callback) {
-                mockCallback.push(callback);
-              });
-
-              initialiseRestartableMediaPlayer();
-
-              for (var index = 0; index < mockCallback.length; index++) {
-                mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING});
-              }
-            });
-
-            afterEach(function () {
-              jasmine.clock().uninstall();
-              mockCallback = [];
-            });
-
-            it('calls resume when approaching the start of the buffer', function () {
-              startPlaybackAndPause(20, false);
-
-              jasmine.clock().tick(12 * 1000);
-
-              expect(player.resume).toHaveBeenCalledWith();
-            });
-
-            it('does not call resume when approaching the start of the buffer with the disableAutoResume option', function () {
-              startPlaybackAndPause(20, true);
-
-              jasmine.clock().tick(12 * 1000);
-
-              expect(player.resume).not.toHaveBeenCalledWith();
-            });
-
-            it('does not call resume if paused after the autoresume point', function () {
-              startPlaybackAndPause(20, false);
-
-              jasmine.clock().tick(11 * 1000);
-
-              expect(player.resume).not.toHaveBeenCalledWith();
-            });
-
-            it('does not auto-resume if the video is no longer paused', function () {
-              startPlaybackAndPause(20, false);
-
-              for (var index = 0; index < mockCallback.length; index++) {
-                mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING});
-              }
-
-              jasmine.clock().tick(12 * 1000);
-
-              expect(player.resume).not.toHaveBeenCalledTimes(2);
-            });
-
-            it('Calls resume when paused is called multiple times', function () {
-              startPlaybackAndPause(0, false);
-
-              var event = {state: MediaPlayerBase.STATE.PLAYING, currentTime: 25};
-              for (var index = 0; index < mockCallback.length; index++) {
-                mockCallback[index](event);
-              }
-
-              restartableMediaPlayer.pause();
-
-              event.currentTime = 30;
-              for (index = 0; index < mockCallback.length; index++) {
-                mockCallback[index](event);
-              }
-
-              restartableMediaPlayer.pause();
-              // uses real time to determine pause intervals
-              // if debugging the time to the buffer will be decreased by the time spent.
-              jasmine.clock().tick(22 * 1000);
-
-              expect(player.resume).toHaveBeenCalledTimes(1);
-            });
-
-            it('calls auto-resume immeditetly if paused after an autoresume', function () {
-              startPlaybackAndPause(20, false);
-
-              jasmine.clock().tick(12 * 1000);
-
-              restartableMediaPlayer.pause();
-
-              jasmine.clock().tick(1);
-
-              expect(player.resume).toHaveBeenCalledTimes(2);
-            });
-
-            it('auto-resume is not cancelled by a paused event state', function () {
-              startPlaybackAndPause(20, false);
-
-              for (var index = 0; index < mockCallback.length; index++) {
-                mockCallback[index]({state: MediaPlayerBase.STATE.PAUSED});
-              }
-
-              jasmine.clock().tick(12 * 1000);
-
-              expect(player.resume).toHaveBeenCalledTimes(1);
-            });
-
-            it('will fake pause if attempting to pause at the start of playback ', function () {
-              startPlaybackAndPause(0, false);
-
-              jasmine.clock().tick(1);
-
-              expect(player.pause).toHaveBeenCalledTimes(1);
-              expect(player.resume).toHaveBeenCalledTimes(1);
-            });
-
-            it('does not calls autoresume immeditetly if paused after an auto-resume with disableAutoResume options', function () {
-              startPlaybackAndPause(20, true);
-
-              jasmine.clock().tick(12 * 1000);
-
-              jasmine.clock().tick(1);
-
-              expect(player.resume).not.toHaveBeenCalledTimes(1);
-            });
-
-            it('time spend buffering is deducted when considering time to auto-resume', function () {
-              restartableMediaPlayer.beginPlaybackFrom(20);
-
-              for (var index = 0; index < mockCallback.length; index++) {
-                mockCallback[index]({state: MediaPlayerBase.STATE.BUFFERING, currentTime: 20});
-              }
-
-              jasmine.clock().tick(11 * 1000);
-
-              for (index = 0; index < mockCallback.length; index++) {
-                mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING, currentTime: 20});
-              }
-
-              restartableMediaPlayer.pause();
-
-              jasmine.clock().tick(3 * 1000);
-
-              expect(player.resume).toHaveBeenCalledTimes(1);
-            });
+            expect(restartableMediaPlayer.getSeekableRange()).toEqual({ start: 0, end: 101 });
           });
         });
       });
+
+      describe('calls the mediaplayer with the correct media Type', function () {
+        beforeEach(function () {
+          initialiseRestartableMediaPlayer();
+        });
+
+        it('for static video', function () {
+          restartableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, '', '', sourceContainer);
+
+          expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer, undefined);
+        });
+
+        it('for live video', function () {
+          restartableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer);
+
+          expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer, undefined);
+        });
+
+        it('for static audio', function () {
+          restartableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, '', '', sourceContainer);
+
+          expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_AUDIO, '', '', sourceContainer, undefined);
+        });
+      });
+
+      describe('Restartable features', function () {
+        it('begins playback with the desired offset', function () {
+          initialiseRestartableMediaPlayer();
+          var offset = 10;
+
+          restartableMediaPlayer.beginPlaybackFrom(offset);
+
+          expect(player.beginPlaybackFrom).toHaveBeenCalledWith(offset);
+        });
+
+        it('should respect config forcing playback from the end of the window', function () {
+          var config = {
+            streaming: {
+              overrides: {
+                forceBeginPlaybackToEndOfWindow: true
+              }
+            }
+          };
+          initialiseRestartableMediaPlayer(config);
+
+          restartableMediaPlayer.beginPlayback();
+
+          expect(player.beginPlaybackFrom).toHaveBeenCalledWith(Infinity);
+        });
+      });
+
+      describe('Pausing and Auto-Resume', function () {
+        var mockCallback = [];
+
+        function startPlaybackAndPause (startTime, disableAutoResume) {
+          restartableMediaPlayer.beginPlaybackFrom(startTime);
+
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING});
+          }
+
+          restartableMediaPlayer.pause({disableAutoResume: disableAutoResume});
+
+          for (index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.PAUSED});
+          }
+        }
+
+        beforeEach(function () {
+          jasmine.clock().install();
+          jasmine.clock().mockDate();
+
+          player.addEventCallback.and.callFake(function (self, callback) {
+            mockCallback.push(callback);
+          });
+
+          initialiseRestartableMediaPlayer();
+
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING});
+          }
+        });
+
+        afterEach(function () {
+          jasmine.clock().uninstall();
+          mockCallback = [];
+        });
+
+        it('calls resume when approaching the start of the buffer', function () {
+          startPlaybackAndPause(20, false);
+
+          jasmine.clock().tick(12 * 1000);
+
+          expect(player.resume).toHaveBeenCalledWith();
+        });
+
+        it('does not call resume when approaching the start of the buffer with the disableAutoResume option', function () {
+          startPlaybackAndPause(20, true);
+
+          jasmine.clock().tick(12 * 1000);
+
+          expect(player.resume).not.toHaveBeenCalledWith();
+        });
+
+        it('does not call resume if paused after the autoresume point', function () {
+          startPlaybackAndPause(20, false);
+
+          jasmine.clock().tick(11 * 1000);
+
+          expect(player.resume).not.toHaveBeenCalledWith();
+        });
+
+        it('does not auto-resume if the video is no longer paused', function () {
+          startPlaybackAndPause(20, false);
+
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING});
+          }
+
+          jasmine.clock().tick(12 * 1000);
+
+          expect(player.resume).not.toHaveBeenCalledTimes(2);
+        });
+
+        it('Calls resume when paused is called multiple times', function () {
+          startPlaybackAndPause(0, false);
+
+          var event = {state: MediaPlayerBase.STATE.PLAYING, currentTime: 25};
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index](event);
+          }
+
+          restartableMediaPlayer.pause();
+
+          event.currentTime = 30;
+          for (index = 0; index < mockCallback.length; index++) {
+            mockCallback[index](event);
+          }
+
+          restartableMediaPlayer.pause();
+          // uses real time to determine pause intervals
+          // if debugging the time to the buffer will be decreased by the time spent.
+          jasmine.clock().tick(22 * 1000);
+
+          expect(player.resume).toHaveBeenCalledTimes(1);
+        });
+
+        it('calls auto-resume immeditetly if paused after an autoresume', function () {
+          startPlaybackAndPause(20, false);
+
+          jasmine.clock().tick(12 * 1000);
+
+          restartableMediaPlayer.pause();
+
+          jasmine.clock().tick(1);
+
+          expect(player.resume).toHaveBeenCalledTimes(2);
+        });
+
+        it('auto-resume is not cancelled by a paused event state', function () {
+          startPlaybackAndPause(20, false);
+
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.PAUSED});
+          }
+
+          jasmine.clock().tick(12 * 1000);
+
+          expect(player.resume).toHaveBeenCalledTimes(1);
+        });
+
+        it('will fake pause if attempting to pause at the start of playback ', function () {
+          startPlaybackAndPause(0, false);
+
+          jasmine.clock().tick(1);
+
+          expect(player.pause).toHaveBeenCalledTimes(1);
+          expect(player.resume).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not calls autoresume immeditetly if paused after an auto-resume with disableAutoResume options', function () {
+          startPlaybackAndPause(20, true);
+
+          jasmine.clock().tick(12 * 1000);
+
+          jasmine.clock().tick(1);
+
+          expect(player.resume).not.toHaveBeenCalledTimes(1);
+        });
+
+        it('time spend buffering is deducted when considering time to auto-resume', function () {
+          restartableMediaPlayer.beginPlaybackFrom(20);
+
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.BUFFERING, currentTime: 20});
+          }
+
+          jasmine.clock().tick(11 * 1000);
+
+          for (index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING, currentTime: 20});
+          }
+
+          restartableMediaPlayer.pause();
+
+          jasmine.clock().tick(3 * 1000);
+
+          expect(player.resume).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+  });

--- a/script-test/playbackstrategies/modifiers/live/seekabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/seekabletest.js
@@ -3,330 +3,330 @@ require(
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
     'bigscreenplayer/playbackstrategy/modifiers/live/seekable'
   ],
-    function (MediaPlayerBase, SeekableMediaPlayer) {
-      var sourceContainer = document.createElement('div');
-      var player;
-      var seekableMediaPlayer;
+  function (MediaPlayerBase, SeekableMediaPlayer) {
+    var sourceContainer = document.createElement('div');
+    var player;
+    var seekableMediaPlayer;
 
-      function wrapperTests (action, expectedReturn) {
-        if (expectedReturn) {
-          player[action].and.returnValue(expectedReturn);
+    function wrapperTests (action, expectedReturn) {
+      if (expectedReturn) {
+        player[action].and.returnValue(expectedReturn);
 
-          expect(seekableMediaPlayer[action]()).toBe(expectedReturn);
-        } else {
-          seekableMediaPlayer[action]();
+        expect(seekableMediaPlayer[action]()).toBe(expectedReturn);
+      } else {
+        seekableMediaPlayer[action]();
 
-          expect(player[action]).toHaveBeenCalledTimes(1);
-        }
+        expect(player[action]).toHaveBeenCalledTimes(1);
       }
+    }
 
-      function initialiseSeekableMediaPlayer (config) {
-        seekableMediaPlayer = SeekableMediaPlayer(player, config);
-      }
+    function initialiseSeekableMediaPlayer (config) {
+      seekableMediaPlayer = SeekableMediaPlayer(player, config);
+    }
 
-      describe('Seekable HMTL5 Live Player', function () {
+    describe('Seekable HMTL5 Live Player', function () {
+      beforeEach(function () {
+        player = jasmine.createSpyObj('player',
+          ['beginPlayback', 'initialiseMedia', 'stop', 'reset', 'getState', 'getSource', 'getMimeType',
+            'addEventCallback', 'removeEventCallback', 'removeAllEventCallbacks', 'getPlayerElement', 'pause',
+            'resume', 'beginPlaybackFrom', 'playFrom', 'getCurrentTime', 'getSeekableRange', 'toPaused',
+            'toPlaying']);
+      });
+
+      describe('methods call the appropriate media player methods', function () {
         beforeEach(function () {
-          player = jasmine.createSpyObj('player',
-            ['beginPlayback', 'initialiseMedia', 'stop', 'reset', 'getState', 'getSource', 'getMimeType',
-              'addEventCallback', 'removeEventCallback', 'removeAllEventCallbacks', 'getPlayerElement', 'pause',
-              'resume', 'beginPlaybackFrom', 'playFrom', 'getCurrentTime', 'getSeekableRange', 'toPaused',
-              'toPlaying']);
+          initialiseSeekableMediaPlayer();
         });
 
-        describe('methods call the appropriate media player methods', function () {
-          beforeEach(function () {
-            initialiseSeekableMediaPlayer();
-          });
-
-          it('calls beginPlayback on the media player', function () {
-            wrapperTests('beginPlayback');
-          });
-
-          it('calls initialiseMedia on the media player', function () {
-            wrapperTests('initialiseMedia');
-          });
-
-          it('calls beginPlayingFrom on the media player', function () {
-            var arg = 0;
-            seekableMediaPlayer.beginPlaybackFrom(arg);
-
-            expect(player.beginPlaybackFrom).toHaveBeenCalledWith(arg);
-          });
-
-          it('calls playFrom on the media player', function () {
-            var arg = 0;
-            seekableMediaPlayer.playFrom(arg);
-
-            expect(player.playFrom).toHaveBeenCalledWith(arg);
-          });
-
-          it('calls stop on the media player', function () {
-            wrapperTests('stop');
-          });
-
-          it('calls reset on the media player', function () {
-            wrapperTests('reset');
-          });
-
-          it('calls getState on the media player', function () {
-            wrapperTests('getState', 'thisState');
-          });
-
-          it('calls getSource on the media player', function () {
-            wrapperTests('getSource', 'thisSource');
-          });
-
-          it('calls getMimeType on the media player', function () {
-            wrapperTests('getMimeType', 'thisMimeType');
-          });
-
-          it('calls addEventCallback on the media player', function () {
-            var thisArg = 'arg';
-            var callback = function () { return; };
-            seekableMediaPlayer.addEventCallback(thisArg, callback);
-
-            expect(player.addEventCallback).toHaveBeenCalledWith(thisArg, callback);
-          });
-
-          it('calls removeEventCallback on the media player', function () {
-            var thisArg = 'arg';
-            var callback = function () { return; };
-            seekableMediaPlayer.removeEventCallback(thisArg, callback);
-
-            expect(player.removeEventCallback).toHaveBeenCalledWith(thisArg, callback);
-          });
-
-          it('calls removeAllEventCallbacks on the media player', function () {
-            wrapperTests('removeAllEventCallbacks');
-          });
-
-          it('calls getPlayerElement on the media player', function () {
-            wrapperTests('getPlayerElement');
-          });
-
-          it('calls pause on the media player', function () {
-            player.getSeekableRange.and.returnValue({start: 0});
-
-            wrapperTests('pause');
-          });
-
-          it('calls getCurrentTime on media player', function () {
-            wrapperTests('getCurrentTime', 'thisTime');
-          });
-
-          it('calls getSeekableRange on media player', function () {
-            wrapperTests('getSeekableRange', 'thisRange');
-          });
+        it('calls beginPlayback on the media player', function () {
+          wrapperTests('beginPlayback');
         });
 
-        describe('Seekable features', function () {
-          it('should respect config forcing playback from the end of the window', function () {
-            var config = {
-              streaming: {
-                overrides: {
-                  forceBeginPlaybackToEndOfWindow: true
-                }
+        it('calls initialiseMedia on the media player', function () {
+          wrapperTests('initialiseMedia');
+        });
+
+        it('calls beginPlayingFrom on the media player', function () {
+          var arg = 0;
+          seekableMediaPlayer.beginPlaybackFrom(arg);
+
+          expect(player.beginPlaybackFrom).toHaveBeenCalledWith(arg);
+        });
+
+        it('calls playFrom on the media player', function () {
+          var arg = 0;
+          seekableMediaPlayer.playFrom(arg);
+
+          expect(player.playFrom).toHaveBeenCalledWith(arg);
+        });
+
+        it('calls stop on the media player', function () {
+          wrapperTests('stop');
+        });
+
+        it('calls reset on the media player', function () {
+          wrapperTests('reset');
+        });
+
+        it('calls getState on the media player', function () {
+          wrapperTests('getState', 'thisState');
+        });
+
+        it('calls getSource on the media player', function () {
+          wrapperTests('getSource', 'thisSource');
+        });
+
+        it('calls getMimeType on the media player', function () {
+          wrapperTests('getMimeType', 'thisMimeType');
+        });
+
+        it('calls addEventCallback on the media player', function () {
+          var thisArg = 'arg';
+          var callback = function () { return; };
+          seekableMediaPlayer.addEventCallback(thisArg, callback);
+
+          expect(player.addEventCallback).toHaveBeenCalledWith(thisArg, callback);
+        });
+
+        it('calls removeEventCallback on the media player', function () {
+          var thisArg = 'arg';
+          var callback = function () { return; };
+          seekableMediaPlayer.removeEventCallback(thisArg, callback);
+
+          expect(player.removeEventCallback).toHaveBeenCalledWith(thisArg, callback);
+        });
+
+        it('calls removeAllEventCallbacks on the media player', function () {
+          wrapperTests('removeAllEventCallbacks');
+        });
+
+        it('calls getPlayerElement on the media player', function () {
+          wrapperTests('getPlayerElement');
+        });
+
+        it('calls pause on the media player', function () {
+          player.getSeekableRange.and.returnValue({start: 0});
+
+          wrapperTests('pause');
+        });
+
+        it('calls getCurrentTime on media player', function () {
+          wrapperTests('getCurrentTime', 'thisTime');
+        });
+
+        it('calls getSeekableRange on media player', function () {
+          wrapperTests('getSeekableRange', 'thisRange');
+        });
+      });
+
+      describe('Seekable features', function () {
+        it('should respect config forcing playback from the end of the window', function () {
+          var config = {
+            streaming: {
+              overrides: {
+                forceBeginPlaybackToEndOfWindow: true
               }
-            };
-            initialiseSeekableMediaPlayer(config);
+            }
+          };
+          initialiseSeekableMediaPlayer(config);
 
-            seekableMediaPlayer.beginPlayback();
+          seekableMediaPlayer.beginPlayback();
 
-            expect(player.beginPlaybackFrom).toHaveBeenCalledWith(Infinity);
+          expect(player.beginPlaybackFrom).toHaveBeenCalledWith(Infinity);
+        });
+      });
+
+      describe('calls the mediaplayer with the correct media Type', function () {
+        beforeEach(function () {
+          initialiseSeekableMediaPlayer();
+        });
+
+        it('for static video', function () {
+          seekableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, '', '', sourceContainer);
+
+          expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer, undefined);
+        });
+
+        it('for live video', function () {
+          seekableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer);
+
+          expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer, undefined);
+        });
+
+        it('for static audio', function () {
+          seekableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, '', '', sourceContainer);
+
+          expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_AUDIO, '', '', sourceContainer, undefined);
+        });
+      });
+
+      describe('Pausing and Auto-Resume', function () {
+        var mockCallback = [];
+
+        function startPlaybackAndPause (startTime, disableAutoResume) {
+          seekableMediaPlayer.beginPlaybackFrom(startTime || 0);
+          seekableMediaPlayer.pause({disableAutoResume: disableAutoResume});
+        }
+
+        beforeEach(function () {
+          jasmine.clock().install();
+          jasmine.clock().mockDate();
+
+          initialiseSeekableMediaPlayer();
+
+          player.getSeekableRange.and.returnValue({start: 0});
+          player.getCurrentTime.and.returnValue(20);
+
+          player.addEventCallback.and.callFake(function (self, callback) {
+            mockCallback.push(callback);
           });
         });
 
-        describe('calls the mediaplayer with the correct media Type', function () {
-          beforeEach(function () {
-            initialiseSeekableMediaPlayer();
-          });
-
-          it('for static video', function () {
-            seekableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, '', '', sourceContainer);
-
-            expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer, undefined);
-          });
-
-          it('for live video', function () {
-            seekableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer);
-
-            expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer, undefined);
-          });
-
-          it('for static audio', function () {
-            seekableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, '', '', sourceContainer);
-
-            expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_AUDIO, '', '', sourceContainer, undefined);
-          });
+        afterEach(function () {
+          jasmine.clock().uninstall();
+          mockCallback = [];
         });
 
-        describe('Pausing and Auto-Resume', function () {
-          var mockCallback = [];
+        it('calls resume when approaching the start of the buffer', function () {
+          startPlaybackAndPause(20, false);
 
-          function startPlaybackAndPause (startTime, disableAutoResume) {
-            seekableMediaPlayer.beginPlaybackFrom(startTime || 0);
-            seekableMediaPlayer.pause({disableAutoResume: disableAutoResume});
+          jasmine.clock().tick(12 * 1000);
+
+          expect(player.resume).toHaveBeenCalledWith();
+        });
+
+        it('does not call resume when approaching the start of the buffer with the disableAutoResume option', function () {
+          startPlaybackAndPause(20, true);
+
+          jasmine.clock().tick(11 * 1000);
+
+          expect(player.resume).not.toHaveBeenCalledWith();
+        });
+
+        it('does not call resume if paused after the auto resume point', function () {
+          startPlaybackAndPause(20, false);
+
+          jasmine.clock().tick(11 * 1000);
+
+          expect(player.resume).not.toHaveBeenCalledWith();
+        });
+
+        it('does not auto-resume if the video is no longer paused', function () {
+          startPlaybackAndPause(20, false);
+
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING});
           }
 
-          beforeEach(function () {
-            jasmine.clock().install();
-            jasmine.clock().mockDate();
+          jasmine.clock().tick(12 * 1000);
 
-            initialiseSeekableMediaPlayer();
+          expect(player.resume).not.toHaveBeenCalled();
+        });
 
-            player.getSeekableRange.and.returnValue({start: 0});
-            player.getCurrentTime.and.returnValue(20);
+        it('Calls resume when paused is called multiple times', function () {
+          startPlaybackAndPause(0, false);
 
-            player.addEventCallback.and.callFake(function (self, callback) {
-              mockCallback.push(callback);
-            });
-          });
+          var event = {state: MediaPlayerBase.STATE.PLAYING, currentTime: 25};
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index](event);
+          }
 
-          afterEach(function () {
-            jasmine.clock().uninstall();
-            mockCallback = [];
-          });
+          seekableMediaPlayer.pause();
 
-          it('calls resume when approaching the start of the buffer', function () {
-            startPlaybackAndPause(20, false);
+          event.currentTime = 30;
+          for (index = 0; index < mockCallback.length; index++) {
+            mockCallback[index](event);
+          }
 
-            jasmine.clock().tick(12 * 1000);
+          seekableMediaPlayer.pause();
+          // uses real time to determine pause intervals
+          // if debugging the time to the buffer will be decreased by the time spent.
+          jasmine.clock().tick(22 * 1000);
 
-            expect(player.resume).toHaveBeenCalledWith();
-          });
+          expect(player.resume).toHaveBeenCalledTimes(1);
+        });
 
-          it('does not call resume when approaching the start of the buffer with the disableAutoResume option', function () {
-            startPlaybackAndPause(20, true);
+        it('calls auto-resume immeditetly if paused after an autoresume', function () {
+          startPlaybackAndPause(20, false);
 
-            jasmine.clock().tick(11 * 1000);
+          jasmine.clock().tick(12 * 1000);
 
-            expect(player.resume).not.toHaveBeenCalledWith();
-          });
+          player.getSeekableRange.and.returnValue({start: 12});
 
-          it('does not call resume if paused after the auto resume point', function () {
-            startPlaybackAndPause(20, false);
+          seekableMediaPlayer.pause();
 
-            jasmine.clock().tick(11 * 1000);
+          jasmine.clock().tick(1);
 
-            expect(player.resume).not.toHaveBeenCalledWith();
-          });
+          expect(player.resume).toHaveBeenCalledTimes(1);
+          expect(player.toPaused).toHaveBeenCalledTimes(1);
+          expect(player.toPlaying).toHaveBeenCalledTimes(1);
+        });
 
-          it('does not auto-resume if the video is no longer paused', function () {
-            startPlaybackAndPause(20, false);
+        it('does not calls autoresume immeditetly if paused after an auto-resume with disableAutoResume options', function () {
+          startPlaybackAndPause(20, true);
 
-            for (var index = 0; index < mockCallback.length; index++) {
-              mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING});
-            }
+          jasmine.clock().tick(12 * 1000);
+          player.getSeekableRange.and.returnValue({start: 12});
 
-            jasmine.clock().tick(12 * 1000);
+          jasmine.clock().tick(1);
 
-            expect(player.resume).not.toHaveBeenCalled();
-          });
+          expect(player.resume).not.toHaveBeenCalledTimes(1);
+        });
 
-          it('Calls resume when paused is called multiple times', function () {
-            startPlaybackAndPause(0, false);
+        it('auto-resume is not cancelled by a paused event state', function () {
+          startPlaybackAndPause(20, false);
 
-            var event = {state: MediaPlayerBase.STATE.PLAYING, currentTime: 25};
-            for (var index = 0; index < mockCallback.length; index++) {
-              mockCallback[index](event);
-            }
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.PAUSED});
+          }
 
-            seekableMediaPlayer.pause();
+          jasmine.clock().tick(12 * 1000);
 
-            event.currentTime = 30;
-            for (index = 0; index < mockCallback.length; index++) {
-              mockCallback[index](event);
-            }
+          expect(player.resume).toHaveBeenCalledTimes(1);
+        });
 
-            seekableMediaPlayer.pause();
-            // uses real time to determine pause intervals
-            // if debugging the time to the buffer will be decreased by the time spent.
-            jasmine.clock().tick(22 * 1000);
+        it('will fake pause if attempting to pause at the start of playback ', function () {
+          player.getCurrentTime.and.returnValue(0);
+          startPlaybackAndPause(0, false);
 
-            expect(player.resume).toHaveBeenCalledTimes(1);
-          });
+          expect(player.toPaused).toHaveBeenCalledTimes(1);
+          expect(player.toPlaying).toHaveBeenCalledTimes(1);
+        });
 
-          it('calls auto-resume immeditetly if paused after an autoresume', function () {
-            startPlaybackAndPause(20, false);
+        it('time spend buffering is deducted when considering time to auto-resume', function () {
+          startPlaybackAndPause(0, false);
 
-            jasmine.clock().tick(12 * 1000);
+          seekableMediaPlayer.resume();
+          player.resume.calls.reset();
 
-            player.getSeekableRange.and.returnValue({start: 12});
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.BUFFERING, currentTime: 20});
+          }
 
-            seekableMediaPlayer.pause();
+          jasmine.clock().tick(11 * 1000);
 
-            jasmine.clock().tick(1);
+          for (index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING, currentTime: 20});
+          }
+          player.getSeekableRange.and.returnValue({start: 20});
 
-            expect(player.resume).toHaveBeenCalledTimes(1);
-            expect(player.toPaused).toHaveBeenCalledTimes(1);
-            expect(player.toPlaying).toHaveBeenCalledTimes(1);
-          });
+          seekableMediaPlayer.pause();
 
-          it('does not calls autoresume immeditetly if paused after an auto-resume with disableAutoResume options', function () {
-            startPlaybackAndPause(20, true);
+          jasmine.clock().tick(3 * 1000);
 
-            jasmine.clock().tick(12 * 1000);
-            player.getSeekableRange.and.returnValue({start: 12});
+          expect(player.toPlaying).toHaveBeenCalledTimes(1);
+        });
 
-            jasmine.clock().tick(1);
+        it('does not calls autoresume immeditetly if paused after an auto-resume with disableAutoResume options', function () {
+          startPlaybackAndPause(20, true);
 
-            expect(player.resume).not.toHaveBeenCalledTimes(1);
-          });
+          jasmine.clock().tick(12 * 1000);
 
-          it('auto-resume is not cancelled by a paused event state', function () {
-            startPlaybackAndPause(20, false);
+          jasmine.clock().tick(1);
 
-            for (var index = 0; index < mockCallback.length; index++) {
-              mockCallback[index]({state: MediaPlayerBase.STATE.PAUSED});
-            }
-
-            jasmine.clock().tick(12 * 1000);
-
-            expect(player.resume).toHaveBeenCalledTimes(1);
-          });
-
-          it('will fake pause if attempting to pause at the start of playback ', function () {
-            player.getCurrentTime.and.returnValue(0);
-            startPlaybackAndPause(0, false);
-
-            expect(player.toPaused).toHaveBeenCalledTimes(1);
-            expect(player.toPlaying).toHaveBeenCalledTimes(1);
-          });
-
-          it('time spend buffering is deducted when considering time to auto-resume', function () {
-            startPlaybackAndPause(0, false);
-
-            seekableMediaPlayer.resume();
-            player.resume.calls.reset();
-
-            for (var index = 0; index < mockCallback.length; index++) {
-              mockCallback[index]({state: MediaPlayerBase.STATE.BUFFERING, currentTime: 20});
-            }
-
-            jasmine.clock().tick(11 * 1000);
-
-            for (index = 0; index < mockCallback.length; index++) {
-              mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING, currentTime: 20});
-            }
-            player.getSeekableRange.and.returnValue({start: 20});
-
-            seekableMediaPlayer.pause();
-
-            jasmine.clock().tick(3 * 1000);
-
-            expect(player.toPlaying).toHaveBeenCalledTimes(1);
-          });
-
-          it('does not calls autoresume immeditetly if paused after an auto-resume with disableAutoResume options', function () {
-            startPlaybackAndPause(20, true);
-
-            jasmine.clock().tick(12 * 1000);
-
-            jasmine.clock().tick(1);
-
-            expect(player.resume).not.toHaveBeenCalledTimes(1);
-          });
+          expect(player.resume).not.toHaveBeenCalledTimes(1);
         });
       });
     });
+  });
 

--- a/script-test/playbackstrategies/nativestrategytest.js
+++ b/script-test/playbackstrategies/nativestrategytest.js
@@ -5,85 +5,85 @@ require(
     'bigscreenplayer/mediasources',
     'squire'
   ],
-    function (WindowTypes, LiveSupport, MediaSources, Squire) {
-      describe('Native Strategy', function () {
-        var nativeStrategy;
-        var html5player;
-        var livePlayer;
-        var mediaPlayer;
+  function (WindowTypes, LiveSupport, MediaSources, Squire) {
+    describe('Native Strategy', function () {
+      var nativeStrategy;
+      var html5player;
+      var livePlayer;
+      var mediaPlayer;
 
-        var mockLegacyAdapter;
-        var mockDevice;
-        var mockConfig = 'config';
+      var mockLegacyAdapter;
+      var mockDevice;
+      var mockConfig = 'config';
 
-        var mediaKind = 'mediaKind';
-        var playbackElement = 'playbackElement';
-        var isUHD = 'isUHD';
-        var mediaSources;
+      var mediaKind = 'mediaKind';
+      var playbackElement = 'playbackElement';
+      var isUHD = 'isUHD';
+      var mediaSources;
 
-        beforeEach(function (done) {
-          var mediaSourceCallbacks = jasmine.createSpyObj('mediaSourceCallbacks', ['onSuccess', 'onError']);
-          mediaSources = new MediaSources([{url: 'http://a', cdn: 'supplierA'}], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, mediaSourceCallbacks);
+      beforeEach(function (done) {
+        var mediaSourceCallbacks = jasmine.createSpyObj('mediaSourceCallbacks', ['onSuccess', 'onError']);
+        mediaSources = new MediaSources([{url: 'http://a', cdn: 'supplierA'}], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, mediaSourceCallbacks);
 
-          var injector = new Squire();
+        var injector = new Squire();
 
-          mockDevice = jasmine.createSpyObj('mockDevice', ['getConfig', 'getLogger']);
+        mockDevice = jasmine.createSpyObj('mockDevice', ['getConfig', 'getLogger']);
 
-          mockLegacyAdapter = jasmine.createSpy('LegacyAdapter');
-          mediaPlayer = jasmine.createSpy('MediaPlayer');
-          html5player = jasmine.createSpy('Html5Player');
-          livePlayer = jasmine.createSpy('LivePlayer');
+        mockLegacyAdapter = jasmine.createSpy('LegacyAdapter');
+        mediaPlayer = jasmine.createSpy('MediaPlayer');
+        html5player = jasmine.createSpy('Html5Player');
+        livePlayer = jasmine.createSpy('LivePlayer');
 
-          html5player.and.returnValue(mediaPlayer);
-          livePlayer.and.returnValue(mediaPlayer);
+        html5player.and.returnValue(mediaPlayer);
+        livePlayer.and.returnValue(mediaPlayer);
 
-          mockDevice.getConfig.and.returnValue(
-            mockConfig
-          );
+        mockDevice.getConfig.and.returnValue(
+          mockConfig
+        );
 
-          injector.mock({
-            'bigscreenplayer/playbackstrategy/legacyplayeradapter': mockLegacyAdapter,
-            'bigscreenplayer/playbackstrategy/modifiers/html5': html5player,
-            'bigscreenplayer/playbackstrategy/modifiers/live/playable': livePlayer
-          });
-
-          injector.require(['bigscreenplayer/playbackstrategy/nativestrategy'], function (strategy) {
-            nativeStrategy = strategy;
-            done();
-          });
+        injector.mock({
+          'bigscreenplayer/playbackstrategy/legacyplayeradapter': mockLegacyAdapter,
+          'bigscreenplayer/playbackstrategy/modifiers/html5': html5player,
+          'bigscreenplayer/playbackstrategy/modifiers/live/playable': livePlayer
         });
 
-        afterEach(function () {
-          window.bigscreenPlayer.liveSupport = LiveSupport.PLAYABLE;
-        });
-
-        it('calls LegacyAdapter with a static media player when called for STATIC window', function () {
-          var windowType = WindowTypes.STATIC;
-          nativeStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD, mockDevice);
-
-          expect(html5player).toHaveBeenCalledWith(mockConfig);
-
-          expect(mockLegacyAdapter).toHaveBeenCalledWith(mediaSources, windowType, playbackElement, isUHD, mockConfig, mediaPlayer);
-        });
-
-        it('calls LegacyAdapter with a live media player when called for a GROWING window', function () {
-          var windowType = WindowTypes.GROWING;
-          nativeStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD, mockDevice);
-
-          expect(html5player).toHaveBeenCalledWith(mockConfig);
-          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.GROWING, mediaSources);
-
-          expect(mockLegacyAdapter).toHaveBeenCalledWith(mediaSources, windowType, playbackElement, isUHD, mockConfig, mediaPlayer);
-        });
-
-        it('calls LegacyAdapter with a live media player when called for a SLIDING window', function () {
-          var windowType = WindowTypes.SLIDING;
-          nativeStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD, mockDevice);
-
-          expect(html5player).toHaveBeenCalledWith(mockConfig);
-          expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.SLIDING, mediaSources);
-
-          expect(mockLegacyAdapter).toHaveBeenCalledWith(mediaSources, windowType, playbackElement, isUHD, mockConfig, mediaPlayer);
+        injector.require(['bigscreenplayer/playbackstrategy/nativestrategy'], function (strategy) {
+          nativeStrategy = strategy;
+          done();
         });
       });
+
+      afterEach(function () {
+        window.bigscreenPlayer.liveSupport = LiveSupport.PLAYABLE;
+      });
+
+      it('calls LegacyAdapter with a static media player when called for STATIC window', function () {
+        var windowType = WindowTypes.STATIC;
+        nativeStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD, mockDevice);
+
+        expect(html5player).toHaveBeenCalledWith(mockConfig);
+
+        expect(mockLegacyAdapter).toHaveBeenCalledWith(mediaSources, windowType, playbackElement, isUHD, mockConfig, mediaPlayer);
+      });
+
+      it('calls LegacyAdapter with a live media player when called for a GROWING window', function () {
+        var windowType = WindowTypes.GROWING;
+        nativeStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD, mockDevice);
+
+        expect(html5player).toHaveBeenCalledWith(mockConfig);
+        expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.GROWING, mediaSources);
+
+        expect(mockLegacyAdapter).toHaveBeenCalledWith(mediaSources, windowType, playbackElement, isUHD, mockConfig, mediaPlayer);
+      });
+
+      it('calls LegacyAdapter with a live media player when called for a SLIDING window', function () {
+        var windowType = WindowTypes.SLIDING;
+        nativeStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD, mockDevice);
+
+        expect(html5player).toHaveBeenCalledWith(mockConfig);
+        expect(livePlayer).toHaveBeenCalledWith(mediaPlayer, mockConfig, WindowTypes.SLIDING, mediaSources);
+
+        expect(mockLegacyAdapter).toHaveBeenCalledWith(mediaSources, windowType, playbackElement, isUHD, mockConfig, mediaPlayer);
+      });
     });
+  });

--- a/script-test/version.js
+++ b/script-test/version.js
@@ -1,11 +1,11 @@
 require(
-    ['bigscreenplayer/version'],
-    function (Version) {
-      'use strict';
-      describe('Version ', function () {
-        it('should return a semver string', function () {
-          expect(Version).toMatch(/^[0-9]+\.[0-9]+\.[0-9]+$/);
-        });
+  ['bigscreenplayer/version'],
+  function (Version) {
+    'use strict';
+    describe('Version ', function () {
+      it('should return a semver string', function () {
+        expect(Version).toMatch(/^[0-9]+\.[0-9]+\.[0-9]+$/);
       });
-    }
+    });
+  }
 );

--- a/script/allowedmediatransitions.js
+++ b/script/allowedmediatransitions.js
@@ -7,13 +7,13 @@ define(
       var player = mediaplayer;
 
       var MediaPlayerState = {
-        EMPTY: 'EMPTY',     // No source set
-        STOPPED: 'STOPPED',   // Source set but no playback
+        EMPTY: 'EMPTY', // No source set
+        STOPPED: 'STOPPED', // Source set but no playback
         BUFFERING: 'BUFFERING', // Not enough data to play, waiting to download more
-        PLAYING: 'PLAYING',   // Media is playing
-        PAUSED: 'PAUSED',    // Media is paused
-        COMPLETE: 'COMPLETE',  // Media has reached its end point
-        ERROR: 'ERROR'      // An error occurred
+        PLAYING: 'PLAYING', // Media is playing
+        PAUSED: 'PAUSED', // Media is paused
+        COMPLETE: 'COMPLETE', // Media has reached its end point
+        ERROR: 'ERROR' // An error occurred
       };
 
       function canBePaused () {

--- a/script/debugger/chronicle.js
+++ b/script/debugger/chronicle.js
@@ -1,116 +1,116 @@
 define('bigscreenplayer/debugger/chronicle',
-function () {
-  'use strict';
-  var chronicle = [];
-  var firstTimeElement;
-  var compressTime;
-  var updateCallbacks = [];
+  function () {
+    'use strict';
+    var chronicle = [];
+    var firstTimeElement;
+    var compressTime;
+    var updateCallbacks = [];
 
-  var TYPES = {
-    INFO: 'info',
-    ERROR: 'error',
-    EVENT: 'event',
-    APICALL: 'apicall',
-    TIME: 'time',
-    KEYVALUE: 'keyvalue'
-  };
+    var TYPES = {
+      INFO: 'info',
+      ERROR: 'error',
+      EVENT: 'event',
+      APICALL: 'apicall',
+      TIME: 'time',
+      KEYVALUE: 'keyvalue'
+    };
 
-  function init () {
-    clear();
-  }
-
-  function clear () {
-    firstTimeElement = true;
-    compressTime = false;
-    chronicle = [];
-  }
-
-  function registerForUpdates (callback) {
-    updateCallbacks.push(callback);
-  }
-
-  function unregisterForUpdates (callback) {
-    var indexOf = updateCallbacks.indexOf(callback);
-    if (indexOf !== -1) {
-      updateCallbacks.splice(indexOf, 1);
+    function init () {
+      clear();
     }
-  }
 
-  function info (message) {
-    pushToChronicle({type: TYPES.INFO, message: message});
-  }
-
-  function error (err) {
-    pushToChronicle({type: TYPES.ERROR, error: err});
-  }
-
-  function event (event) {
-    pushToChronicle({type: TYPES.EVENT, event: event});
-  }
-
-  function apicall (callType) {
-    pushToChronicle({type: TYPES.APICALL, calltype: callType});
-  }
-
-  function time (time) {
-    if (firstTimeElement) {
-      pushToChronicle({type: TYPES.TIME, currentTime: time});
-      firstTimeElement = false;
-    } else if (!compressTime) {
-      pushToChronicle({type: TYPES.TIME, currentTime: time});
-      compressTime = true;
-    } else {
-      var lastElement = chronicle.pop();
-      lastElement.currentTime = time;
-      pushToChronicle(lastElement);
-    }
-  }
-
-  function keyValue (obj) {
-    pushToChronicle({type: TYPES.KEYVALUE, keyvalue: obj});
-  }
-
-  function retrieve () {
-    return chronicle.slice();
-  }
-
-  function timestamp (obj) {
-    obj.timestamp = new Date().getTime();
-  }
-
-  function pushToChronicle (obj) {
-    if (obj.type !== TYPES.TIME) {
+    function clear () {
       firstTimeElement = true;
       compressTime = false;
+      chronicle = [];
     }
-    timestamp(obj);
-    chronicle.push(obj);
-    updates();
-  }
 
-  function updates () {
-    updateCallbacks.forEach(function (callback) {
-      callback(retrieve());
-    });
-  }
+    function registerForUpdates (callback) {
+      updateCallbacks.push(callback);
+    }
 
-  function tearDown () {
-    clear();
-  }
+    function unregisterForUpdates (callback) {
+      var indexOf = updateCallbacks.indexOf(callback);
+      if (indexOf !== -1) {
+        updateCallbacks.splice(indexOf, 1);
+      }
+    }
 
-  return {
-    init: init,
-    TYPES: TYPES,
-    clear: clear,
-    info: info,
-    error: error,
-    event: event,
-    apicall: apicall,
-    time: time,
-    keyValue: keyValue,
-    retrieve: retrieve,
-    tearDown: tearDown,
-    registerForUpdates: registerForUpdates,
-    unregisterForUpdates: unregisterForUpdates
-  };
-});
+    function info (message) {
+      pushToChronicle({type: TYPES.INFO, message: message});
+    }
+
+    function error (err) {
+      pushToChronicle({type: TYPES.ERROR, error: err});
+    }
+
+    function event (event) {
+      pushToChronicle({type: TYPES.EVENT, event: event});
+    }
+
+    function apicall (callType) {
+      pushToChronicle({type: TYPES.APICALL, calltype: callType});
+    }
+
+    function time (time) {
+      if (firstTimeElement) {
+        pushToChronicle({type: TYPES.TIME, currentTime: time});
+        firstTimeElement = false;
+      } else if (!compressTime) {
+        pushToChronicle({type: TYPES.TIME, currentTime: time});
+        compressTime = true;
+      } else {
+        var lastElement = chronicle.pop();
+        lastElement.currentTime = time;
+        pushToChronicle(lastElement);
+      }
+    }
+
+    function keyValue (obj) {
+      pushToChronicle({type: TYPES.KEYVALUE, keyvalue: obj});
+    }
+
+    function retrieve () {
+      return chronicle.slice();
+    }
+
+    function timestamp (obj) {
+      obj.timestamp = new Date().getTime();
+    }
+
+    function pushToChronicle (obj) {
+      if (obj.type !== TYPES.TIME) {
+        firstTimeElement = true;
+        compressTime = false;
+      }
+      timestamp(obj);
+      chronicle.push(obj);
+      updates();
+    }
+
+    function updates () {
+      updateCallbacks.forEach(function (callback) {
+        callback(retrieve());
+      });
+    }
+
+    function tearDown () {
+      clear();
+    }
+
+    return {
+      init: init,
+      TYPES: TYPES,
+      clear: clear,
+      info: info,
+      error: error,
+      event: event,
+      apicall: apicall,
+      time: time,
+      keyValue: keyValue,
+      retrieve: retrieve,
+      tearDown: tearDown,
+      registerForUpdates: registerForUpdates,
+      unregisterForUpdates: unregisterForUpdates
+    };
+  });

--- a/script/debugger/debugpresenter.js
+++ b/script/debugger/debugpresenter.js
@@ -3,106 +3,106 @@ define('bigscreenplayer/debugger/debugpresenter',
     'bigscreenplayer/models/mediastate',
     'bigscreenplayer/debugger/chronicle'
   ],
- function (MediaState, Chronicle) {
-   'use strict';
-   var view;
+  function (MediaState, Chronicle) {
+    'use strict';
+    var view;
 
-   function init (newView) {
-     view = newView;
-   }
+    function init (newView) {
+      view = newView;
+    }
 
-   function update (logs) {
-     view.render({ static: parseStaticFields(logs), dynamic: parseDynamicFields(logs) });
-   }
+    function update (logs) {
+      view.render({ static: parseStaticFields(logs), dynamic: parseDynamicFields(logs) });
+    }
 
-   function parseStaticFields (logs) {
-     var latestStaticFields = [];
-     var staticFields = logs.filter(function (log) {
-       return isStaticLog(log);
-     });
+    function parseStaticFields (logs) {
+      var latestStaticFields = [];
+      var staticFields = logs.filter(function (log) {
+        return isStaticLog(log);
+      });
 
-     var uniqueKeys = findUniqueKeys(staticFields);
-     uniqueKeys.forEach(function (key) {
-       var matchingStaticLogs = staticFields.filter(function (log) {
-         return log.keyvalue.key === key;
-       });
-       latestStaticFields.push(matchingStaticLogs.pop());
-     });
+      var uniqueKeys = findUniqueKeys(staticFields);
+      uniqueKeys.forEach(function (key) {
+        var matchingStaticLogs = staticFields.filter(function (log) {
+          return log.keyvalue.key === key;
+        });
+        latestStaticFields.push(matchingStaticLogs.pop());
+      });
 
-     return latestStaticFields.map(function (field) {
-       return {key: sanitiseKeyString(field.keyvalue.key), value: sanitiseValueString(field.keyvalue.value)};
-     });
-   }
+      return latestStaticFields.map(function (field) {
+        return {key: sanitiseKeyString(field.keyvalue.key), value: sanitiseValueString(field.keyvalue.value)};
+      });
+    }
 
-   function parseDynamicFields (logs) {
-     var dynamicLogs;
+    function parseDynamicFields (logs) {
+      var dynamicLogs;
 
-     dynamicLogs = logs.filter(function (log) {
-       return !isStaticLog(log);
-     }).map(function (log) {
-       var dateString = new Date(log.timestamp).toISOString();
-       switch (log.type) {
-         case Chronicle.TYPES.INFO:
-           return dateString + ' - Info: ' + log.message;
-         case Chronicle.TYPES.TIME:
-           return dateString + ' - Video time: ' + parseFloat(log.currentTime).toFixed(2);
-         case Chronicle.TYPES.EVENT:
-           return dateString + ' - Event: ' + convertToReadableEvent(log.event.state);
-         case Chronicle.TYPES.ERROR:
-           return dateString + ' - Error: ' + log.error.errorId + ' | ' + log.error.message;
-         case Chronicle.TYPES.APICALL:
-           return dateString + ' - Api call: ' + log.calltype;
-         default:
-           return dateString + ' - Unknown log format';
-       }
-     });
+      dynamicLogs = logs.filter(function (log) {
+        return !isStaticLog(log);
+      }).map(function (log) {
+        var dateString = new Date(log.timestamp).toISOString();
+        switch (log.type) {
+          case Chronicle.TYPES.INFO:
+            return dateString + ' - Info: ' + log.message;
+          case Chronicle.TYPES.TIME:
+            return dateString + ' - Video time: ' + parseFloat(log.currentTime).toFixed(2);
+          case Chronicle.TYPES.EVENT:
+            return dateString + ' - Event: ' + convertToReadableEvent(log.event.state);
+          case Chronicle.TYPES.ERROR:
+            return dateString + ' - Error: ' + log.error.errorId + ' | ' + log.error.message;
+          case Chronicle.TYPES.APICALL:
+            return dateString + ' - Api call: ' + log.calltype;
+          default:
+            return dateString + ' - Unknown log format';
+        }
+      });
 
-     return dynamicLogs;
-   }
+      return dynamicLogs;
+    }
 
-   function isStaticLog (log) {
-     return log.type === Chronicle.TYPES.KEYVALUE;
-   }
+    function isStaticLog (log) {
+      return log.type === Chronicle.TYPES.KEYVALUE;
+    }
 
-   function findUniqueKeys (logs) {
-     var uniqueKeys = [];
-     logs.forEach(function (log) {
-       if (uniqueKeys.indexOf(log.keyvalue.key) === -1) {
-         uniqueKeys.push(log.keyvalue.key);
-       }
-     });
-     return uniqueKeys;
-   }
+    function findUniqueKeys (logs) {
+      var uniqueKeys = [];
+      logs.forEach(function (log) {
+        if (uniqueKeys.indexOf(log.keyvalue.key) === -1) {
+          uniqueKeys.push(log.keyvalue.key);
+        }
+      });
+      return uniqueKeys;
+    }
 
-   function sanitiseKeyString (key) {
-     return key.replace(/([A-Z])/g, ' $1').toLowerCase();
-   }
+    function sanitiseKeyString (key) {
+      return key.replace(/([A-Z])/g, ' $1').toLowerCase();
+    }
 
-   function sanitiseValueString (value) {
-     if (value instanceof Date) {
-       var hours = zeroPadTimeUnits(value.getHours()) + value.getHours();
-       var mins = zeroPadTimeUnits(value.getMinutes()) + value.getMinutes();
-       var secs = zeroPadTimeUnits(value.getSeconds()) + value.getSeconds();
-       return hours + ':' + mins + ':' + secs;
-     }
-     return value;
-   }
+    function sanitiseValueString (value) {
+      if (value instanceof Date) {
+        var hours = zeroPadTimeUnits(value.getHours()) + value.getHours();
+        var mins = zeroPadTimeUnits(value.getMinutes()) + value.getMinutes();
+        var secs = zeroPadTimeUnits(value.getSeconds()) + value.getSeconds();
+        return hours + ':' + mins + ':' + secs;
+      }
+      return value;
+    }
 
-   function zeroPadTimeUnits (unit) {
-     return (unit < 10 ? '0' : '');
-   }
+    function zeroPadTimeUnits (unit) {
+      return (unit < 10 ? '0' : '');
+    }
 
-   function convertToReadableEvent (type) {
-     for (var key in MediaState) {
-       if (MediaState[key] === type) {
-         return key;
-       }
-     }
-     return type;
-   }
+    function convertToReadableEvent (type) {
+      for (var key in MediaState) {
+        if (MediaState[key] === type) {
+          return key;
+        }
+      }
+      return type;
+    }
 
-   return {
-     init: init,
-     update: update
-   };
- });
+    return {
+      init: init,
+      update: update
+    };
+  });

--- a/script/debugger/debugtool.js
+++ b/script/debugger/debugtool.js
@@ -4,83 +4,83 @@ define('bigscreenplayer/debugger/debugtool',
     'bigscreenplayer/debugger/debugpresenter',
     'bigscreenplayer/debugger/debugview'
   ],
- function (Chronicle, DebugPresenter, DebugView) {
-   'use strict';
-   function DebugTool () {
-     var rootElement;
-     var presenter = DebugPresenter;
-     var view;
-     var visible = false;
+  function (Chronicle, DebugPresenter, DebugView) {
+    'use strict';
+    function DebugTool () {
+      var rootElement;
+      var presenter = DebugPresenter;
+      var view;
+      var visible = false;
 
-     var staticFieldValues = {};
+      var staticFieldValues = {};
 
-     function toggleVisibility () {
-       if (visible) {
-         hide();
-       } else {
-         show();
-       }
-     }
+      function toggleVisibility () {
+        if (visible) {
+          hide();
+        } else {
+          show();
+        }
+      }
 
-     function show () {
-       view = DebugView;
-       view.setRootElement(rootElement);
-       view.init();
-       presenter.init(view);
-       presenter.update(Chronicle.retrieve());
-       Chronicle.registerForUpdates(presenter.update);
-       visible = true;
-     }
+      function show () {
+        view = DebugView;
+        view.setRootElement(rootElement);
+        view.init();
+        presenter.init(view);
+        presenter.update(Chronicle.retrieve());
+        Chronicle.registerForUpdates(presenter.update);
+        visible = true;
+      }
 
-     function hide () {
-       view.tearDown();
-       Chronicle.unregisterForUpdates(presenter.update);
-       visible = false;
-     }
+      function hide () {
+        view.tearDown();
+        Chronicle.unregisterForUpdates(presenter.update);
+        visible = false;
+      }
 
-     function updateKeyValue (message) {
-       var staticFieldValue = staticFieldValues[message.key];
+      function updateKeyValue (message) {
+        var staticFieldValue = staticFieldValues[message.key];
 
-       if (staticFieldValue) {
-         var entry = Chronicle.retrieve()[staticFieldValue.index];
-         if (entry) {
-           entry.keyvalue = message;
-         }
-       } else {
-         staticFieldValues[message.key] = {value: message.value, index: Chronicle.retrieve().length};
-         Chronicle.keyValue(message);
-       }
-     }
+        if (staticFieldValue) {
+          var entry = Chronicle.retrieve()[staticFieldValue.index];
+          if (entry) {
+            entry.keyvalue = message;
+          }
+        } else {
+          staticFieldValues[message.key] = {value: message.value, index: Chronicle.retrieve().length};
+          Chronicle.keyValue(message);
+        }
+      }
 
-     function setRootElement (element) {
-       rootElement = element;
-     }
+      function setRootElement (element) {
+        rootElement = element;
+      }
 
-     function tearDown () {
-       staticFieldValues = {};
-       if (visible) {
-         hide();
-       }
-     }
+      function tearDown () {
+        staticFieldValues = {};
+        if (visible) {
+          hide();
+        }
+      }
 
-     return {
-       toggleVisibility: toggleVisibility,
-       setRootElement: setRootElement,
-       info: Chronicle.info,
-       error: Chronicle.error,
-       event: Chronicle.event,
-       time: Chronicle.time,
-       apicall: Chronicle.apicall,
-       keyValue: updateKeyValue,
-       tearDown: tearDown
-     };
-   }
+      return {
+        toggleVisibility: toggleVisibility,
+        setRootElement: setRootElement,
+        info: Chronicle.info,
+        error: Chronicle.error,
+        event: Chronicle.event,
+        time: Chronicle.time,
+        apicall: Chronicle.apicall,
+        keyValue: updateKeyValue,
+        tearDown: tearDown
+      };
+    }
 
-   var instance;
+    var instance;
 
-   if (instance === undefined) {
-     instance = new DebugTool();
-   }
+    if (instance === undefined) {
+      instance = new DebugTool();
+    }
 
-   return instance;
- });
+    return instance;
+  });

--- a/script/debugger/debugview.js
+++ b/script/debugger/debugview.js
@@ -1,100 +1,100 @@
 define('bigscreenplayer/debugger/debugview',
- function () {
-   'use strict';
-   var appElement, logBox, logContainer, staticContainer, staticBox;
+  function () {
+    'use strict';
+    var appElement, logBox, logContainer, staticContainer, staticBox;
 
-   function init () {
-     logBox = document.createElement('div');
-     logContainer = document.createElement('span');
-     staticBox = document.createElement('div');
-     staticContainer = document.createElement('span');
+    function init () {
+      logBox = document.createElement('div');
+      logContainer = document.createElement('span');
+      staticBox = document.createElement('div');
+      staticContainer = document.createElement('span');
 
-     if (appElement === undefined) {
-       appElement = document.body;
-     }
+      if (appElement === undefined) {
+        appElement = document.body;
+      }
 
-     logBox.id = 'logBox';
-     logBox.style.position = 'absolute';
-     logBox.style.width = '63%';
-     logBox.style.left = '5%';
-     logBox.style.top = '15%';
-     logBox.style.bottom = '25%';
-     logBox.style.backgroundColor = '#1D1D1D';
-     logBox.style.opacity = 0.9;
-     logBox.style.overflow = 'hidden';
+      logBox.id = 'logBox';
+      logBox.style.position = 'absolute';
+      logBox.style.width = '63%';
+      logBox.style.left = '5%';
+      logBox.style.top = '15%';
+      logBox.style.bottom = '25%';
+      logBox.style.backgroundColor = '#1D1D1D';
+      logBox.style.opacity = 0.9;
+      logBox.style.overflow = 'hidden';
 
-     staticBox.id = 'staticBox';
-     staticBox.style.position = 'absolute';
-     staticBox.style.width = '26%';
-     staticBox.style.right = '5%';
-     staticBox.style.top = '15%';
-     staticBox.style.bottom = '25%';
-     staticBox.style.backgroundColor = '#1D1D1D';
-     staticBox.style.opacity = 0.9;
-     staticBox.style.overflow = 'hidden';
+      staticBox.id = 'staticBox';
+      staticBox.style.position = 'absolute';
+      staticBox.style.width = '26%';
+      staticBox.style.right = '5%';
+      staticBox.style.top = '15%';
+      staticBox.style.bottom = '25%';
+      staticBox.style.backgroundColor = '#1D1D1D';
+      staticBox.style.opacity = 0.9;
+      staticBox.style.overflow = 'hidden';
 
-     logContainer.id = 'logContainer';
-     logContainer.style.color = '#ffffff';
-     logContainer.style.fontSize = '11pt';
-     logContainer.style.position = 'absolute';
-     logContainer.style.bottom = '1%';
-     logContainer.style.left = '1%';
-     logContainer.style.wordWrap = 'break-word';
-     logContainer.style.whiteSpace = 'pre-line';
+      logContainer.id = 'logContainer';
+      logContainer.style.color = '#ffffff';
+      logContainer.style.fontSize = '11pt';
+      logContainer.style.position = 'absolute';
+      logContainer.style.bottom = '1%';
+      logContainer.style.left = '1%';
+      logContainer.style.wordWrap = 'break-word';
+      logContainer.style.whiteSpace = 'pre-line';
 
-     staticContainer.id = 'staticContainer';
-     staticContainer.style.color = '#ffffff';
-     staticContainer.style.fontSize = '11pt';
-     staticContainer.style.wordWrap = 'break-word';
-     staticContainer.style.left = '1%';
-     staticContainer.style.whiteSpace = 'pre-line';
+      staticContainer.id = 'staticContainer';
+      staticContainer.style.color = '#ffffff';
+      staticContainer.style.fontSize = '11pt';
+      staticContainer.style.wordWrap = 'break-word';
+      staticContainer.style.left = '1%';
+      staticContainer.style.whiteSpace = 'pre-line';
 
-     logBox.appendChild(logContainer);
-     staticBox.appendChild(staticContainer);
-     appElement.appendChild(logBox);
-     appElement.appendChild(staticBox);
-   }
+      logBox.appendChild(logContainer);
+      staticBox.appendChild(staticContainer);
+      appElement.appendChild(logBox);
+      appElement.appendChild(staticBox);
+    }
 
-   function setRootElement (root) {
-     if (root) {
-       appElement = root;
-     }
-   }
+    function setRootElement (root) {
+      if (root) {
+        appElement = root;
+      }
+    }
 
-   function render (logData) {
-     var dynamicLogs = logData.dynamic;
-     var LINES_TO_DISPLAY = 29;
-     if (dynamicLogs.length === 0) {
-       logContainer.innerHTML = '';
-     }
+    function render (logData) {
+      var dynamicLogs = logData.dynamic;
+      var LINES_TO_DISPLAY = 29;
+      if (dynamicLogs.length === 0) {
+        logContainer.innerHTML = '';
+      }
 
-     dynamicLogs = dynamicLogs.slice(-LINES_TO_DISPLAY);
-     logContainer.innerHTML = dynamicLogs.join('\n');
+      dynamicLogs = dynamicLogs.slice(-LINES_TO_DISPLAY);
+      logContainer.innerHTML = dynamicLogs.join('\n');
 
-     var staticLogString = '';
-     logData.static.forEach(function (log) {
-       staticLogString = staticLogString + log.key + ': ' + log.value + '\n\n';
-     });
+      var staticLogString = '';
+      logData.static.forEach(function (log) {
+        staticLogString = staticLogString + log.key + ': ' + log.value + '\n\n';
+      });
 
-     staticContainer.innerHTML = staticLogString;
-   }
+      staticContainer.innerHTML = staticLogString;
+    }
 
-   function tearDown () {
-     if (appElement) {
-       appElement.removeChild(document.getElementById('logBox'));
-       appElement.removeChild(document.getElementById('staticBox'));
-       appElement = undefined;
-     }
-     staticContainer = undefined;
-     logContainer = undefined;
-     logBox = undefined;
-     staticBox = undefined;
-   }
+    function tearDown () {
+      if (appElement) {
+        appElement.removeChild(document.getElementById('logBox'));
+        appElement.removeChild(document.getElementById('staticBox'));
+        appElement = undefined;
+      }
+      staticContainer = undefined;
+      logContainer = undefined;
+      logBox = undefined;
+      staticBox = undefined;
+    }
 
-   return {
-     init: init,
-     setRootElement: setRootElement,
-     render: render,
-     tearDown: tearDown
-   };
- });
+    return {
+      init: init,
+      setRootElement: setRootElement,
+      render: render,
+      tearDown: tearDown
+    };
+  });

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -11,198 +11,198 @@ define('bigscreenplayer/mediasources',
     'bigscreenplayer/models/transferformats',
     'bigscreenplayer/models/livesupport'
   ],
-function (PlaybackUtils, WindowTypes, Plugins, PluginEnums, PluginData, DebugTool, ManifestLoader, PlaybackStrategy, TransferFormats, LiveSupport) {
-  'use strict';
-  return function () {
-    var mediaSources;
-    var windowType;
-    var liveSupport;
-    var serverDate;
-    var time = {};
-    var transferFormat;
+  function (PlaybackUtils, WindowTypes, Plugins, PluginEnums, PluginData, DebugTool, ManifestLoader, PlaybackStrategy, TransferFormats, LiveSupport) {
+    'use strict';
+    return function () {
+      var mediaSources;
+      var windowType;
+      var liveSupport;
+      var serverDate;
+      var time = {};
+      var transferFormat;
 
-    function init (urls, newServerDate, newWindowType, newLiveSupport, callbacks) {
-      if (urls === undefined || urls.length === 0) {
-        throw new Error('Media Sources urls are undefined');
-      }
+      function init (urls, newServerDate, newWindowType, newLiveSupport, callbacks) {
+        if (urls === undefined || urls.length === 0) {
+          throw new Error('Media Sources urls are undefined');
+        }
 
-      if (callbacks === undefined ||
+        if (callbacks === undefined ||
       callbacks.onSuccess === undefined ||
       callbacks.onError === undefined) {
-        throw new Error('Media Sources callbacks are undefined');
-      }
+          throw new Error('Media Sources callbacks are undefined');
+        }
 
-      windowType = newWindowType;
-      liveSupport = newLiveSupport;
-      serverDate = newServerDate;
-      mediaSources = PlaybackUtils.cloneArray(urls);
-      updateDebugOutput();
-
-      if (needToGetManifest(windowType, liveSupport)) {
-        loadManifest(serverDate, callbacks);
-      } else {
-        callbacks.onSuccess();
-      }
-    }
-
-    function failover (postFailoverAction, failoverErrorAction, failoverParams) {
-      if (shouldFailover(failoverParams)) {
-        emitCdnFailover(failoverParams);
-        updateCdns();
+        windowType = newWindowType;
+        liveSupport = newLiveSupport;
+        serverDate = newServerDate;
+        mediaSources = PlaybackUtils.cloneArray(urls);
         updateDebugOutput();
 
         if (needToGetManifest(windowType, liveSupport)) {
-          loadManifest(serverDate, { onSuccess: postFailoverAction, onError: failoverErrorAction });
+          loadManifest(serverDate, callbacks);
         } else {
-          postFailoverAction();
+          callbacks.onSuccess();
         }
-      } else {
-        failoverErrorAction();
-      }
-    }
-
-    function shouldFailover (failoverParams) {
-      if (isFirstManifest(failoverParams.serviceLocation)) {
-        return false;
       }
 
-      var talRestartable = window.bigscreenPlayer.playbackStrategy === PlaybackStrategy.TAL && liveSupport === LiveSupport.RESTARTABLE;
-      var aboutToEnd = failoverParams.duration && failoverParams.currentTime > failoverParams.duration - 5;
-      var shouldStaticFailover = windowType === WindowTypes.STATIC && !aboutToEnd;
-      var shouldLiveFailover = windowType !== WindowTypes.STATIC && !talRestartable;
-      return isFailoverInfoValid(failoverParams) && hasSourcesToFailoverTo() && (shouldStaticFailover || shouldLiveFailover);
-    }
+      function failover (postFailoverAction, failoverErrorAction, failoverParams) {
+        if (shouldFailover(failoverParams)) {
+          emitCdnFailover(failoverParams);
+          updateCdns();
+          updateDebugOutput();
 
-    // we don't want to failover on the first playback
-    // the serviceLocation is set to our first cdn url
-    // see manifest modifier - generateBaseUrls
-    function isFirstManifest (serviceLocation) {
-      return serviceLocation === getCurrentUrl();
-    }
+          if (needToGetManifest(windowType, liveSupport)) {
+            loadManifest(serverDate, { onSuccess: postFailoverAction, onError: failoverErrorAction });
+          } else {
+            postFailoverAction();
+          }
+        } else {
+          failoverErrorAction();
+        }
+      }
 
-    function isFailoverInfoValid (failoverParams) {
-      var infoValid = typeof failoverParams === 'object' &&
+      function shouldFailover (failoverParams) {
+        if (isFirstManifest(failoverParams.serviceLocation)) {
+          return false;
+        }
+
+        var talRestartable = window.bigscreenPlayer.playbackStrategy === PlaybackStrategy.TAL && liveSupport === LiveSupport.RESTARTABLE;
+        var aboutToEnd = failoverParams.duration && failoverParams.currentTime > failoverParams.duration - 5;
+        var shouldStaticFailover = windowType === WindowTypes.STATIC && !aboutToEnd;
+        var shouldLiveFailover = windowType !== WindowTypes.STATIC && !talRestartable;
+        return isFailoverInfoValid(failoverParams) && hasSourcesToFailoverTo() && (shouldStaticFailover || shouldLiveFailover);
+      }
+
+      // we don't want to failover on the first playback
+      // the serviceLocation is set to our first cdn url
+      // see manifest modifier - generateBaseUrls
+      function isFirstManifest (serviceLocation) {
+        return serviceLocation === getCurrentUrl();
+      }
+
+      function isFailoverInfoValid (failoverParams) {
+        var infoValid = typeof failoverParams === 'object' &&
                     typeof failoverParams.errorMessage === 'string' &&
                     typeof failoverParams.isBufferingTimeoutError === 'boolean';
 
-      if (!infoValid) {
-        DebugTool.error('failoverInfo is not valid');
+        if (!infoValid) {
+          DebugTool.error('failoverInfo is not valid');
+        }
+
+        return infoValid;
       }
 
-      return infoValid;
-    }
+      function needToGetManifest (windowType, liveSupport) {
+        var requiresManifestLoad = {
+          restartable: true,
+          seekable: true,
+          playable: false,
+          none: false
+        };
 
-    function needToGetManifest (windowType, liveSupport) {
-      var requiresManifestLoad = {
-        restartable: true,
-        seekable: true,
-        playable: false,
-        none: false
+        var requiredTransferFormat = transferFormat === TransferFormats.HLS || transferFormat === undefined;
+        return requiredTransferFormat && windowType !== WindowTypes.STATIC && requiresManifestLoad[liveSupport];
+      }
+
+      function refresh (onSuccess, onError) {
+        loadManifest(serverDate, {onSuccess: onSuccess, onError: onError});
+      }
+
+      function loadManifest (serverDate, callbacks) {
+        var onManifestLoadSuccess = function (manifestData) {
+          time = manifestData.time;
+          transferFormat = manifestData.transferFormat;
+          callbacks.onSuccess();
+        };
+
+        var failoverError = function () {
+          callbacks.onError({error: 'manifest'});
+        };
+
+        var onManifestLoadError = function () {
+          failover(load, failoverError, {errorMessage: 'manifest-load', isBufferingTimeoutError: false});
+        };
+
+        function load () {
+          ManifestLoader.load(
+            getCurrentUrl(),
+            serverDate,
+            {
+              onSuccess: onManifestLoadSuccess,
+              onError: onManifestLoadError
+            }
+          );
+        }
+
+        load();
+      }
+
+      function getCurrentUrl () {
+        if (mediaSources.length > 0) {
+          return mediaSources[0].url.toString();
+        }
+
+        return '';
+      }
+
+      function availableUrls () {
+        return mediaSources.map(function (mediaSource) {
+          return mediaSource.url;
+        });
+      }
+
+      function generateTime () {
+        return time;
+      }
+
+      function updateCdns () {
+        if (hasSourcesToFailoverTo()) {
+          mediaSources.shift();
+        }
+      }
+
+      function hasSourcesToFailoverTo () {
+        return mediaSources.length > 1;
+      }
+
+      function emitCdnFailover (failoverInfo) {
+        var evt = new PluginData({
+          status: PluginEnums.STATUS.FAILOVER,
+          stateType: PluginEnums.TYPE.ERROR,
+          isBufferingTimeoutError: failoverInfo.isBufferingTimeoutError,
+          cdn: mediaSources[0].cdn,
+          newCdn: mediaSources[1].cdn
+        });
+        Plugins.interface.onErrorHandled(evt);
+      }
+
+      function getCurrentCdn () {
+        if (mediaSources.length > 0) {
+          return mediaSources[0].cdn.toString();
+        }
+
+        return '';
+      }
+
+      function availableCdns () {
+        return mediaSources.map(function (mediaSource) {
+          return mediaSource.cdn;
+        });
+      }
+
+      function updateDebugOutput () {
+        DebugTool.keyValue({key: 'available cdns', value: availableCdns()});
+        DebugTool.keyValue({key: 'current cdn', value: getCurrentCdn()});
+        DebugTool.keyValue({key: 'url', value: getCurrentUrl()});
+      }
+
+      return {
+        init: init,
+        failover: failover,
+        refresh: refresh,
+        currentSource: getCurrentUrl,
+        availableSources: availableUrls,
+        time: generateTime
       };
-
-      var requiredTransferFormat = transferFormat === TransferFormats.HLS || transferFormat === undefined;
-      return requiredTransferFormat && windowType !== WindowTypes.STATIC && requiresManifestLoad[liveSupport];
-    }
-
-    function refresh (onSuccess, onError) {
-      loadManifest(serverDate, {onSuccess: onSuccess, onError: onError});
-    }
-
-    function loadManifest (serverDate, callbacks) {
-      var onManifestLoadSuccess = function (manifestData) {
-        time = manifestData.time;
-        transferFormat = manifestData.transferFormat;
-        callbacks.onSuccess();
-      };
-
-      var failoverError = function () {
-        callbacks.onError({error: 'manifest'});
-      };
-
-      var onManifestLoadError = function () {
-        failover(load, failoverError, {errorMessage: 'manifest-load', isBufferingTimeoutError: false});
-      };
-
-      function load () {
-        ManifestLoader.load(
-          getCurrentUrl(),
-          serverDate,
-          {
-            onSuccess: onManifestLoadSuccess,
-            onError: onManifestLoadError
-          }
-      );
-      }
-
-      load();
-    }
-
-    function getCurrentUrl () {
-      if (mediaSources.length > 0) {
-        return mediaSources[0].url.toString();
-      }
-
-      return '';
-    }
-
-    function availableUrls () {
-      return mediaSources.map(function (mediaSource) {
-        return mediaSource.url;
-      });
-    }
-
-    function generateTime () {
-      return time;
-    }
-
-    function updateCdns () {
-      if (hasSourcesToFailoverTo()) {
-        mediaSources.shift();
-      }
-    }
-
-    function hasSourcesToFailoverTo () {
-      return mediaSources.length > 1;
-    }
-
-    function emitCdnFailover (failoverInfo) {
-      var evt = new PluginData({
-        status: PluginEnums.STATUS.FAILOVER,
-        stateType: PluginEnums.TYPE.ERROR,
-        isBufferingTimeoutError: failoverInfo.isBufferingTimeoutError,
-        cdn: mediaSources[0].cdn,
-        newCdn: mediaSources[1].cdn
-      });
-      Plugins.interface.onErrorHandled(evt);
-    }
-
-    function getCurrentCdn () {
-      if (mediaSources.length > 0) {
-        return mediaSources[0].cdn.toString();
-      }
-
-      return '';
-    }
-
-    function availableCdns () {
-      return mediaSources.map(function (mediaSource) {
-        return mediaSource.cdn;
-      });
-    }
-
-    function updateDebugOutput () {
-      DebugTool.keyValue({key: 'available cdns', value: availableCdns()});
-      DebugTool.keyValue({key: 'current cdn', value: getCurrentCdn()});
-      DebugTool.keyValue({key: 'url', value: getCurrentUrl()});
-    }
-
-    return {
-      init: init,
-      failover: failover,
-      refresh: refresh,
-      currentSource: getCurrentUrl,
-      availableSources: availableUrls,
-      time: generateTime
     };
-  };
-});
+  });

--- a/script/models/pausetriggers.js
+++ b/script/models/pausetriggers.js
@@ -1,14 +1,14 @@
 define(
-    'bigscreenplayer/models/pausetriggers',
-    function () {
-      'use strict';
+  'bigscreenplayer/models/pausetriggers',
+  function () {
+    'use strict';
 
-      var PauseTriggers = {
-        USER: 1,
-        APP: 2,
-        DEVICE: 3
-      };
+    var PauseTriggers = {
+      USER: 1,
+      APP: 2,
+      DEVICE: 3
+    };
 
-      return PauseTriggers;
-    }
-  );
+    return PauseTriggers;
+  }
+);

--- a/script/models/playbackstrategy.js
+++ b/script/models/playbackstrategy.js
@@ -1,12 +1,12 @@
 define(
-    'bigscreenplayer/models/playbackstrategy', [],
-    function () {
-      'use strict';
-      return {
-        MSE: 'msestrategy',
-        HYBRID: 'hybridstrategy',
-        NATIVE: 'nativestrategy',
-        TAL: 'talstrategy'
-      };
-    });
+  'bigscreenplayer/models/playbackstrategy', [],
+  function () {
+    'use strict';
+    return {
+      MSE: 'msestrategy',
+      HYBRID: 'hybridstrategy',
+      NATIVE: 'nativestrategy',
+      TAL: 'talstrategy'
+    };
+  });
 

--- a/script/playbackstrategy/modifiers/cehtml.js
+++ b/script/playbackstrategy/modifiers/cehtml.js
@@ -1,765 +1,765 @@
 define(
-    'bigscreenplayer/playbackstrategy/modifiers/cehtml',
+  'bigscreenplayer/playbackstrategy/modifiers/cehtml',
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
     'bigscreenplayer/debugger/debugtool'
   ],
-    function (MediaPlayerBase, DebugTool) {
-      'use strict';
-      var CLAMP_OFFSET_FROM_END_OF_RANGE = 1.1;
+  function (MediaPlayerBase, DebugTool) {
+    'use strict';
+    var CLAMP_OFFSET_FROM_END_OF_RANGE = 1.1;
 
-      var STATE = {
-        STOPPED: 0,
-        PLAYING: 1,
-        PAUSED: 2,
-        CONNECTING: 3,
-        BUFFERING: 4,
-        FINISHED: 5,
-        ERROR: 6
+    var STATE = {
+      STOPPED: 0,
+      PLAYING: 1,
+      PAUSED: 2,
+      CONNECTING: 3,
+      BUFFERING: 4,
+      FINISHED: 5,
+      ERROR: 6
+    };
+
+    return function (deviceConfig) {
+      var eventCallbacks = [];
+      var state = MediaPlayerBase.STATE.EMPTY;
+
+      var mediaElement;
+      var updateInterval;
+
+      var mediaType;
+      var source;
+      var mimeType;
+
+      var deferSeekingTo;
+      var range;
+
+      var postBufferingState;
+      var seekFinished;
+      var count;
+      var timeoutHappened;
+
+      var disableSentinels;
+
+      var sentinelSeekTime;
+      var seekSentinelTolerance;
+      var sentinelInterval;
+      var sentinelIntervalNumber;
+      var timeAtLastSentinelInterval;
+
+      var sentinelTimeIsNearEnd;
+      var timeHasAdvanced;
+
+      var sentinelLimits = {
+        pause: {
+          maximumAttempts: 2,
+          successEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE,
+          failureEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE,
+          currentAttemptCount: 0
+        },
+        seek: {
+          maximumAttempts: 2,
+          successEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK,
+          failureEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE,
+          currentAttemptCount: 0
+        }
       };
 
-      return function (deviceConfig) {
-        var eventCallbacks = [];
-        var state = MediaPlayerBase.STATE.EMPTY;
+      function addEventCallback (thisArg, callback) {
+        var eventCallback = function (event) {
+          callback.call(thisArg, event);
+        };
 
-        var mediaElement;
-        var updateInterval;
+        eventCallbacks.push({ from: callback, to: eventCallback });
+      }
 
-        var mediaType;
-        var source;
-        var mimeType;
+      function removeEventCallback (thisArg, callback) {
+        eventCallbacks = eventCallbacks.filter(function (cb) {
+          return cb.from !== callback;
+        });
+      }
 
-        var deferSeekingTo;
-        var range;
+      function removeAllEventCallbacks () {
+        eventCallbacks = [];
+      }
 
-        var postBufferingState;
-        var seekFinished;
-        var count;
-        var timeoutHappened;
+      function emitEvent (eventType, eventLabels) {
+        var event = {
+          type: eventType,
+          currentTime: getCurrentTime(),
+          seekableRange: getSeekableRange(),
+          duration: getDuration(),
+          url: getSource(),
+          mimeType: getMimeType(),
+          state: getState()
+        };
 
-        var disableSentinels;
+        if (eventLabels) {
+          for (var key in eventLabels) {
+            if (eventLabels.hasOwnProperty(key)) {
+              event[key] = eventLabels[key];
+            }
+          }
+        }
 
-        var sentinelSeekTime;
-        var seekSentinelTolerance;
-        var sentinelInterval;
-        var sentinelIntervalNumber;
-        var timeAtLastSentinelInterval;
+        eventCallbacks.forEach(function (callback) {
+          callback.to(event);
+        });
+      }
 
-        var sentinelTimeIsNearEnd;
-        var timeHasAdvanced;
+      function getClampedTime (seconds) {
+        var range = getSeekableRange();
+        var offsetFromEnd = getClampOffsetFromConfig();
+        var nearToEnd = Math.max(range.end - offsetFromEnd, range.start);
+        if (seconds < range.start) {
+          return range.start;
+        } else if (seconds > nearToEnd) {
+          return nearToEnd;
+        } else {
+          return seconds;
+        }
+      }
 
-        var sentinelLimits = {
-          pause: {
-            maximumAttempts: 2,
-            successEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE,
-            failureEvent: MediaPlayerBase.EVENT.SENTINEL_PAUSE_FAILURE,
-            currentAttemptCount: 0
-          },
-          seek: {
-            maximumAttempts: 2,
-            successEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK,
-            failureEvent: MediaPlayerBase.EVENT.SENTINEL_SEEK_FAILURE,
-            currentAttemptCount: 0
+      function getClampOffsetFromConfig () {
+        var clampOffsetFromEndOfRange;
+
+        // TODO: can we tidy this, is it needed any more? If so we can combine it into bigscreen-player configs
+        // if (config && config.streaming && config.streaming.overrides) {
+        //   clampOffsetFromEndOfRange = config.streaming.overrides.clampOffsetFromEndOfRange;
+        // }
+
+        if (clampOffsetFromEndOfRange !== undefined) {
+          return clampOffsetFromEndOfRange;
+        } else {
+          return CLAMP_OFFSET_FROM_END_OF_RANGE;
+        }
+      }
+
+      function isLiveMedia () {
+        return (mediaType === MediaPlayerBase.TYPE.LIVE_VIDEO) || (mediaType === MediaPlayerBase.TYPE.LIVE_AUDIO);
+      }
+
+      function getSource () {
+        return source;
+      }
+
+      function getMimeType () {
+        return mimeType;
+      }
+
+      function getState () {
+        return state;
+      }
+
+      function setSeekSentinelTolerance () {
+        var ON_DEMAND_SEEK_SENTINEL_TOLERANCE = 15;
+        var LIVE_SEEK_SENTINEL_TOLERANCE = 30;
+
+        seekSentinelTolerance = ON_DEMAND_SEEK_SENTINEL_TOLERANCE;
+        if (isLiveMedia()) {
+          seekSentinelTolerance = LIVE_SEEK_SENTINEL_TOLERANCE;
+        }
+      }
+
+      function initialiseMedia (type, url, mediaMimeType, sourceContainer, opts) {
+        disableSentinels = opts.disableSentinels;
+        mediaType = type;
+        source = url;
+        mimeType = mediaMimeType;
+        opts = opts || {};
+
+        emitSeekAttempted();
+
+        if (getState() === MediaPlayerBase.STATE.EMPTY) {
+          timeAtLastSentinelInterval = 0;
+          setSeekSentinelTolerance();
+          createElement();
+          addElementToDOM();
+          mediaElement.data = source;
+          registerEventHandlers();
+          toStopped();
+        } else {
+          toError('Cannot set source unless in the \'' + MediaPlayerBase.STATE.EMPTY + '\' state');
+        }
+      }
+
+      function resume () {
+        postBufferingState = MediaPlayerBase.STATE.PLAYING;
+        switch (getState()) {
+          case MediaPlayerBase.STATE.PLAYING:
+          case MediaPlayerBase.STATE.BUFFERING:
+            break;
+
+          case MediaPlayerBase.STATE.PAUSED:
+            mediaElement.play(1);
+            toPlaying();
+            break;
+
+          default:
+            toError('Cannot resume while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function playFrom (seconds) {
+        postBufferingState = MediaPlayerBase.STATE.PLAYING;
+        sentinelLimits.seek.currentAttemptCount = 0;
+        switch (getState()) {
+          case MediaPlayerBase.STATE.BUFFERING:
+            deferSeekingTo = seconds;
+            break;
+
+          case MediaPlayerBase.STATE.COMPLETE:
+            toBuffering();
+            mediaElement.stop();
+            playAndSetDeferredSeek(seconds);
+            break;
+
+          case MediaPlayerBase.STATE.PLAYING:
+            toBuffering();
+            var seekResult = seekTo(seconds);
+            if (seekResult === false) {
+              toPlaying();
+            }
+            break;
+
+          case MediaPlayerBase.STATE.PAUSED:
+            toBuffering();
+            seekTo(seconds);
+            mediaElement.play(1);
+            break;
+
+          default:
+            toError('Cannot playFrom while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function getDuration () {
+        switch (getState()) {
+          case MediaPlayerBase.STATE.STOPPED:
+          case MediaPlayerBase.STATE.ERROR:
+            return undefined;
+          default:
+            if (isLiveMedia()) {
+              return Infinity;
+            }
+            return getMediaDuration();
+        }
+      }
+
+      function beginPlayback () {
+        postBufferingState = MediaPlayerBase.STATE.PLAYING;
+        switch (getState()) {
+          case MediaPlayerBase.STATE.STOPPED:
+            toBuffering();
+            mediaElement.play(1);
+            break;
+
+          default:
+            toError('Cannot beginPlayback while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function beginPlaybackFrom (seconds) {
+        postBufferingState = MediaPlayerBase.STATE.PLAYING;
+        sentinelLimits.seek.currentAttemptCount = 0;
+
+        switch (getState()) {
+          case MediaPlayerBase.STATE.STOPPED:
+            // Seeking past 0 requires calling play first when media has not been loaded
+            toBuffering();
+            playAndSetDeferredSeek(seconds);
+            break;
+
+          default:
+            toError('Cannot beginPlayback while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function pause () {
+        postBufferingState = MediaPlayerBase.STATE.PAUSED;
+        switch (getState()) {
+          case MediaPlayerBase.STATE.BUFFERING:
+          case MediaPlayerBase.STATE.PAUSED:
+            break;
+
+          case MediaPlayerBase.STATE.PLAYING:
+            mediaElement.play(0);
+            toPaused();
+            break;
+
+          default:
+            toError('Cannot pause while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function stop () {
+        switch (getState()) {
+          case MediaPlayerBase.STATE.STOPPED:
+            break;
+
+          case MediaPlayerBase.STATE.BUFFERING:
+          case MediaPlayerBase.STATE.PLAYING:
+          case MediaPlayerBase.STATE.PAUSED:
+          case MediaPlayerBase.STATE.COMPLETE:
+            sentinelSeekTime = undefined;
+            if (mediaElement.stop) {
+              mediaElement.stop();
+              toStopped();
+            } else {
+              toError('mediaElement.stop is not a function : failed to stop the media player');
+            }
+            break;
+
+          default:
+            toError('Cannot stop while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function reset () {
+        switch (getState()) {
+          case MediaPlayerBase.STATE.EMPTY:
+            break;
+
+          case MediaPlayerBase.STATE.STOPPED:
+          case MediaPlayerBase.STATE.ERROR:
+            toEmpty();
+            break;
+
+          default:
+            toError('Cannot reset while in the \'' + getState() + '\' state');
+            break;
+        }
+      }
+
+      function getCurrentTime () {
+        switch (getState()) {
+          case MediaPlayerBase.STATE.STOPPED:
+          case MediaPlayerBase.STATE.ERROR:
+            break;
+
+          case MediaPlayerBase.STATE.COMPLETE:
+            if (range) {
+              return range.end;
+            }
+            break;
+
+          default:
+            if (mediaElement) {
+              return mediaElement.playPosition / 1000;
+            }
+            break;
+        }
+        return undefined;
+      }
+
+      function getSeekableRange () {
+        switch (getState()) {
+          case MediaPlayerBase.STATE.STOPPED:
+          case MediaPlayerBase.STATE.ERROR:
+            break;
+
+          default:
+            return range;
+        }
+        return undefined;
+      }
+
+      function getMediaDuration () {
+        if (range) {
+          return range.end;
+        }
+        return undefined;
+      }
+
+      function getPlayerElement () {
+        return mediaElement;
+      }
+
+      function onFinishedBuffering () {
+        cacheRange();
+
+        if (getState() !== MediaPlayerBase.STATE.BUFFERING) {
+          return;
+        }
+
+        if (waitingToSeek()) {
+          toBuffering();
+          performDeferredSeek();
+        } else if (waitingToPause()) {
+          toPaused();
+          mediaElement.play(0);
+        } else {
+          toPlaying();
+        }
+      }
+
+      function onDeviceError () {
+        reportError('Media element error code: ' + mediaElement.error);
+      }
+
+      function onDeviceBuffering () {
+        if (getState() === MediaPlayerBase.STATE.PLAYING) {
+          toBuffering();
+        }
+      }
+
+      function onEndOfMedia () {
+        if (getState() !== MediaPlayerBase.STATE.COMPLETE) {
+          toComplete();
+        }
+      }
+
+      function emitSeekAttempted () {
+        if (getState() === MediaPlayerBase.STATE.EMPTY) {
+          emitEvent(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
+          seekFinished = false;
+        }
+
+        count = 0;
+        timeoutHappened = false;
+        if (deviceConfig.restartTimeout) {
+          setTimeout(function () {
+            timeoutHappened = true;
+          }, deviceConfig.restartTimeout);
+        } else {
+          timeoutHappened = true;
+        }
+      }
+
+      function emitSeekFinishedAtCorrectStartingPoint () {
+        var isAtCorrectStartingPoint = Math.abs(getCurrentTime() - sentinelSeekTime) <= seekSentinelTolerance;
+
+        if (sentinelSeekTime === undefined) {
+          isAtCorrectStartingPoint = true;
+        }
+
+        var isPlayingAtCorrectTime = getState() === MediaPlayerBase.STATE.PLAYING && isAtCorrectStartingPoint;
+
+        if (isPlayingAtCorrectTime && count >= 5 && timeoutHappened && !seekFinished) {
+          emitEvent(MediaPlayerBase.EVENT.SEEK_FINISHED);
+          seekFinished = true;
+        } else if (isPlayingAtCorrectTime) {
+          count++;
+        } else {
+          count = 0;
+        }
+      }
+
+      function onStatus () {
+        if (getState() === MediaPlayerBase.STATE.PLAYING) {
+          emitEvent(MediaPlayerBase.EVENT.STATUS);
+        }
+
+        emitSeekFinishedAtCorrectStartingPoint();
+      }
+
+      function createElement () {
+        mediaElement = document.createElement('object', 'mediaPlayer');
+        mediaElement.type = mimeType;
+        mediaElement.style.position = 'absolute';
+        mediaElement.style.top = '0px';
+        mediaElement.style.left = '0px';
+        mediaElement.style.width = '100%';
+        mediaElement.style.height = '100%';
+      }
+
+      function registerEventHandlers () {
+        var DEVICE_UPDATE_PERIOD_MS = 500;
+
+        mediaElement.onPlayStateChange = function () {
+          switch (mediaElement.playState) {
+            case STATE.STOPPED:
+              break;
+            case STATE.PLAYING:
+              onFinishedBuffering();
+              break;
+            case STATE.PAUSED:
+              break;
+            case STATE.CONNECTING:
+              break;
+            case STATE.BUFFERING:
+              onDeviceBuffering();
+              break;
+            case STATE.FINISHED:
+              onEndOfMedia();
+              break;
+            case STATE.ERROR:
+              onDeviceError();
+              break;
+            default:
+              // do nothing
+              break;
           }
         };
 
-        function addEventCallback (thisArg, callback) {
-          var eventCallback = function (event) {
-            callback.call(thisArg, event);
+        updateInterval = setInterval(function () {
+          onStatus();
+        }, DEVICE_UPDATE_PERIOD_MS);
+      }
+
+      function addElementToDOM () {
+        var body = document.getElementsByTagName('body')[0];
+        body.insertBefore(mediaElement, body.firstChild);
+      }
+
+      function cacheRange () {
+        if (mediaElement) {
+          range = {
+            start: 0,
+            end: mediaElement.playTime / 1000
           };
-
-          eventCallbacks.push({ from: callback, to: eventCallback });
         }
+      }
 
-        function removeEventCallback (thisArg, callback) {
-          eventCallbacks = eventCallbacks.filter(function (cb) {
-            return cb.from !== callback;
-          });
+      function playAndSetDeferredSeek (seconds) {
+        mediaElement.play(1);
+        if (seconds > 0) {
+          deferSeekingTo = seconds;
         }
+      }
 
-        function removeAllEventCallbacks () {
-          eventCallbacks = [];
+      function waitingToSeek () {
+        return (deferSeekingTo !== undefined);
+      }
+
+      function performDeferredSeek () {
+        seekTo(deferSeekingTo);
+        deferSeekingTo = undefined;
+      }
+
+      function seekTo (seconds) {
+        var clampedTime = getClampedTime(seconds);
+        if (clampedTime !== seconds) {
+          DebugTool.info('playFrom ' + seconds + ' clamped to ' + clampedTime + ' - seekable range is { start: ' + range.start + ', end: ' + range.end + ' }');
         }
+        sentinelSeekTime = clampedTime;
+        return mediaElement.seek(clampedTime * 1000);
+      }
 
-        function emitEvent (eventType, eventLabels) {
-          var event = {
-            type: eventType,
-            currentTime: getCurrentTime(),
-            seekableRange: getSeekableRange(),
-            duration: getDuration(),
-            url: getSource(),
-            mimeType: getMimeType(),
-            state: getState()
-          };
+      function waitingToPause () {
+        return (postBufferingState === MediaPlayerBase.STATE.PAUSED);
+      }
 
-          if (eventLabels) {
-            for (var key in eventLabels) {
-              if (eventLabels.hasOwnProperty(key)) {
-                event[key] = eventLabels[key];
-              }
-            }
-          }
-
-          eventCallbacks.forEach(function (callback) {
-            callback.to(event);
-          });
+      function wipe () {
+        mediaType = undefined;
+        source = undefined;
+        mimeType = undefined;
+        sentinelSeekTime = undefined;
+        range = undefined;
+        if (mediaElement) {
+          clearInterval(updateInterval);
+          clearSentinels();
+          destroyMediaElement();
+        } else {
         }
+      }
 
-        function getClampedTime (seconds) {
-          var range = getSeekableRange();
-          var offsetFromEnd = getClampOffsetFromConfig();
-          var nearToEnd = Math.max(range.end - offsetFromEnd, range.start);
-          if (seconds < range.start) {
-            return range.start;
-          } else if (seconds > nearToEnd) {
-            return nearToEnd;
-          } else {
-            return seconds;
-          }
+      function destroyMediaElement () {
+        delete mediaElement.onPlayStateChange;
+        if (mediaElement.parentElement) {
+          mediaElement.parentElement.removeChild(mediaElement);
+        } else {
         }
-
-        function getClampOffsetFromConfig () {
-          var clampOffsetFromEndOfRange;
-
-          // TODO: can we tidy this, is it needed any more? If so we can combine it into bigscreen-player configs
-          // if (config && config.streaming && config.streaming.overrides) {
-          //   clampOffsetFromEndOfRange = config.streaming.overrides.clampOffsetFromEndOfRange;
-          // }
-
-          if (clampOffsetFromEndOfRange !== undefined) {
-            return clampOffsetFromEndOfRange;
-          } else {
-            return CLAMP_OFFSET_FROM_END_OF_RANGE;
-          }
-        }
-
-        function isLiveMedia () {
-          return (mediaType === MediaPlayerBase.TYPE.LIVE_VIDEO) || (mediaType === MediaPlayerBase.TYPE.LIVE_AUDIO);
-        }
-
-        function getSource () {
-          return source;
-        }
-
-        function getMimeType () {
-          return mimeType;
-        }
-
-        function getState () {
-          return state;
-        }
-
-        function setSeekSentinelTolerance () {
-          var ON_DEMAND_SEEK_SENTINEL_TOLERANCE = 15;
-          var LIVE_SEEK_SENTINEL_TOLERANCE = 30;
-
-          seekSentinelTolerance = ON_DEMAND_SEEK_SENTINEL_TOLERANCE;
-          if (isLiveMedia()) {
-            seekSentinelTolerance = LIVE_SEEK_SENTINEL_TOLERANCE;
-          }
-        }
-
-        function initialiseMedia (type, url, mediaMimeType, sourceContainer, opts) {
-          disableSentinels = opts.disableSentinels;
-          mediaType = type;
-          source = url;
-          mimeType = mediaMimeType;
-          opts = opts || {};
-
-          emitSeekAttempted();
-
-          if (getState() === MediaPlayerBase.STATE.EMPTY) {
-            timeAtLastSentinelInterval = 0;
-            setSeekSentinelTolerance();
-            createElement();
-            addElementToDOM();
-            mediaElement.data = source;
-            registerEventHandlers();
-            toStopped();
-          } else {
-            toError('Cannot set source unless in the \'' + MediaPlayerBase.STATE.EMPTY + '\' state');
-          }
-        }
-
-        function resume () {
-          postBufferingState = MediaPlayerBase.STATE.PLAYING;
-          switch (getState()) {
-            case MediaPlayerBase.STATE.PLAYING:
-            case MediaPlayerBase.STATE.BUFFERING:
-              break;
-
-            case MediaPlayerBase.STATE.PAUSED:
-              mediaElement.play(1);
-              toPlaying();
-              break;
-
-            default:
-              toError('Cannot resume while in the \'' + getState() + '\' state');
-              break;
-          }
-        }
-
-        function playFrom (seconds) {
-          postBufferingState = MediaPlayerBase.STATE.PLAYING;
-          sentinelLimits.seek.currentAttemptCount = 0;
-          switch (getState()) {
-            case MediaPlayerBase.STATE.BUFFERING:
-              deferSeekingTo = seconds;
-              break;
-
-            case MediaPlayerBase.STATE.COMPLETE:
-              toBuffering();
-              mediaElement.stop();
-              playAndSetDeferredSeek(seconds);
-              break;
-
-            case MediaPlayerBase.STATE.PLAYING:
-              toBuffering();
-              var seekResult = seekTo(seconds);
-              if (seekResult === false) {
-                toPlaying();
-              }
-              break;
-
-            case MediaPlayerBase.STATE.PAUSED:
-              toBuffering();
-              seekTo(seconds);
-              mediaElement.play(1);
-              break;
-
-            default:
-              toError('Cannot playFrom while in the \'' + getState() + '\' state');
-              break;
-          }
-        }
-
-        function getDuration () {
-          switch (getState()) {
-            case MediaPlayerBase.STATE.STOPPED:
-            case MediaPlayerBase.STATE.ERROR:
-              return undefined;
-            default:
-              if (isLiveMedia()) {
-                return Infinity;
-              }
-              return getMediaDuration();
-          }
-        }
-
-        function beginPlayback () {
-          postBufferingState = MediaPlayerBase.STATE.PLAYING;
-          switch (getState()) {
-            case MediaPlayerBase.STATE.STOPPED:
-              toBuffering();
-              mediaElement.play(1);
-              break;
-
-            default:
-              toError('Cannot beginPlayback while in the \'' + getState() + '\' state');
-              break;
-          }
-        }
-
-        function beginPlaybackFrom (seconds) {
-          postBufferingState = MediaPlayerBase.STATE.PLAYING;
-          sentinelLimits.seek.currentAttemptCount = 0;
-
-          switch (getState()) {
-            case MediaPlayerBase.STATE.STOPPED:
-              // Seeking past 0 requires calling play first when media has not been loaded
-              toBuffering();
-              playAndSetDeferredSeek(seconds);
-              break;
-
-            default:
-              toError('Cannot beginPlayback while in the \'' + getState() + '\' state');
-              break;
-          }
-        }
-
-        function pause () {
-          postBufferingState = MediaPlayerBase.STATE.PAUSED;
-          switch (getState()) {
-            case MediaPlayerBase.STATE.BUFFERING:
-            case MediaPlayerBase.STATE.PAUSED:
-              break;
-
-            case MediaPlayerBase.STATE.PLAYING:
-              mediaElement.play(0);
-              toPaused();
-              break;
-
-            default:
-              toError('Cannot pause while in the \'' + getState() + '\' state');
-              break;
-          }
-        }
-
-        function stop () {
-          switch (getState()) {
-            case MediaPlayerBase.STATE.STOPPED:
-              break;
-
-            case MediaPlayerBase.STATE.BUFFERING:
-            case MediaPlayerBase.STATE.PLAYING:
-            case MediaPlayerBase.STATE.PAUSED:
-            case MediaPlayerBase.STATE.COMPLETE:
-              sentinelSeekTime = undefined;
-              if (mediaElement.stop) {
-                mediaElement.stop();
-                toStopped();
-              } else {
-                toError('mediaElement.stop is not a function : failed to stop the media player');
-              }
-              break;
-
-            default:
-              toError('Cannot stop while in the \'' + getState() + '\' state');
-              break;
-          }
-        }
-
-        function reset () {
-          switch (getState()) {
-            case MediaPlayerBase.STATE.EMPTY:
-              break;
-
-            case MediaPlayerBase.STATE.STOPPED:
-            case MediaPlayerBase.STATE.ERROR:
-              toEmpty();
-              break;
-
-            default:
-              toError('Cannot reset while in the \'' + getState() + '\' state');
-              break;
-          }
-        }
-
-        function getCurrentTime () {
-          switch (getState()) {
-            case MediaPlayerBase.STATE.STOPPED:
-            case MediaPlayerBase.STATE.ERROR:
-              break;
-
-            case MediaPlayerBase.STATE.COMPLETE:
-              if (range) {
-                return range.end;
-              }
-              break;
-
-            default:
-              if (mediaElement) {
-                return mediaElement.playPosition / 1000;
-              }
-              break;
-          }
-          return undefined;
-        }
-
-        function getSeekableRange () {
-          switch (getState()) {
-            case MediaPlayerBase.STATE.STOPPED:
-            case MediaPlayerBase.STATE.ERROR:
-              break;
-
-            default:
-              return range;
-          }
-          return undefined;
-        }
-
-        function getMediaDuration () {
-          if (range) {
-            return range.end;
-          }
-          return undefined;
-        }
-
-        function getPlayerElement () {
-          return mediaElement;
-        }
-
-        function onFinishedBuffering () {
-          cacheRange();
-
-          if (getState() !== MediaPlayerBase.STATE.BUFFERING) {
-            return;
-          }
-
-          if (waitingToSeek()) {
-            toBuffering();
-            performDeferredSeek();
-          } else if (waitingToPause()) {
-            toPaused();
-            mediaElement.play(0);
-          } else {
-            toPlaying();
-          }
-        }
-
-        function onDeviceError () {
-          reportError('Media element error code: ' + mediaElement.error);
-        }
-
-        function onDeviceBuffering () {
-          if (getState() === MediaPlayerBase.STATE.PLAYING) {
-            toBuffering();
-          }
-        }
-
-        function onEndOfMedia () {
-          if (getState() !== MediaPlayerBase.STATE.COMPLETE) {
-            toComplete();
-          }
-        }
-
-        function emitSeekAttempted () {
-          if (getState() === MediaPlayerBase.STATE.EMPTY) {
-            emitEvent(MediaPlayerBase.EVENT.SEEK_ATTEMPTED);
-            seekFinished = false;
-          }
-
-          count = 0;
-          timeoutHappened = false;
-          if (deviceConfig.restartTimeout) {
-            setTimeout(function () {
-              timeoutHappened = true;
-            }, deviceConfig.restartTimeout);
-          } else {
-            timeoutHappened = true;
-          }
-        }
-
-        function emitSeekFinishedAtCorrectStartingPoint () {
-          var isAtCorrectStartingPoint = Math.abs(getCurrentTime() - sentinelSeekTime) <= seekSentinelTolerance;
-
-          if (sentinelSeekTime === undefined) {
-            isAtCorrectStartingPoint = true;
-          }
-
-          var isPlayingAtCorrectTime = getState() === MediaPlayerBase.STATE.PLAYING && isAtCorrectStartingPoint;
-
-          if (isPlayingAtCorrectTime && count >= 5 && timeoutHappened && !seekFinished) {
-            emitEvent(MediaPlayerBase.EVENT.SEEK_FINISHED);
-            seekFinished = true;
-          } else if (isPlayingAtCorrectTime) {
-            count++;
-          } else {
-            count = 0;
-          }
-        }
-
-        function onStatus () {
-          if (getState() === MediaPlayerBase.STATE.PLAYING) {
-            emitEvent(MediaPlayerBase.EVENT.STATUS);
-          }
-
-          emitSeekFinishedAtCorrectStartingPoint();
-        }
-
-        function createElement () {
-          mediaElement = document.createElement('object', 'mediaPlayer');
-          mediaElement.type = mimeType;
-          mediaElement.style.position = 'absolute';
-          mediaElement.style.top = '0px';
-          mediaElement.style.left = '0px';
-          mediaElement.style.width = '100%';
-          mediaElement.style.height = '100%';
-        }
-
-        function registerEventHandlers () {
-          var DEVICE_UPDATE_PERIOD_MS = 500;
-
-          mediaElement.onPlayStateChange = function () {
-            switch (mediaElement.playState) {
-              case STATE.STOPPED:
-                break;
-              case STATE.PLAYING:
-                onFinishedBuffering();
-                break;
-              case STATE.PAUSED:
-                break;
-              case STATE.CONNECTING:
-                break;
-              case STATE.BUFFERING:
-                onDeviceBuffering();
-                break;
-              case STATE.FINISHED:
-                onEndOfMedia();
-                break;
-              case STATE.ERROR:
-                onDeviceError();
-                break;
-              default:
-                        // do nothing
-                break;
-            }
-          };
-
-          updateInterval = setInterval(function () {
-            onStatus();
-          }, DEVICE_UPDATE_PERIOD_MS);
-        }
-
-        function addElementToDOM () {
-          var body = document.getElementsByTagName('body')[0];
-          body.insertBefore(mediaElement, body.firstChild);
-        }
-
-        function cacheRange () {
-          if (mediaElement) {
-            range = {
-              start: 0,
-              end: mediaElement.playTime / 1000
-            };
-          }
-        }
-
-        function playAndSetDeferredSeek (seconds) {
-          mediaElement.play(1);
-          if (seconds > 0) {
-            deferSeekingTo = seconds;
-          }
-        }
-
-        function waitingToSeek () {
-          return (deferSeekingTo !== undefined);
-        }
-
-        function performDeferredSeek () {
-          seekTo(deferSeekingTo);
-          deferSeekingTo = undefined;
-        }
-
-        function seekTo (seconds) {
-          var clampedTime = getClampedTime(seconds);
-          if (clampedTime !== seconds) {
-            DebugTool.info('playFrom ' + seconds + ' clamped to ' + clampedTime + ' - seekable range is { start: ' + range.start + ', end: ' + range.end + ' }');
-          }
-          sentinelSeekTime = clampedTime;
-          return mediaElement.seek(clampedTime * 1000);
-        }
-
-        function waitingToPause () {
-          return (postBufferingState === MediaPlayerBase.STATE.PAUSED);
-        }
-
-        function wipe () {
-          mediaType = undefined;
-          source = undefined;
-          mimeType = undefined;
-          sentinelSeekTime = undefined;
-          range = undefined;
-          if (mediaElement) {
-            clearInterval(updateInterval);
-            clearSentinels();
-            destroyMediaElement();
-          } else {
-          }
-        }
-
-        function destroyMediaElement () {
-          delete mediaElement.onPlayStateChange;
-          if (mediaElement.parentElement) {
-            mediaElement.parentElement.removeChild(mediaElement);
-          } else {
-          }
-          mediaElement = undefined;
-        }
-
-        function reportError (errorMessage) {
-          DebugTool.info(errorMessage);
-          emitEvent(MediaPlayerBase.EVENT.ERROR, {'errorMessage': errorMessage});
-        }
-
-        function toStopped () {
-          state = MediaPlayerBase.STATE.STOPPED;
-          emitEvent(MediaPlayerBase.EVENT.STOPPED);
-          if (sentinelInterval) {
-            clearSentinels();
-          }
-        }
-
-        function toBuffering () {
-          state = MediaPlayerBase.STATE.BUFFERING;
-          emitEvent(MediaPlayerBase.EVENT.BUFFERING);
-          setSentinels([exitBufferingSentinel]);
-        }
-
-        function toPlaying () {
-          state = MediaPlayerBase.STATE.PLAYING;
-          emitEvent(MediaPlayerBase.EVENT.PLAYING);
-          setSentinels([
-            shouldBeSeekedSentinel,
-            enterCompleteSentinel,
-            enterBufferingSentinel
-          ]);
-        }
-
-        function toPaused () {
-          state = MediaPlayerBase.STATE.PAUSED;
-          emitEvent(MediaPlayerBase.EVENT.PAUSED);
-          setSentinels([
-            shouldBePausedSentinel,
-            shouldBeSeekedSentinel
-          ]);
-        }
-
-        function toComplete () {
-          state = MediaPlayerBase.STATE.COMPLETE;
-          emitEvent(MediaPlayerBase.EVENT.COMPLETE);
+        mediaElement = undefined;
+      }
+
+      function reportError (errorMessage) {
+        DebugTool.info(errorMessage);
+        emitEvent(MediaPlayerBase.EVENT.ERROR, {'errorMessage': errorMessage});
+      }
+
+      function toStopped () {
+        state = MediaPlayerBase.STATE.STOPPED;
+        emitEvent(MediaPlayerBase.EVENT.STOPPED);
+        if (sentinelInterval) {
           clearSentinels();
         }
+      }
 
-        function toEmpty () {
-          wipe();
-          state = MediaPlayerBase.STATE.EMPTY;
+      function toBuffering () {
+        state = MediaPlayerBase.STATE.BUFFERING;
+        emitEvent(MediaPlayerBase.EVENT.BUFFERING);
+        setSentinels([exitBufferingSentinel]);
+      }
+
+      function toPlaying () {
+        state = MediaPlayerBase.STATE.PLAYING;
+        emitEvent(MediaPlayerBase.EVENT.PLAYING);
+        setSentinels([
+          shouldBeSeekedSentinel,
+          enterCompleteSentinel,
+          enterBufferingSentinel
+        ]);
+      }
+
+      function toPaused () {
+        state = MediaPlayerBase.STATE.PAUSED;
+        emitEvent(MediaPlayerBase.EVENT.PAUSED);
+        setSentinels([
+          shouldBePausedSentinel,
+          shouldBeSeekedSentinel
+        ]);
+      }
+
+      function toComplete () {
+        state = MediaPlayerBase.STATE.COMPLETE;
+        emitEvent(MediaPlayerBase.EVENT.COMPLETE);
+        clearSentinels();
+      }
+
+      function toEmpty () {
+        wipe();
+        state = MediaPlayerBase.STATE.EMPTY;
+      }
+
+      function toError (errorMessage) {
+        wipe();
+        state = MediaPlayerBase.STATE.ERROR;
+        reportError(errorMessage);
+      }
+
+      function isNearToEnd (seconds) {
+        return (getDuration() - seconds <= 1);
+      }
+
+      function setSentinels (sentinels) {
+        if (disableSentinels) {
+          return;
         }
 
-        function toError (errorMessage) {
-          wipe();
-          state = MediaPlayerBase.STATE.ERROR;
-          reportError(errorMessage);
-        }
+        sentinelLimits.pause.currentAttemptCount = 0;
+        timeAtLastSentinelInterval = getCurrentTime();
+        clearSentinels();
+        sentinelIntervalNumber = 0;
+        sentinelInterval = setInterval(function () {
+          var newTime = getCurrentTime();
+          sentinelIntervalNumber++;
 
-        function isNearToEnd (seconds) {
-          return (getDuration() - seconds <= 1);
-        }
+          timeHasAdvanced = newTime ? (newTime > (timeAtLastSentinelInterval + 0.2)) : false;
+          sentinelTimeIsNearEnd = isNearToEnd(newTime || timeAtLastSentinelInterval);
 
-        function setSentinels (sentinels) {
-          if (disableSentinels) {
-            return;
-          }
-
-          sentinelLimits.pause.currentAttemptCount = 0;
-          timeAtLastSentinelInterval = getCurrentTime();
-          clearSentinels();
-          sentinelIntervalNumber = 0;
-          sentinelInterval = setInterval(function () {
-            var newTime = getCurrentTime();
-            sentinelIntervalNumber++;
-
-            timeHasAdvanced = newTime ? (newTime > (timeAtLastSentinelInterval + 0.2)) : false;
-            sentinelTimeIsNearEnd = isNearToEnd(newTime || timeAtLastSentinelInterval);
-
-            for (var i = 0; i < sentinels.length; i++) {
-              var sentinelActionPerformed = sentinels[i].call(this);
-              if (sentinelActionPerformed) {
-                break;
-              }
+          for (var i = 0; i < sentinels.length; i++) {
+            var sentinelActionPerformed = sentinels[i].call(this);
+            if (sentinelActionPerformed) {
+              break;
             }
+          }
 
-            timeAtLastSentinelInterval = newTime;
-          }, 1100);
+          timeAtLastSentinelInterval = newTime;
+        }, 1100);
+      }
+
+      function clearSentinels () {
+        clearInterval(sentinelInterval);
+      }
+
+      function enterBufferingSentinel () {
+        var sentinelBufferingRequired = !timeHasAdvanced && !sentinelTimeIsNearEnd && (sentinelIntervalNumber > 1);
+        if (sentinelBufferingRequired) {
+          emitEvent(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
+          toBuffering();
         }
+        return sentinelBufferingRequired;
+      }
 
-        function clearSentinels () {
-          clearInterval(sentinelInterval);
+      function exitBufferingSentinel () {
+        var sentinelExitBufferingRequired = timeHasAdvanced;
+        if (sentinelExitBufferingRequired) {
+          emitEvent(MediaPlayerBase.EVENT.SENTINEL_EXIT_BUFFERING);
+          onFinishedBuffering();
         }
+        return sentinelExitBufferingRequired;
+      }
 
-        function enterBufferingSentinel () {
-          var sentinelBufferingRequired = !timeHasAdvanced && !sentinelTimeIsNearEnd && (sentinelIntervalNumber > 1);
-          if (sentinelBufferingRequired) {
-            emitEvent(MediaPlayerBase.EVENT.SENTINEL_ENTER_BUFFERING);
-            toBuffering();
-          }
-          return sentinelBufferingRequired;
-        }
-
-        function exitBufferingSentinel () {
-          var sentinelExitBufferingRequired = timeHasAdvanced;
-          if (sentinelExitBufferingRequired) {
-            emitEvent(MediaPlayerBase.EVENT.SENTINEL_EXIT_BUFFERING);
-            onFinishedBuffering();
-          }
-          return sentinelExitBufferingRequired;
-        }
-
-        function shouldBeSeekedSentinel () {
-          if (sentinelSeekTime === undefined) {
-            return false;
-          }
-
-          var currentTime = getCurrentTime();
-
-          var clampedSentinelSeekTime = getClampedTime(sentinelSeekTime);
-
-          var sentinelSeekRequired = Math.abs(clampedSentinelSeekTime - currentTime) > seekSentinelTolerance;
-          var sentinelActionTaken = false;
-
-          if (sentinelSeekRequired) {
-            var mediaElement = mediaElement;
-            sentinelActionTaken = nextSentinelAttempt(sentinelLimits.seek, function () {
-              mediaElement.seek(clampedSentinelSeekTime * 1000);
-            });
-          } else if (sentinelIntervalNumber < 3) {
-            sentinelSeekTime = currentTime;
-          } else {
-            sentinelSeekTime = undefined;
-          }
-          return sentinelActionTaken;
-        }
-
-        function shouldBePausedSentinel () {
-          var sentinelPauseRequired = timeHasAdvanced;
-          var sentinelActionTaken = false;
-          if (sentinelPauseRequired) {
-            var mediaElement = mediaElement;
-            sentinelActionTaken = nextSentinelAttempt(sentinelLimits.pause, function () {
-              mediaElement.play(0);
-            });
-          }
-          return sentinelActionTaken;
-        }
-
-        function enterCompleteSentinel () {
-          var sentinelCompleteRequired = !timeHasAdvanced && sentinelTimeIsNearEnd;
-          if (sentinelCompleteRequired) {
-            emitEvent(MediaPlayerBase.EVENT.SENTINEL_COMPLETE);
-            onEndOfMedia();
-          }
-          return sentinelCompleteRequired;
-        }
-
-        function nextSentinelAttempt (sentinelInfo, attemptFn) {
-          var currentAttemptCount, maxAttemptCount;
-
-          sentinelInfo.currentAttemptCount += 1;
-          currentAttemptCount = sentinelInfo.currentAttemptCount;
-          maxAttemptCount = sentinelInfo.maximumAttempts;
-
-          if (currentAttemptCount === maxAttemptCount + 1) {
-            emitEvent(sentinelInfo.failureEvent);
-          }
-
-          if (currentAttemptCount <= maxAttemptCount) {
-            attemptFn();
-            emitEvent(sentinelInfo.successEvent);
-            return true;
-          }
-
+      function shouldBeSeekedSentinel () {
+        if (sentinelSeekTime === undefined) {
           return false;
         }
 
-        return {
-          addEventCallback: addEventCallback,
-          removeEventCallback: removeEventCallback,
-          removeAllEventCallbacks: removeAllEventCallbacks,
-          initialiseMedia: initialiseMedia,
-          resume: resume,
-          playFrom: playFrom,
-          beginPlayback: beginPlayback,
-          beginPlaybackFrom: beginPlaybackFrom,
-          pause: pause,
-          stop: stop,
-          reset: reset,
-          getSource: getSource,
-          getMimeType: getMimeType,
-          getSeekableRange: getSeekableRange,
-          getMediaDuration: getMediaDuration,
-          getState: getState,
-          getPlayerElement: getPlayerElement,
-          getDuration: getDuration
-        };
+        var currentTime = getCurrentTime();
+
+        var clampedSentinelSeekTime = getClampedTime(sentinelSeekTime);
+
+        var sentinelSeekRequired = Math.abs(clampedSentinelSeekTime - currentTime) > seekSentinelTolerance;
+        var sentinelActionTaken = false;
+
+        if (sentinelSeekRequired) {
+          var mediaElement = mediaElement;
+          sentinelActionTaken = nextSentinelAttempt(sentinelLimits.seek, function () {
+            mediaElement.seek(clampedSentinelSeekTime * 1000);
+          });
+        } else if (sentinelIntervalNumber < 3) {
+          sentinelSeekTime = currentTime;
+        } else {
+          sentinelSeekTime = undefined;
+        }
+        return sentinelActionTaken;
+      }
+
+      function shouldBePausedSentinel () {
+        var sentinelPauseRequired = timeHasAdvanced;
+        var sentinelActionTaken = false;
+        if (sentinelPauseRequired) {
+          var mediaElement = mediaElement;
+          sentinelActionTaken = nextSentinelAttempt(sentinelLimits.pause, function () {
+            mediaElement.play(0);
+          });
+        }
+        return sentinelActionTaken;
+      }
+
+      function enterCompleteSentinel () {
+        var sentinelCompleteRequired = !timeHasAdvanced && sentinelTimeIsNearEnd;
+        if (sentinelCompleteRequired) {
+          emitEvent(MediaPlayerBase.EVENT.SENTINEL_COMPLETE);
+          onEndOfMedia();
+        }
+        return sentinelCompleteRequired;
+      }
+
+      function nextSentinelAttempt (sentinelInfo, attemptFn) {
+        var currentAttemptCount, maxAttemptCount;
+
+        sentinelInfo.currentAttemptCount += 1;
+        currentAttemptCount = sentinelInfo.currentAttemptCount;
+        maxAttemptCount = sentinelInfo.maximumAttempts;
+
+        if (currentAttemptCount === maxAttemptCount + 1) {
+          emitEvent(sentinelInfo.failureEvent);
+        }
+
+        if (currentAttemptCount <= maxAttemptCount) {
+          attemptFn();
+          emitEvent(sentinelInfo.successEvent);
+          return true;
+        }
+
+        return false;
+      }
+
+      return {
+        addEventCallback: addEventCallback,
+        removeEventCallback: removeEventCallback,
+        removeAllEventCallbacks: removeAllEventCallbacks,
+        initialiseMedia: initialiseMedia,
+        resume: resume,
+        playFrom: playFrom,
+        beginPlayback: beginPlayback,
+        beginPlaybackFrom: beginPlaybackFrom,
+        pause: pause,
+        stop: stop,
+        reset: reset,
+        getSource: getSource,
+        getMimeType: getMimeType,
+        getSeekableRange: getSeekableRange,
+        getMediaDuration: getMediaDuration,
+        getState: getState,
+        getPlayerElement: getPlayerElement,
+        getDuration: getDuration
       };
-    });
+    };
+  });

--- a/script/playbackstrategy/modifiers/live/playable.js
+++ b/script/playbackstrategy/modifiers/live/playable.js
@@ -1,64 +1,64 @@
 define(
-    'bigscreenplayer/playbackstrategy/modifiers/live/playable',
+  'bigscreenplayer/playbackstrategy/modifiers/live/playable',
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase'
   ],
-    function (MediaPlayerBase) {
-      'use strict';
-      function PlayableLivePlayer (mediaPlayer) {
-        return {
-          beginPlayback: function beginPlayback () {
-            mediaPlayer.beginPlayback();
-          },
+  function (MediaPlayerBase) {
+    'use strict';
+    function PlayableLivePlayer (mediaPlayer) {
+      return {
+        beginPlayback: function beginPlayback () {
+          mediaPlayer.beginPlayback();
+        },
 
-          initialiseMedia: function initialiseMedia (mediaType, sourceUrl, mimeType, sourceContainer, opts) {
-            if (mediaType === MediaPlayerBase.TYPE.AUDIO) {
-              mediaType = MediaPlayerBase.TYPE.LIVE_AUDIO;
-            } else {
-              mediaType = MediaPlayerBase.TYPE.LIVE_VIDEO;
-            }
-
-            mediaPlayer.initialiseMedia(mediaType, sourceUrl, mimeType, sourceContainer, opts);
-          },
-
-          stop: function stop () {
-            mediaPlayer.stop();
-          },
-
-          reset: function reset () {
-            mediaPlayer.reset();
-          },
-
-          getState: function getState () {
-            return mediaPlayer.getState();
-          },
-
-          getSource: function getSource () {
-            return mediaPlayer.getSource();
-          },
-
-          getMimeType: function getMimeType () {
-            return mediaPlayer.getMimeType();
-          },
-
-          addEventCallback: function addEventCallback (thisArg, callback) {
-            mediaPlayer.addEventCallback(thisArg, callback);
-          },
-
-          removeEventCallback: function removeEventCallback (thisArg, callback) {
-            mediaPlayer.removeEventCallback(thisArg, callback);
-          },
-
-          removeAllEventCallbacks: function removeAllEventCallbacks () {
-            mediaPlayer.removeAllEventCallbacks();
-          },
-
-          getPlayerElement: function getPlayerElement () {
-            return mediaPlayer.getPlayerElement();
+        initialiseMedia: function initialiseMedia (mediaType, sourceUrl, mimeType, sourceContainer, opts) {
+          if (mediaType === MediaPlayerBase.TYPE.AUDIO) {
+            mediaType = MediaPlayerBase.TYPE.LIVE_AUDIO;
+          } else {
+            mediaType = MediaPlayerBase.TYPE.LIVE_VIDEO;
           }
-        };
-      }
 
-      return PlayableLivePlayer;
+          mediaPlayer.initialiseMedia(mediaType, sourceUrl, mimeType, sourceContainer, opts);
+        },
+
+        stop: function stop () {
+          mediaPlayer.stop();
+        },
+
+        reset: function reset () {
+          mediaPlayer.reset();
+        },
+
+        getState: function getState () {
+          return mediaPlayer.getState();
+        },
+
+        getSource: function getSource () {
+          return mediaPlayer.getSource();
+        },
+
+        getMimeType: function getMimeType () {
+          return mediaPlayer.getMimeType();
+        },
+
+        addEventCallback: function addEventCallback (thisArg, callback) {
+          mediaPlayer.addEventCallback(thisArg, callback);
+        },
+
+        removeEventCallback: function removeEventCallback (thisArg, callback) {
+          mediaPlayer.removeEventCallback(thisArg, callback);
+        },
+
+        removeAllEventCallbacks: function removeAllEventCallbacks () {
+          mediaPlayer.removeAllEventCallbacks();
+        },
+
+        getPlayerElement: function getPlayerElement () {
+          return mediaPlayer.getPlayerElement();
+        }
+      };
     }
+
+    return PlayableLivePlayer;
+  }
 );

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -1,157 +1,157 @@
 define(
-    'bigscreenplayer/playbackstrategy/modifiers/live/restartable',
+  'bigscreenplayer/playbackstrategy/modifiers/live/restartable',
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
     'bigscreenplayer/models/windowtypes',
     'bigscreenplayer/dynamicwindowutils'
   ],
-    function (MediaPlayerBase, WindowTypes, DynamicWindowUtils) {
-      'use strict';
+  function (MediaPlayerBase, WindowTypes, DynamicWindowUtils) {
+    'use strict';
 
-      function RestartableLivePlayer (mediaPlayer, deviceConfig, windowType, mediaSources) {
-        var callbacksMap = [];
-        var startTime;
-        var fakeTimer = {};
-        var timeCorrection = mediaSources.time().correction || 0;
-        addEventCallback(this, updateFakeTimer);
+    function RestartableLivePlayer (mediaPlayer, deviceConfig, windowType, mediaSources) {
+      var callbacksMap = [];
+      var startTime;
+      var fakeTimer = {};
+      var timeCorrection = mediaSources.time().correction || 0;
+      addEventCallback(this, updateFakeTimer);
 
-        function updateFakeTimer (event) {
-          if (fakeTimer.wasPlaying && fakeTimer.runningTime) {
-            fakeTimer.currentTime += (Date.now() - fakeTimer.runningTime) / 1000;
-          }
-
-          fakeTimer.runningTime = Date.now();
-          fakeTimer.wasPlaying = event.state === MediaPlayerBase.STATE.PLAYING;
+      function updateFakeTimer (event) {
+        if (fakeTimer.wasPlaying && fakeTimer.runningTime) {
+          fakeTimer.currentTime += (Date.now() - fakeTimer.runningTime) / 1000;
         }
 
-        function addEventCallback (thisArg, callback) {
-          function newCallback (event) {
-            event.currentTime = getCurrentTime();
-            event.seekableRange = getSeekableRange();
-            callback(event);
-          }
-          callbacksMap.push({ from: callback, to: newCallback });
-          mediaPlayer.addEventCallback(thisArg, newCallback);
+        fakeTimer.runningTime = Date.now();
+        fakeTimer.wasPlaying = event.state === MediaPlayerBase.STATE.PLAYING;
+      }
+
+      function addEventCallback (thisArg, callback) {
+        function newCallback (event) {
+          event.currentTime = getCurrentTime();
+          event.seekableRange = getSeekableRange();
+          callback(event);
         }
+        callbacksMap.push({ from: callback, to: newCallback });
+        mediaPlayer.addEventCallback(thisArg, newCallback);
+      }
 
-        function removeEventCallback (thisArg, callback) {
-          var filteredCallbacks = callbacksMap.filter(function (cb) {
-            return cb.from === callback;
-          });
+      function removeEventCallback (thisArg, callback) {
+        var filteredCallbacks = callbacksMap.filter(function (cb) {
+          return cb.from === callback;
+        });
 
-          if (filteredCallbacks.length > 0) {
-            callbacksMap = callbacksMap.splice(callbacksMap.indexOf(filteredCallbacks[0]));
+        if (filteredCallbacks.length > 0) {
+          callbacksMap = callbacksMap.splice(callbacksMap.indexOf(filteredCallbacks[0]));
 
-            mediaPlayer.removeEventCallback(thisArg, filteredCallbacks[0].to);
-          }
+          mediaPlayer.removeEventCallback(thisArg, filteredCallbacks[0].to);
         }
+      }
 
-        function removeAllEventCallbacks () {
-          mediaPlayer.removeAllEventCallbacks();
+      function removeAllEventCallbacks () {
+        mediaPlayer.removeAllEventCallbacks();
+      }
+
+      function resume () {
+        mediaPlayer.resume();
+      }
+
+      function pause (opts) {
+        mediaPlayer.pause();
+        opts = opts || {};
+        if (opts.disableAutoResume !== true) {
+          DynamicWindowUtils.autoResumeAtStartOfRange(
+            getCurrentTime(),
+            getSeekableRange(),
+            addEventCallback,
+            removeEventCallback,
+            MediaPlayerBase.unpausedEventCheck,
+            resume);
         }
+      }
 
-        function resume () {
-          mediaPlayer.resume();
-        }
+      function getCurrentTime () {
+        return fakeTimer.currentTime + timeCorrection;
+      }
 
-        function pause (opts) {
-          mediaPlayer.pause();
-          opts = opts || {};
-          if (opts.disableAutoResume !== true) {
-            DynamicWindowUtils.autoResumeAtStartOfRange(
-              getCurrentTime(),
-              getSeekableRange(),
-              addEventCallback,
-              removeEventCallback,
-              MediaPlayerBase.unpausedEventCheck,
-              resume);
-          }
-        }
-
-        function getCurrentTime () {
-          return fakeTimer.currentTime + timeCorrection;
-        }
-
-        function getSeekableRange () {
-          var windowLength = (mediaSources.time().windowEndTime - mediaSources.time().windowStartTime) / 1000;
-          var delta = (Date.now() - startTime) / 1000;
-          return {
-            start: (windowType === WindowTypes.SLIDING ? delta : 0) + timeCorrection,
-            end: windowLength + delta + timeCorrection
-          };
-        }
-
+      function getSeekableRange () {
+        var windowLength = (mediaSources.time().windowEndTime - mediaSources.time().windowStartTime) / 1000;
+        var delta = (Date.now() - startTime) / 1000;
         return {
-          beginPlayback: function () {
-            var config = deviceConfig;
-
-            startTime = Date.now();
-            fakeTimer.currentTime = (mediaSources.time().windowEndTime - mediaSources.time().windowStartTime) / 1000;
-
-            if (config && config.streaming && config.streaming.overrides && config.streaming.overrides.forceBeginPlaybackToEndOfWindow) {
-              mediaPlayer.beginPlaybackFrom(Infinity);
-            } else {
-              mediaPlayer.beginPlayback();
-            }
-          },
-
-          beginPlaybackFrom: function (offset) {
-            startTime = Date.now();
-            fakeTimer.currentTime = offset;
-            mediaPlayer.beginPlaybackFrom(offset);
-          },
-
-          initialiseMedia: function (mediaType, sourceUrl, mimeType, sourceContainer, opts) {
-            if (mediaType === MediaPlayerBase.TYPE.AUDIO) {
-              mediaType = MediaPlayerBase.TYPE.LIVE_AUDIO;
-            } else {
-              mediaType = MediaPlayerBase.TYPE.LIVE_VIDEO;
-            }
-
-            mediaPlayer.initialiseMedia(mediaType, sourceUrl, mimeType, sourceContainer, opts);
-          },
-
-          pause: pause,
-
-          resume: resume,
-
-          stop: function () {
-            mediaPlayer.stop();
-          },
-
-          reset: function () {
-            mediaPlayer.reset();
-          },
-
-          getState: function () {
-            return mediaPlayer.getState();
-          },
-
-          getSource: function () {
-            return mediaPlayer.getSource();
-          },
-
-          getMimeType: function () {
-            return mediaPlayer.getMimeType();
-          },
-
-          addEventCallback: addEventCallback,
-
-          removeEventCallback: removeEventCallback,
-
-          removeAllEventCallbacks: removeAllEventCallbacks,
-
-          getPlayerElement: function () {
-            return mediaPlayer.getPlayerElement();
-          },
-
-          getCurrentTime: getCurrentTime,
-
-          getSeekableRange: getSeekableRange
-
+          start: (windowType === WindowTypes.SLIDING ? delta : 0) + timeCorrection,
+          end: windowLength + delta + timeCorrection
         };
       }
 
-      return RestartableLivePlayer;
+      return {
+        beginPlayback: function () {
+          var config = deviceConfig;
+
+          startTime = Date.now();
+          fakeTimer.currentTime = (mediaSources.time().windowEndTime - mediaSources.time().windowStartTime) / 1000;
+
+          if (config && config.streaming && config.streaming.overrides && config.streaming.overrides.forceBeginPlaybackToEndOfWindow) {
+            mediaPlayer.beginPlaybackFrom(Infinity);
+          } else {
+            mediaPlayer.beginPlayback();
+          }
+        },
+
+        beginPlaybackFrom: function (offset) {
+          startTime = Date.now();
+          fakeTimer.currentTime = offset;
+          mediaPlayer.beginPlaybackFrom(offset);
+        },
+
+        initialiseMedia: function (mediaType, sourceUrl, mimeType, sourceContainer, opts) {
+          if (mediaType === MediaPlayerBase.TYPE.AUDIO) {
+            mediaType = MediaPlayerBase.TYPE.LIVE_AUDIO;
+          } else {
+            mediaType = MediaPlayerBase.TYPE.LIVE_VIDEO;
+          }
+
+          mediaPlayer.initialiseMedia(mediaType, sourceUrl, mimeType, sourceContainer, opts);
+        },
+
+        pause: pause,
+
+        resume: resume,
+
+        stop: function () {
+          mediaPlayer.stop();
+        },
+
+        reset: function () {
+          mediaPlayer.reset();
+        },
+
+        getState: function () {
+          return mediaPlayer.getState();
+        },
+
+        getSource: function () {
+          return mediaPlayer.getSource();
+        },
+
+        getMimeType: function () {
+          return mediaPlayer.getMimeType();
+        },
+
+        addEventCallback: addEventCallback,
+
+        removeEventCallback: removeEventCallback,
+
+        removeAllEventCallbacks: removeAllEventCallbacks,
+
+        getPlayerElement: function () {
+          return mediaPlayer.getPlayerElement();
+        },
+
+        getCurrentTime: getCurrentTime,
+
+        getSeekableRange: getSeekableRange
+
+      };
     }
+
+    return RestartableLivePlayer;
+  }
 );

--- a/script/playbackstrategy/modifiers/live/seekable.js
+++ b/script/playbackstrategy/modifiers/live/seekable.js
@@ -1,125 +1,125 @@
 define(
-    'bigscreenplayer/playbackstrategy/modifiers/live/seekable',
+  'bigscreenplayer/playbackstrategy/modifiers/live/seekable',
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
     'bigscreenplayer/dynamicwindowutils'
   ],
-    function (MediaPlayerBase, DynamicWindowUtils) {
-      'use strict';
+  function (MediaPlayerBase, DynamicWindowUtils) {
+    'use strict';
 
-      function SeekableLivePlayer (mediaPlayer, deviceConfig) {
-        var AUTO_RESUME_WINDOW_START_CUSHION_SECONDS = 8;
+    function SeekableLivePlayer (mediaPlayer, deviceConfig) {
+      var AUTO_RESUME_WINDOW_START_CUSHION_SECONDS = 8;
 
-        function addEventCallback (thisArg, callback) {
-          mediaPlayer.addEventCallback(thisArg, callback);
-        }
-
-        function removeEventCallback (thisArg, callback) {
-          mediaPlayer.removeEventCallback(thisArg, callback);
-        }
-
-        function removeAllEventCallbacks () {
-          mediaPlayer.removeAllEventCallbacks();
-        }
-
-        function resume () {
-          mediaPlayer.resume();
-        }
-
-        return ({
-          initialiseMedia: function initialiseMedia (mediaType, sourceUrl, mimeType, sourceContainer, opts) {
-            if (mediaType === MediaPlayerBase.TYPE.AUDIO) {
-              mediaType = MediaPlayerBase.TYPE.LIVE_AUDIO;
-            } else {
-              mediaType = MediaPlayerBase.TYPE.LIVE_VIDEO;
-            }
-
-            mediaPlayer.initialiseMedia(mediaType, sourceUrl, mimeType, sourceContainer, opts);
-          },
-
-          beginPlayback: function beginPlayback () {
-            var config = deviceConfig;
-            if (config && config.streaming && config.streaming.overrides && config.streaming.overrides.forceBeginPlaybackToEndOfWindow) {
-              mediaPlayer.beginPlaybackFrom(Infinity);
-            } else {
-              mediaPlayer.beginPlayback();
-            }
-          },
-
-          beginPlaybackFrom: function beginPlaybackFrom (offset) {
-            mediaPlayer.beginPlaybackFrom(offset);
-          },
-
-          playFrom: function playFrom (offset) {
-            mediaPlayer.playFrom(offset);
-          },
-
-          pause: function pause (opts) {
-            opts = opts || {};
-            var secondsUntilStartOfWindow = mediaPlayer.getCurrentTime() - mediaPlayer.getSeekableRange().start;
-
-            if (opts.disableAutoResume) {
-              mediaPlayer.pause();
-            } else if (secondsUntilStartOfWindow <= AUTO_RESUME_WINDOW_START_CUSHION_SECONDS) {
-              mediaPlayer.toPaused();
-              mediaPlayer.toPlaying();
-            } else {
-              mediaPlayer.pause();
-              DynamicWindowUtils.autoResumeAtStartOfRange(
-                mediaPlayer.getCurrentTime(),
-                mediaPlayer.getSeekableRange(),
-                addEventCallback,
-                removeEventCallback,
-                MediaPlayerBase.unpausedEventCheck,
-                resume);
-            }
-          },
-          resume: resume,
-
-          stop: function stop () {
-            mediaPlayer.stop();
-          },
-
-          reset: function reset () {
-            mediaPlayer.reset();
-          },
-
-          getState: function getState () {
-            return mediaPlayer.getState();
-          },
-
-          getSource: function getSource () {
-            return mediaPlayer.getSource();
-          },
-
-          getCurrentTime: function getCurrentTime () {
-            return mediaPlayer.getCurrentTime();
-          },
-
-          getSeekableRange: function getSeekableRange () {
-            return mediaPlayer.getSeekableRange();
-          },
-
-          getMimeType: function getMimeType () {
-            return mediaPlayer.getMimeType();
-          },
-
-          addEventCallback: addEventCallback,
-
-          removeEventCallback: removeEventCallback,
-
-          removeAllEventCallbacks: removeAllEventCallbacks,
-
-          getPlayerElement: function getPlayerElement () {
-            return mediaPlayer.getPlayerElement();
-          },
-
-          getLiveSupport: function getLiveSupport () {
-            return MediaPlayerBase.LIVE_SUPPORT.SEEKABLE;
-          }
-
-        });
+      function addEventCallback (thisArg, callback) {
+        mediaPlayer.addEventCallback(thisArg, callback);
       }
 
-      return SeekableLivePlayer;
-    });
+      function removeEventCallback (thisArg, callback) {
+        mediaPlayer.removeEventCallback(thisArg, callback);
+      }
+
+      function removeAllEventCallbacks () {
+        mediaPlayer.removeAllEventCallbacks();
+      }
+
+      function resume () {
+        mediaPlayer.resume();
+      }
+
+      return ({
+        initialiseMedia: function initialiseMedia (mediaType, sourceUrl, mimeType, sourceContainer, opts) {
+          if (mediaType === MediaPlayerBase.TYPE.AUDIO) {
+            mediaType = MediaPlayerBase.TYPE.LIVE_AUDIO;
+          } else {
+            mediaType = MediaPlayerBase.TYPE.LIVE_VIDEO;
+          }
+
+          mediaPlayer.initialiseMedia(mediaType, sourceUrl, mimeType, sourceContainer, opts);
+        },
+
+        beginPlayback: function beginPlayback () {
+          var config = deviceConfig;
+          if (config && config.streaming && config.streaming.overrides && config.streaming.overrides.forceBeginPlaybackToEndOfWindow) {
+            mediaPlayer.beginPlaybackFrom(Infinity);
+          } else {
+            mediaPlayer.beginPlayback();
+          }
+        },
+
+        beginPlaybackFrom: function beginPlaybackFrom (offset) {
+          mediaPlayer.beginPlaybackFrom(offset);
+        },
+
+        playFrom: function playFrom (offset) {
+          mediaPlayer.playFrom(offset);
+        },
+
+        pause: function pause (opts) {
+          opts = opts || {};
+          var secondsUntilStartOfWindow = mediaPlayer.getCurrentTime() - mediaPlayer.getSeekableRange().start;
+
+          if (opts.disableAutoResume) {
+            mediaPlayer.pause();
+          } else if (secondsUntilStartOfWindow <= AUTO_RESUME_WINDOW_START_CUSHION_SECONDS) {
+            mediaPlayer.toPaused();
+            mediaPlayer.toPlaying();
+          } else {
+            mediaPlayer.pause();
+            DynamicWindowUtils.autoResumeAtStartOfRange(
+              mediaPlayer.getCurrentTime(),
+              mediaPlayer.getSeekableRange(),
+              addEventCallback,
+              removeEventCallback,
+              MediaPlayerBase.unpausedEventCheck,
+              resume);
+          }
+        },
+        resume: resume,
+
+        stop: function stop () {
+          mediaPlayer.stop();
+        },
+
+        reset: function reset () {
+          mediaPlayer.reset();
+        },
+
+        getState: function getState () {
+          return mediaPlayer.getState();
+        },
+
+        getSource: function getSource () {
+          return mediaPlayer.getSource();
+        },
+
+        getCurrentTime: function getCurrentTime () {
+          return mediaPlayer.getCurrentTime();
+        },
+
+        getSeekableRange: function getSeekableRange () {
+          return mediaPlayer.getSeekableRange();
+        },
+
+        getMimeType: function getMimeType () {
+          return mediaPlayer.getMimeType();
+        },
+
+        addEventCallback: addEventCallback,
+
+        removeEventCallback: removeEventCallback,
+
+        removeAllEventCallbacks: removeAllEventCallbacks,
+
+        getPlayerElement: function getPlayerElement () {
+          return mediaPlayer.getPlayerElement();
+        },
+
+        getLiveSupport: function getLiveSupport () {
+          return MediaPlayerBase.LIVE_SUPPORT.SEEKABLE;
+        }
+
+      });
+    }
+
+    return SeekableLivePlayer;
+  });

--- a/script/playbackstrategy/modifiers/mediaplayerbase.js
+++ b/script/playbackstrategy/modifiers/mediaplayerbase.js
@@ -1,56 +1,56 @@
 define(
-    'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
-    function () {
-      var STATE = {
-        EMPTY: 'EMPTY',     // No source set
-        STOPPED: 'STOPPED',   // Source set but no playback
-        BUFFERING: 'BUFFERING', // Not enough data to play, waiting to download more
-        PLAYING: 'PLAYING',   // Media is playing
-        PAUSED: 'PAUSED',    // Media is paused
-        COMPLETE: 'COMPLETE',  // Media has reached its end point
-        ERROR: 'ERROR'      // An error occurred
-      };
+  'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
+  function () {
+    var STATE = {
+      EMPTY: 'EMPTY', // No source set
+      STOPPED: 'STOPPED', // Source set but no playback
+      BUFFERING: 'BUFFERING', // Not enough data to play, waiting to download more
+      PLAYING: 'PLAYING', // Media is playing
+      PAUSED: 'PAUSED', // Media is paused
+      COMPLETE: 'COMPLETE', // Media has reached its end point
+      ERROR: 'ERROR' // An error occurred
+    };
 
-      var EVENT = {
-        STOPPED: 'stopped',   // Event fired when playback is stopped
-        BUFFERING: 'buffering', // Event fired when playback has to suspend due to buffering
-        PLAYING: 'playing',   // Event fired when starting (or resuming) playing of the media
-        PAUSED: 'paused',    // Event fired when media playback pauses
-        COMPLETE: 'complete',  // Event fired when media playback has reached the end of the media
-        ERROR: 'error',     // Event fired when an error condition occurs
-        STATUS: 'status',    // Event fired regularly during play
-        SENTINEL_ENTER_BUFFERING: 'sentinel-enter-buffering', // Event fired when a sentinel has to act because the device has started buffering but not reported it
-        SENTINEL_EXIT_BUFFERING: 'sentinel-exit-buffering',  // Event fired when a sentinel has to act because the device has finished buffering but not reported it
-        SENTINEL_PAUSE: 'sentinel-pause',           // Event fired when a sentinel has to act because the device has failed to pause when expected
-        SENTINEL_PLAY: 'sentinel-play',            // Event fired when a sentinel has to act because the device has failed to play when expected
-        SENTINEL_SEEK: 'sentinel-seek',            // Event fired when a sentinel has to act because the device has failed to seek to the correct location
-        SENTINEL_COMPLETE: 'sentinel-complete',        // Event fired when a sentinel has to act because the device has completed the media but not reported it
-        SENTINEL_PAUSE_FAILURE: 'sentinel-pause-failure',   // Event fired when the pause sentinel has failed twice, so it is giving up
-        SENTINEL_SEEK_FAILURE: 'sentinel-seek-failure',     // Event fired when the seek sentinel has failed twice, so it is giving up
-        SEEK_ATTEMPTED: 'seek-attempted', // Event fired when a device using a seekfinishedemitevent modifier sets the source
-        SEEK_FINISHED: 'seek-finished'    // Event fired when a device using a seekfinishedemitevent modifier has seeked successfully
-      };
+    var EVENT = {
+      STOPPED: 'stopped', // Event fired when playback is stopped
+      BUFFERING: 'buffering', // Event fired when playback has to suspend due to buffering
+      PLAYING: 'playing', // Event fired when starting (or resuming) playing of the media
+      PAUSED: 'paused', // Event fired when media playback pauses
+      COMPLETE: 'complete', // Event fired when media playback has reached the end of the media
+      ERROR: 'error', // Event fired when an error condition occurs
+      STATUS: 'status', // Event fired regularly during play
+      SENTINEL_ENTER_BUFFERING: 'sentinel-enter-buffering', // Event fired when a sentinel has to act because the device has started buffering but not reported it
+      SENTINEL_EXIT_BUFFERING: 'sentinel-exit-buffering', // Event fired when a sentinel has to act because the device has finished buffering but not reported it
+      SENTINEL_PAUSE: 'sentinel-pause', // Event fired when a sentinel has to act because the device has failed to pause when expected
+      SENTINEL_PLAY: 'sentinel-play', // Event fired when a sentinel has to act because the device has failed to play when expected
+      SENTINEL_SEEK: 'sentinel-seek', // Event fired when a sentinel has to act because the device has failed to seek to the correct location
+      SENTINEL_COMPLETE: 'sentinel-complete', // Event fired when a sentinel has to act because the device has completed the media but not reported it
+      SENTINEL_PAUSE_FAILURE: 'sentinel-pause-failure', // Event fired when the pause sentinel has failed twice, so it is giving up
+      SENTINEL_SEEK_FAILURE: 'sentinel-seek-failure', // Event fired when the seek sentinel has failed twice, so it is giving up
+      SEEK_ATTEMPTED: 'seek-attempted', // Event fired when a device using a seekfinishedemitevent modifier sets the source
+      SEEK_FINISHED: 'seek-finished' // Event fired when a device using a seekfinishedemitevent modifier has seeked successfully
+    };
 
-      var TYPE = {
-        VIDEO: 'video',
-        AUDIO: 'audio',
-        LIVE_VIDEO: 'live-video',
-        LIVE_AUDIO: 'live-audio'
-      };
+    var TYPE = {
+      VIDEO: 'video',
+      AUDIO: 'audio',
+      LIVE_VIDEO: 'live-video',
+      LIVE_AUDIO: 'live-audio'
+    };
 
-      function unpausedEventCheck (event) {
-        if (event && event.state) {
-          return event.state !== STATE.PAUSED;
-        } else {
-          return undefined;
-        }
+    function unpausedEventCheck (event) {
+      if (event && event.state) {
+        return event.state !== STATE.PAUSED;
+      } else {
+        return undefined;
       }
-
-      return {
-        STATE: STATE,
-        EVENT: EVENT,
-        TYPE: TYPE,
-        unpausedEventCheck: unpausedEventCheck
-      };
     }
+
+    return {
+      STATE: STATE,
+      EVENT: EVENT,
+      TYPE: TYPE,
+      unpausedEventCheck: unpausedEventCheck
+    };
+  }
 );

--- a/script/plugindata.js
+++ b/script/plugindata.js
@@ -1,18 +1,18 @@
 define(
-    'bigscreenplayer/plugindata',
-    function () {
-      'use strict';
+  'bigscreenplayer/plugindata',
+  function () {
+    'use strict';
 
-      function PluginData (args) {
-        this.status = args.status;
-        this.stateType = args.stateType;
-        this.isBufferingTimeoutError = args.isBufferingTimeoutError || false;
-        this.isInitialPlay = args.isInitialPlay;
-        this.cdn = args.cdn;
-        this.newCdn = args.newCdn;
-        this.timeStamp = new Date();
-      }
-
-      return PluginData;
+    function PluginData (args) {
+      this.status = args.status;
+      this.stateType = args.stateType;
+      this.isBufferingTimeoutError = args.isBufferingTimeoutError || false;
+      this.isInitialPlay = args.isInitialPlay;
+      this.cdn = args.cdn;
+      this.newCdn = args.newCdn;
+      this.timeStamp = new Date();
     }
+
+    return PluginData;
+  }
 );

--- a/script/pluginenums.js
+++ b/script/pluginenums.js
@@ -1,20 +1,20 @@
 define(
-    'bigscreenplayer/pluginenums',
-    function () {
-      'use strict';
+  'bigscreenplayer/pluginenums',
+  function () {
+    'use strict';
 
-      return {
-        STATUS: {
-          STARTED: 'started',
-          DISMISSED: 'dismissed',
-          FATAL: 'fatal',
-          FAILOVER: 'failover'
-        },
-        TYPE: {
-          BUFFERING: 'buffering',
-          ERROR: 'error'
-        }
-      };
-    }
+    return {
+      STATUS: {
+        STARTED: 'started',
+        DISMISSED: 'dismissed',
+        FATAL: 'fatal',
+        FAILOVER: 'failover'
+      },
+      TYPE: {
+        BUFFERING: 'buffering',
+        ERROR: 'error'
+      }
+    };
+  }
 );
 

--- a/script/utils/playbackutils.js
+++ b/script/utils/playbackutils.js
@@ -1,158 +1,158 @@
 define(
-    'bigscreenplayer/utils/playbackutils',
-    function () {
-      'use strict';
+  'bigscreenplayer/utils/playbackutils',
+  function () {
+    'use strict';
 
-      return {
-        clone: function (args) {
-          var clone = {};
-          for (var prop in args) {
-            if (args.hasOwnProperty(prop)) {
-              clone[prop] = args[prop];
-            }
+    return {
+      clone: function (args) {
+        var clone = {};
+        for (var prop in args) {
+          if (args.hasOwnProperty(prop)) {
+            clone[prop] = args[prop];
           }
-          return clone;
-        },
-
-        deepClone: function (objectToClone) {
-          if (!objectToClone) {
-            return objectToClone;
-          }
-
-          var clone, propValue, propName;
-          clone = Array.isArray(objectToClone) ? [] : {};
-          for (propName in objectToClone) {
-            propValue = objectToClone[propName];
-
-            // check for date
-            if (propValue && Object.prototype.toString.call(propValue) === '[object Date]') {
-              clone[propName] = new Date(propValue);
-              continue;
-            }
-
-            clone[propName] = (typeof propValue === 'object') ? this.deepClone(propValue) : propValue;
-          }
-          return clone;
-        },
-
-        cloneArray: function (arr) {
-          var clone = [];
-
-          for (var i = 0, n = arr.length; i < n; i++) {
-            clone.push(this.clone(arr[i]));
-          }
-
-          return clone;
-        },
-
-        merge: function () {
-          var merged = {};
-
-          for (var i = 0; i < arguments.length; i++) {
-            var obj = arguments[i];
-            for (var param in obj) {
-              merged[param] = obj[param];
-            }
-          }
-
-          return merged;
-        },
-
-        arrayStartsWith: function (array, partial) {
-          for (var i = 0; i < partial.length; i++) {
-            if (array[i] !== partial[i]) {
-              return false;
-            }
-          }
-
-          return true;
-        },
-
-        find: function (array, predicate) {
-          return array.reduce(function (acc, it, i) {
-            return acc !== false ? acc : predicate(it) && it;
-          }, false);
-        },
-
-        findIndex: function (array, predicate) {
-          return array.reduce(function (acc, it, i) {
-            return acc !== false ? acc : predicate(it) && i;
-          }, false);
-        },
-
-        swap: function (array, i, j) {
-          var arr = array.slice();
-          var temp = arr[i];
-
-          arr[i] = arr[j];
-          arr[j] = temp;
-
-          return arr;
-        },
-
-        pluck: function (array, property) {
-          var plucked = [];
-
-          for (var i = 0; i < array.length; i++) {
-            plucked.push(array[i][property]);
-          }
-
-          return plucked;
-        },
-
-        flatten: function (arr) {
-          return [].concat.apply([], arr);
-        },
-
-        without: function (arr, value) {
-          var newArray = [];
-
-          for (var i = 0; i < arr.length; i++) {
-            if (arr[i] !== value) {
-              newArray.push(arr[i]);
-            }
-          }
-
-          return newArray;
-        },
-
-        contains: function (arr, subset) {
-          return [].concat(subset).every(function (item) { return [].concat(arr).indexOf(item) > -1; });
-        },
-
-        pickRandomFromArray: function (arr) {
-          return arr[Math.floor(Math.random() * arr.length)];
-        },
-
-        filter: function (arr, predicate) {
-          var filteredArray = [];
-
-          for (var i = 0; i < arr.length; i++) {
-            if (predicate(arr[i])) {
-              filteredArray.push(arr[i]);
-            }
-          }
-
-          return filteredArray;
-        },
-
-        noop: function () {},
-
-        generateUUID: function () {
-          var d = new Date().getTime();
-
-          return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-            var r = (d + Math.random() * 16) % 16 | 0;
-            d = Math.floor(d / 16);
-            return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
-          });
-        },
-
-        path: function (object, keys) {
-          return (keys || []).reduce(function (accum, key) {
-            return (accum || {})[key];
-          }, object || {});
         }
-      };
-    }
-  );
+        return clone;
+      },
+
+      deepClone: function (objectToClone) {
+        if (!objectToClone) {
+          return objectToClone;
+        }
+
+        var clone, propValue, propName;
+        clone = Array.isArray(objectToClone) ? [] : {};
+        for (propName in objectToClone) {
+          propValue = objectToClone[propName];
+
+          // check for date
+          if (propValue && Object.prototype.toString.call(propValue) === '[object Date]') {
+            clone[propName] = new Date(propValue);
+            continue;
+          }
+
+          clone[propName] = (typeof propValue === 'object') ? this.deepClone(propValue) : propValue;
+        }
+        return clone;
+      },
+
+      cloneArray: function (arr) {
+        var clone = [];
+
+        for (var i = 0, n = arr.length; i < n; i++) {
+          clone.push(this.clone(arr[i]));
+        }
+
+        return clone;
+      },
+
+      merge: function () {
+        var merged = {};
+
+        for (var i = 0; i < arguments.length; i++) {
+          var obj = arguments[i];
+          for (var param in obj) {
+            merged[param] = obj[param];
+          }
+        }
+
+        return merged;
+      },
+
+      arrayStartsWith: function (array, partial) {
+        for (var i = 0; i < partial.length; i++) {
+          if (array[i] !== partial[i]) {
+            return false;
+          }
+        }
+
+        return true;
+      },
+
+      find: function (array, predicate) {
+        return array.reduce(function (acc, it, i) {
+          return acc !== false ? acc : predicate(it) && it;
+        }, false);
+      },
+
+      findIndex: function (array, predicate) {
+        return array.reduce(function (acc, it, i) {
+          return acc !== false ? acc : predicate(it) && i;
+        }, false);
+      },
+
+      swap: function (array, i, j) {
+        var arr = array.slice();
+        var temp = arr[i];
+
+        arr[i] = arr[j];
+        arr[j] = temp;
+
+        return arr;
+      },
+
+      pluck: function (array, property) {
+        var plucked = [];
+
+        for (var i = 0; i < array.length; i++) {
+          plucked.push(array[i][property]);
+        }
+
+        return plucked;
+      },
+
+      flatten: function (arr) {
+        return [].concat.apply([], arr);
+      },
+
+      without: function (arr, value) {
+        var newArray = [];
+
+        for (var i = 0; i < arr.length; i++) {
+          if (arr[i] !== value) {
+            newArray.push(arr[i]);
+          }
+        }
+
+        return newArray;
+      },
+
+      contains: function (arr, subset) {
+        return [].concat(subset).every(function (item) { return [].concat(arr).indexOf(item) > -1; });
+      },
+
+      pickRandomFromArray: function (arr) {
+        return arr[Math.floor(Math.random() * arr.length)];
+      },
+
+      filter: function (arr, predicate) {
+        var filteredArray = [];
+
+        for (var i = 0; i < arr.length; i++) {
+          if (predicate(arr[i])) {
+            filteredArray.push(arr[i]);
+          }
+        }
+
+        return filteredArray;
+      },
+
+      noop: function () {},
+
+      generateUUID: function () {
+        var d = new Date().getTime();
+
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+          var r = (d + Math.random() * 16) % 16 | 0;
+          d = Math.floor(d / 16);
+          return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+        });
+      },
+
+      path: function (object, keys) {
+        return (keys || []).reduce(function (accum, key) {
+          return (accum || {})[key];
+        }, object || {});
+      }
+    };
+  }
+);

--- a/script/version.js
+++ b/script/version.js
@@ -1,5 +1,5 @@
 define('bigscreenplayer/version',
   function () {
-    return '3.14.1';
+    return '3.14.2';
   }
 );


### PR DESCRIPTION
📺 What

Update eslint to 7.2.0. 

Due to a change along the way from version 3.0.0 to 7.2.0 `"ecmaVersion": 5, "sourceType": "module"` can no longer be used. However, module usage is still caught using the `es5/no-es2015` plugin.

🛠 How

Update `eslint` in the `package.json`. 
Update the `.eslintrc` rules. 
Accept that all the files go through the linter again and spacing issues show up.

