### PR TITLE
Auto resume after seek whilst paused

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1905,7 +1905,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
@@ -3906,7 +3906,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
@@ -6748,7 +6748,7 @@
     "jasmine": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.2.0.tgz",
-      "integrity": "sha512-qv6TZ32r+slrQz8fbx2EhGbD9zlJo3NwPrpLK1nE8inILtZO9Fap52pyHk7mNTh4tG50a+1+tOiWVT3jO5I0Sg==",
+      "integrity": "sha1-s6AYRUeBgFZQ5GV4gD0I58/dez0=",
       "dev": true,
       "requires": {
         "glob": "^7.0.6",
@@ -6758,7 +6758,7 @@
     "jasmine-core": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.2.1.tgz",
-      "integrity": "sha512-pa9tbBWgU0EE4SWgc85T4sa886ufuQdsgruQANhECYjwqgV4z7Vw/499aCaP8ZH79JDS4vhm8doDG9HO4+e4sA==",
+      "integrity": "sha1-jk/1uGFgPugzQ/K0nu5qD/6WUM4=",
       "dev": true
     },
     "js-tokens": {
@@ -6905,7 +6905,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1662,23 +1662,6 @@
       "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
       "dev": true
     },
-    "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "^3.0.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
-    },
     "agent-base": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
@@ -1941,44 +1924,6 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
     },
     "babel-loader": {
       "version": "8.0.6",
@@ -3913,6 +3858,12 @@
         "eslint-visitor-keys": "^1.2.0"
       },
       "dependencies": {
+        "acorn-jsx": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+          "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+          "dev": true
+        },
         "eslint-visitor-keys": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",

--- a/script-test/playbackstrategies/modifiers/live/restartabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/restartabletest.js
@@ -266,7 +266,9 @@ require(
       describe('Pausing and Auto-Resume', function () {
         var mockCallback = [];
 
-        function startPlaybackAndPause (startTime, disableAutoResume) {
+        function startPlaybackAndPause (startTime, disableAutoResume, windowType) {
+          initialiseRestartableMediaPlayer(undefined, windowType);
+
           restartableMediaPlayer.beginPlaybackFrom(startTime);
 
           for (var index = 0; index < mockCallback.length; index++) {
@@ -287,12 +289,6 @@ require(
           player.addEventCallback.and.callFake(function (self, callback) {
             mockCallback.push(callback);
           });
-
-          initialiseRestartableMediaPlayer();
-
-          for (var index = 0; index < mockCallback.length; index++) {
-            mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING});
-          }
         });
 
         afterEach(function () {
@@ -403,6 +399,8 @@ require(
         });
 
         it('time spend buffering is deducted when considering time to auto-resume', function () {
+          startPlaybackAndPause();
+
           restartableMediaPlayer.beginPlaybackFrom(20);
 
           for (var index = 0; index < mockCallback.length; index++) {
@@ -420,6 +418,14 @@ require(
           jasmine.clock().tick(3 * 1000);
 
           expect(player.resume).toHaveBeenCalledTimes(1);
+        });
+
+        it('Should not start auto resume timeout if window type is not SLIDING', function () {
+          startPlaybackAndPause(20, false, WindowTypes.GROWING);
+
+          jasmine.clock().tick(12 * 1000);
+
+          expect(player.resume).not.toHaveBeenCalled();
         });
       });
     });

--- a/script-test/playbackstrategies/modifiers/live/seekabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/seekabletest.js
@@ -351,6 +351,8 @@ require(
 
           seekableMediaPlayer.playFrom(50);
 
+          seekableMediaPlayer.pause();
+
           jasmine.clock().tick(42 * 1000);
 
           expect(player.resume).toHaveBeenCalledTimes(1);

--- a/script-test/playbackstrategies/modifiers/live/seekabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/seekabletest.js
@@ -1,9 +1,10 @@
 require(
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
-    'bigscreenplayer/playbackstrategy/modifiers/live/seekable'
+    'bigscreenplayer/playbackstrategy/modifiers/live/seekable',
+    'bigscreenplayer/models/windowtypes'
   ],
-    function (MediaPlayerBase, SeekableMediaPlayer) {
+    function (MediaPlayerBase, SeekableMediaPlayer, WindowTypes) {
       var sourceContainer = document.createElement('div');
       var player;
       var seekableMediaPlayer;
@@ -20,8 +21,8 @@ require(
         }
       }
 
-      function initialiseSeekableMediaPlayer (config) {
-        seekableMediaPlayer = SeekableMediaPlayer(player, config);
+      function initialiseSeekableMediaPlayer (config, windowType) {
+        seekableMediaPlayer = SeekableMediaPlayer(player, config, windowType);
       }
 
       describe('Seekable HMTL5 Live Player', function () {
@@ -172,7 +173,7 @@ require(
             jasmine.clock().install();
             jasmine.clock().mockDate();
 
-            initialiseSeekableMediaPlayer();
+            initialiseSeekableMediaPlayer(undefined, WindowTypes.SLIDING);
 
             player.getSeekableRange.and.returnValue({start: 0});
             player.getCurrentTime.and.returnValue(20);
@@ -285,6 +286,18 @@ require(
             expect(player.resume).toHaveBeenCalledTimes(1);
           });
 
+          it('auto-resume is not cancelled by a status event', function () {
+            startPlaybackAndPause(20, false);
+
+            for (var index = 0; index < mockCallback.length; index++) {
+              mockCallback[index]({type: MediaPlayerBase.EVENT.STATUS});
+            }
+
+            jasmine.clock().tick(12 * 1000);
+
+            expect(player.resume).toHaveBeenCalledTimes(1);
+          });
+
           it('will fake pause if attempting to pause at the start of playback ', function () {
             player.getCurrentTime.and.returnValue(0);
             startPlaybackAndPause(0, false);
@@ -325,6 +338,22 @@ require(
             jasmine.clock().tick(1);
 
             expect(player.resume).not.toHaveBeenCalledTimes(1);
+          });
+
+          it('Should auto resume when paused after a seek', function () {
+            player.getSeekableRange.and.returnValue({start: 0});
+            player.getCurrentTime.and.returnValue(100);
+
+            startPlaybackAndPause(100, false);
+
+            player.getCurrentTime.and.returnValue(50);
+            player.getState.and.returnValue(MediaPlayerBase.STATE.PAUSED);
+
+            seekableMediaPlayer.playFrom(50);
+
+            jasmine.clock().tick(42 * 1000);
+
+            expect(player.resume).toHaveBeenCalledTimes(1);
           });
         });
       });

--- a/script-test/playbackstrategies/modifiers/live/seekabletest.js
+++ b/script-test/playbackstrategies/modifiers/live/seekabletest.js
@@ -4,358 +4,358 @@ require(
     'bigscreenplayer/playbackstrategy/modifiers/live/seekable',
     'bigscreenplayer/models/windowtypes'
   ],
-    function (MediaPlayerBase, SeekableMediaPlayer, WindowTypes) {
-      var sourceContainer = document.createElement('div');
-      var player;
-      var seekableMediaPlayer;
+  function (MediaPlayerBase, SeekableMediaPlayer, WindowTypes) {
+    var sourceContainer = document.createElement('div');
+    var player;
+    var seekableMediaPlayer;
 
-      function wrapperTests (action, expectedReturn) {
-        if (expectedReturn) {
-          player[action].and.returnValue(expectedReturn);
+    function wrapperTests (action, expectedReturn) {
+      if (expectedReturn) {
+        player[action].and.returnValue(expectedReturn);
 
-          expect(seekableMediaPlayer[action]()).toBe(expectedReturn);
-        } else {
-          seekableMediaPlayer[action]();
+        expect(seekableMediaPlayer[action]()).toBe(expectedReturn);
+      } else {
+        seekableMediaPlayer[action]();
 
-          expect(player[action]).toHaveBeenCalledTimes(1);
-        }
+        expect(player[action]).toHaveBeenCalledTimes(1);
       }
+    }
 
-      function initialiseSeekableMediaPlayer (config, windowType) {
-        seekableMediaPlayer = SeekableMediaPlayer(player, config, windowType);
-      }
+    function initialiseSeekableMediaPlayer (config, windowType) {
+      seekableMediaPlayer = SeekableMediaPlayer(player, config, windowType);
+    }
 
-      describe('Seekable HMTL5 Live Player', function () {
+    describe('Seekable HMTL5 Live Player', function () {
+      beforeEach(function () {
+        player = jasmine.createSpyObj('player',
+          ['beginPlayback', 'initialiseMedia', 'stop', 'reset', 'getState', 'getSource', 'getMimeType',
+            'addEventCallback', 'removeEventCallback', 'removeAllEventCallbacks', 'getPlayerElement', 'pause',
+            'resume', 'beginPlaybackFrom', 'playFrom', 'getCurrentTime', 'getSeekableRange', 'toPaused',
+            'toPlaying']);
+      });
+
+      describe('methods call the appropriate media player methods', function () {
         beforeEach(function () {
-          player = jasmine.createSpyObj('player',
-            ['beginPlayback', 'initialiseMedia', 'stop', 'reset', 'getState', 'getSource', 'getMimeType',
-              'addEventCallback', 'removeEventCallback', 'removeAllEventCallbacks', 'getPlayerElement', 'pause',
-              'resume', 'beginPlaybackFrom', 'playFrom', 'getCurrentTime', 'getSeekableRange', 'toPaused',
-              'toPlaying']);
+          initialiseSeekableMediaPlayer();
         });
 
-        describe('methods call the appropriate media player methods', function () {
-          beforeEach(function () {
-            initialiseSeekableMediaPlayer();
-          });
-
-          it('calls beginPlayback on the media player', function () {
-            wrapperTests('beginPlayback');
-          });
-
-          it('calls initialiseMedia on the media player', function () {
-            wrapperTests('initialiseMedia');
-          });
-
-          it('calls beginPlayingFrom on the media player', function () {
-            var arg = 0;
-            seekableMediaPlayer.beginPlaybackFrom(arg);
-
-            expect(player.beginPlaybackFrom).toHaveBeenCalledWith(arg);
-          });
-
-          it('calls playFrom on the media player', function () {
-            var arg = 0;
-            seekableMediaPlayer.playFrom(arg);
-
-            expect(player.playFrom).toHaveBeenCalledWith(arg);
-          });
-
-          it('calls stop on the media player', function () {
-            wrapperTests('stop');
-          });
-
-          it('calls reset on the media player', function () {
-            wrapperTests('reset');
-          });
-
-          it('calls getState on the media player', function () {
-            wrapperTests('getState', 'thisState');
-          });
-
-          it('calls getSource on the media player', function () {
-            wrapperTests('getSource', 'thisSource');
-          });
-
-          it('calls getMimeType on the media player', function () {
-            wrapperTests('getMimeType', 'thisMimeType');
-          });
-
-          it('calls addEventCallback on the media player', function () {
-            var thisArg = 'arg';
-            var callback = function () { return; };
-            seekableMediaPlayer.addEventCallback(thisArg, callback);
-
-            expect(player.addEventCallback).toHaveBeenCalledWith(thisArg, callback);
-          });
-
-          it('calls removeEventCallback on the media player', function () {
-            var thisArg = 'arg';
-            var callback = function () { return; };
-            seekableMediaPlayer.removeEventCallback(thisArg, callback);
-
-            expect(player.removeEventCallback).toHaveBeenCalledWith(thisArg, callback);
-          });
-
-          it('calls removeAllEventCallbacks on the media player', function () {
-            wrapperTests('removeAllEventCallbacks');
-          });
-
-          it('calls getPlayerElement on the media player', function () {
-            wrapperTests('getPlayerElement');
-          });
-
-          it('calls pause on the media player', function () {
-            player.getSeekableRange.and.returnValue({start: 0});
-
-            wrapperTests('pause');
-          });
-
-          it('calls getCurrentTime on media player', function () {
-            wrapperTests('getCurrentTime', 'thisTime');
-          });
-
-          it('calls getSeekableRange on media player', function () {
-            wrapperTests('getSeekableRange', 'thisRange');
-          });
+        it('calls beginPlayback on the media player', function () {
+          wrapperTests('beginPlayback');
         });
 
-        describe('Seekable features', function () {
-          it('should respect config forcing playback from the end of the window', function () {
-            var config = {
-              streaming: {
-                overrides: {
-                  forceBeginPlaybackToEndOfWindow: true
-                }
+        it('calls initialiseMedia on the media player', function () {
+          wrapperTests('initialiseMedia');
+        });
+
+        it('calls beginPlayingFrom on the media player', function () {
+          var arg = 0;
+          seekableMediaPlayer.beginPlaybackFrom(arg);
+
+          expect(player.beginPlaybackFrom).toHaveBeenCalledWith(arg);
+        });
+
+        it('calls playFrom on the media player', function () {
+          var arg = 0;
+          seekableMediaPlayer.playFrom(arg);
+
+          expect(player.playFrom).toHaveBeenCalledWith(arg);
+        });
+
+        it('calls stop on the media player', function () {
+          wrapperTests('stop');
+        });
+
+        it('calls reset on the media player', function () {
+          wrapperTests('reset');
+        });
+
+        it('calls getState on the media player', function () {
+          wrapperTests('getState', 'thisState');
+        });
+
+        it('calls getSource on the media player', function () {
+          wrapperTests('getSource', 'thisSource');
+        });
+
+        it('calls getMimeType on the media player', function () {
+          wrapperTests('getMimeType', 'thisMimeType');
+        });
+
+        it('calls addEventCallback on the media player', function () {
+          var thisArg = 'arg';
+          var callback = function () { return; };
+          seekableMediaPlayer.addEventCallback(thisArg, callback);
+
+          expect(player.addEventCallback).toHaveBeenCalledWith(thisArg, callback);
+        });
+
+        it('calls removeEventCallback on the media player', function () {
+          var thisArg = 'arg';
+          var callback = function () { return; };
+          seekableMediaPlayer.removeEventCallback(thisArg, callback);
+
+          expect(player.removeEventCallback).toHaveBeenCalledWith(thisArg, callback);
+        });
+
+        it('calls removeAllEventCallbacks on the media player', function () {
+          wrapperTests('removeAllEventCallbacks');
+        });
+
+        it('calls getPlayerElement on the media player', function () {
+          wrapperTests('getPlayerElement');
+        });
+
+        it('calls pause on the media player', function () {
+          player.getSeekableRange.and.returnValue({start: 0});
+
+          wrapperTests('pause');
+        });
+
+        it('calls getCurrentTime on media player', function () {
+          wrapperTests('getCurrentTime', 'thisTime');
+        });
+
+        it('calls getSeekableRange on media player', function () {
+          wrapperTests('getSeekableRange', 'thisRange');
+        });
+      });
+
+      describe('Seekable features', function () {
+        it('should respect config forcing playback from the end of the window', function () {
+          var config = {
+            streaming: {
+              overrides: {
+                forceBeginPlaybackToEndOfWindow: true
               }
-            };
-            initialiseSeekableMediaPlayer(config);
+            }
+          };
+          initialiseSeekableMediaPlayer(config);
 
-            seekableMediaPlayer.beginPlayback();
+          seekableMediaPlayer.beginPlayback();
 
-            expect(player.beginPlaybackFrom).toHaveBeenCalledWith(Infinity);
+          expect(player.beginPlaybackFrom).toHaveBeenCalledWith(Infinity);
+        });
+      });
+
+      describe('calls the mediaplayer with the correct media Type', function () {
+        beforeEach(function () {
+          initialiseSeekableMediaPlayer();
+        });
+
+        it('for static video', function () {
+          seekableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, '', '', sourceContainer);
+
+          expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer, undefined);
+        });
+
+        it('for live video', function () {
+          seekableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer);
+
+          expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer, undefined);
+        });
+
+        it('for static audio', function () {
+          seekableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, '', '', sourceContainer);
+
+          expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_AUDIO, '', '', sourceContainer, undefined);
+        });
+      });
+
+      describe('Pausing and Auto-Resume', function () {
+        var mockCallback = [];
+
+        function startPlaybackAndPause (startTime, disableAutoResume) {
+          seekableMediaPlayer.beginPlaybackFrom(startTime || 0);
+          seekableMediaPlayer.pause({disableAutoResume: disableAutoResume});
+        }
+
+        beforeEach(function () {
+          jasmine.clock().install();
+          jasmine.clock().mockDate();
+
+          initialiseSeekableMediaPlayer(undefined, WindowTypes.SLIDING);
+
+          player.getSeekableRange.and.returnValue({start: 0});
+          player.getCurrentTime.and.returnValue(20);
+
+          player.addEventCallback.and.callFake(function (self, callback) {
+            mockCallback.push(callback);
           });
         });
 
-        describe('calls the mediaplayer with the correct media Type', function () {
-          beforeEach(function () {
-            initialiseSeekableMediaPlayer();
-          });
-
-          it('for static video', function () {
-            seekableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, '', '', sourceContainer);
-
-            expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer, undefined);
-          });
-
-          it('for live video', function () {
-            seekableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer);
-
-            expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_VIDEO, '', '', sourceContainer, undefined);
-          });
-
-          it('for static audio', function () {
-            seekableMediaPlayer.initialiseMedia(MediaPlayerBase.TYPE.AUDIO, '', '', sourceContainer);
-
-            expect(player.initialiseMedia).toHaveBeenCalledWith(MediaPlayerBase.TYPE.LIVE_AUDIO, '', '', sourceContainer, undefined);
-          });
+        afterEach(function () {
+          jasmine.clock().uninstall();
+          mockCallback = [];
         });
 
-        describe('Pausing and Auto-Resume', function () {
-          var mockCallback = [];
+        it('calls resume when approaching the start of the buffer', function () {
+          startPlaybackAndPause(20, false);
 
-          function startPlaybackAndPause (startTime, disableAutoResume) {
-            seekableMediaPlayer.beginPlaybackFrom(startTime || 0);
-            seekableMediaPlayer.pause({disableAutoResume: disableAutoResume});
+          jasmine.clock().tick(12 * 1000);
+
+          expect(player.resume).toHaveBeenCalledWith();
+        });
+
+        it('does not call resume when approaching the start of the buffer with the disableAutoResume option', function () {
+          startPlaybackAndPause(20, true);
+
+          jasmine.clock().tick(11 * 1000);
+
+          expect(player.resume).not.toHaveBeenCalledWith();
+        });
+
+        it('does not call resume if paused after the auto resume point', function () {
+          startPlaybackAndPause(20, false);
+
+          jasmine.clock().tick(11 * 1000);
+
+          expect(player.resume).not.toHaveBeenCalledWith();
+        });
+
+        it('does not auto-resume if the video is no longer paused', function () {
+          startPlaybackAndPause(20, false);
+
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING});
           }
 
-          beforeEach(function () {
-            jasmine.clock().install();
-            jasmine.clock().mockDate();
+          jasmine.clock().tick(12 * 1000);
 
-            initialiseSeekableMediaPlayer(undefined, WindowTypes.SLIDING);
+          expect(player.resume).not.toHaveBeenCalled();
+        });
 
-            player.getSeekableRange.and.returnValue({start: 0});
-            player.getCurrentTime.and.returnValue(20);
+        it('Calls resume when paused is called multiple times', function () {
+          startPlaybackAndPause(0, false);
 
-            player.addEventCallback.and.callFake(function (self, callback) {
-              mockCallback.push(callback);
-            });
-          });
+          var event = {state: MediaPlayerBase.STATE.PLAYING, currentTime: 25};
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index](event);
+          }
 
-          afterEach(function () {
-            jasmine.clock().uninstall();
-            mockCallback = [];
-          });
+          seekableMediaPlayer.pause();
 
-          it('calls resume when approaching the start of the buffer', function () {
-            startPlaybackAndPause(20, false);
+          event.currentTime = 30;
+          for (index = 0; index < mockCallback.length; index++) {
+            mockCallback[index](event);
+          }
 
-            jasmine.clock().tick(12 * 1000);
-
-            expect(player.resume).toHaveBeenCalledWith();
-          });
-
-          it('does not call resume when approaching the start of the buffer with the disableAutoResume option', function () {
-            startPlaybackAndPause(20, true);
-
-            jasmine.clock().tick(11 * 1000);
-
-            expect(player.resume).not.toHaveBeenCalledWith();
-          });
-
-          it('does not call resume if paused after the auto resume point', function () {
-            startPlaybackAndPause(20, false);
-
-            jasmine.clock().tick(11 * 1000);
-
-            expect(player.resume).not.toHaveBeenCalledWith();
-          });
-
-          it('does not auto-resume if the video is no longer paused', function () {
-            startPlaybackAndPause(20, false);
-
-            for (var index = 0; index < mockCallback.length; index++) {
-              mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING});
-            }
-
-            jasmine.clock().tick(12 * 1000);
-
-            expect(player.resume).not.toHaveBeenCalled();
-          });
-
-          it('Calls resume when paused is called multiple times', function () {
-            startPlaybackAndPause(0, false);
-
-            var event = {state: MediaPlayerBase.STATE.PLAYING, currentTime: 25};
-            for (var index = 0; index < mockCallback.length; index++) {
-              mockCallback[index](event);
-            }
-
-            seekableMediaPlayer.pause();
-
-            event.currentTime = 30;
-            for (index = 0; index < mockCallback.length; index++) {
-              mockCallback[index](event);
-            }
-
-            seekableMediaPlayer.pause();
+          seekableMediaPlayer.pause();
           // uses real time to determine pause intervals
           // if debugging the time to the buffer will be decreased by the time spent.
-            jasmine.clock().tick(22 * 1000);
+          jasmine.clock().tick(22 * 1000);
 
-            expect(player.resume).toHaveBeenCalledTimes(1);
-          });
+          expect(player.resume).toHaveBeenCalledTimes(1);
+        });
 
-          it('calls auto-resume immeditetly if paused after an autoresume', function () {
-            startPlaybackAndPause(20, false);
+        it('calls auto-resume immeditetly if paused after an autoresume', function () {
+          startPlaybackAndPause(20, false);
 
-            jasmine.clock().tick(12 * 1000);
+          jasmine.clock().tick(12 * 1000);
 
-            player.getSeekableRange.and.returnValue({start: 12});
+          player.getSeekableRange.and.returnValue({start: 12});
 
-            seekableMediaPlayer.pause();
+          seekableMediaPlayer.pause();
 
-            jasmine.clock().tick(1);
+          jasmine.clock().tick(1);
 
-            expect(player.resume).toHaveBeenCalledTimes(1);
-            expect(player.toPaused).toHaveBeenCalledTimes(1);
-            expect(player.toPlaying).toHaveBeenCalledTimes(1);
-          });
+          expect(player.resume).toHaveBeenCalledTimes(1);
+          expect(player.toPaused).toHaveBeenCalledTimes(1);
+          expect(player.toPlaying).toHaveBeenCalledTimes(1);
+        });
 
-          it('does not calls autoresume immeditetly if paused after an auto-resume with disableAutoResume options', function () {
-            startPlaybackAndPause(20, true);
+        it('does not calls autoresume immeditetly if paused after an auto-resume with disableAutoResume options', function () {
+          startPlaybackAndPause(20, true);
 
-            jasmine.clock().tick(12 * 1000);
-            player.getSeekableRange.and.returnValue({start: 12});
+          jasmine.clock().tick(12 * 1000);
+          player.getSeekableRange.and.returnValue({start: 12});
 
-            jasmine.clock().tick(1);
+          jasmine.clock().tick(1);
 
-            expect(player.resume).not.toHaveBeenCalledTimes(1);
-          });
+          expect(player.resume).not.toHaveBeenCalledTimes(1);
+        });
 
-          it('auto-resume is not cancelled by a paused event state', function () {
-            startPlaybackAndPause(20, false);
+        it('auto-resume is not cancelled by a paused event state', function () {
+          startPlaybackAndPause(20, false);
 
-            for (var index = 0; index < mockCallback.length; index++) {
-              mockCallback[index]({state: MediaPlayerBase.STATE.PAUSED});
-            }
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.PAUSED});
+          }
 
-            jasmine.clock().tick(12 * 1000);
+          jasmine.clock().tick(12 * 1000);
 
-            expect(player.resume).toHaveBeenCalledTimes(1);
-          });
+          expect(player.resume).toHaveBeenCalledTimes(1);
+        });
 
-          it('auto-resume is not cancelled by a status event', function () {
-            startPlaybackAndPause(20, false);
+        it('auto-resume is not cancelled by a status event', function () {
+          startPlaybackAndPause(20, false);
 
-            for (var index = 0; index < mockCallback.length; index++) {
-              mockCallback[index]({type: MediaPlayerBase.EVENT.STATUS});
-            }
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({type: MediaPlayerBase.EVENT.STATUS});
+          }
 
-            jasmine.clock().tick(12 * 1000);
+          jasmine.clock().tick(12 * 1000);
 
-            expect(player.resume).toHaveBeenCalledTimes(1);
-          });
+          expect(player.resume).toHaveBeenCalledTimes(1);
+        });
 
-          it('will fake pause if attempting to pause at the start of playback ', function () {
-            player.getCurrentTime.and.returnValue(0);
-            startPlaybackAndPause(0, false);
+        it('will fake pause if attempting to pause at the start of playback ', function () {
+          player.getCurrentTime.and.returnValue(0);
+          startPlaybackAndPause(0, false);
 
-            expect(player.toPaused).toHaveBeenCalledTimes(1);
-            expect(player.toPlaying).toHaveBeenCalledTimes(1);
-          });
+          expect(player.toPaused).toHaveBeenCalledTimes(1);
+          expect(player.toPlaying).toHaveBeenCalledTimes(1);
+        });
 
-          it('time spend buffering is deducted when considering time to auto-resume', function () {
-            startPlaybackAndPause(0, false);
+        it('time spend buffering is deducted when considering time to auto-resume', function () {
+          startPlaybackAndPause(0, false);
 
-            seekableMediaPlayer.resume();
-            player.resume.calls.reset();
+          seekableMediaPlayer.resume();
+          player.resume.calls.reset();
 
-            for (var index = 0; index < mockCallback.length; index++) {
-              mockCallback[index]({state: MediaPlayerBase.STATE.BUFFERING, currentTime: 20});
-            }
+          for (var index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.BUFFERING, currentTime: 20});
+          }
 
-            jasmine.clock().tick(11 * 1000);
+          jasmine.clock().tick(11 * 1000);
 
-            for (index = 0; index < mockCallback.length; index++) {
-              mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING, currentTime: 20});
-            }
-            player.getSeekableRange.and.returnValue({start: 20});
+          for (index = 0; index < mockCallback.length; index++) {
+            mockCallback[index]({state: MediaPlayerBase.STATE.PLAYING, currentTime: 20});
+          }
+          player.getSeekableRange.and.returnValue({start: 20});
 
-            seekableMediaPlayer.pause();
+          seekableMediaPlayer.pause();
 
-            jasmine.clock().tick(3 * 1000);
+          jasmine.clock().tick(3 * 1000);
 
-            expect(player.toPlaying).toHaveBeenCalledTimes(1);
-          });
+          expect(player.toPlaying).toHaveBeenCalledTimes(1);
+        });
 
-          it('does not calls autoresume immeditetly if paused after an auto-resume with disableAutoResume options', function () {
-            startPlaybackAndPause(20, true);
+        it('does not calls autoresume immeditetly if paused after an auto-resume with disableAutoResume options', function () {
+          startPlaybackAndPause(20, true);
 
-            jasmine.clock().tick(12 * 1000);
+          jasmine.clock().tick(12 * 1000);
 
-            jasmine.clock().tick(1);
+          jasmine.clock().tick(1);
 
-            expect(player.resume).not.toHaveBeenCalledTimes(1);
-          });
+          expect(player.resume).not.toHaveBeenCalledTimes(1);
+        });
 
-          it('Should auto resume when paused after a seek', function () {
-            player.getSeekableRange.and.returnValue({start: 0});
-            player.getCurrentTime.and.returnValue(100);
+        it('Should auto resume when paused after a seek', function () {
+          player.getSeekableRange.and.returnValue({start: 0});
+          player.getCurrentTime.and.returnValue(100);
 
-            startPlaybackAndPause(100, false);
+          startPlaybackAndPause(100, false);
 
-            player.getCurrentTime.and.returnValue(50);
-            player.getState.and.returnValue(MediaPlayerBase.STATE.PAUSED);
+          player.getCurrentTime.and.returnValue(50);
+          player.getState.and.returnValue(MediaPlayerBase.STATE.PAUSED);
 
-            seekableMediaPlayer.playFrom(50);
+          seekableMediaPlayer.playFrom(50);
 
-            jasmine.clock().tick(42 * 1000);
+          jasmine.clock().tick(42 * 1000);
 
-            expect(player.resume).toHaveBeenCalledTimes(1);
-          });
+          expect(player.resume).toHaveBeenCalledTimes(1);
         });
       });
     });
+  });
 

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -766,14 +766,18 @@ require(
           it('should start auto resume timeout when paused and seeking', function () {
             mockDashInstance.isPaused.and.returnValue(true);
 
+            mseStrategy.pause();
+            mseStrategy.setCurrentTime();
+
             eventCallbacks('seeked');
 
-            expect(mockDynamicWindowUtils.autoResumeAtStartOfRange).toHaveBeenCalledTimes(1);
+            expect(mockDynamicWindowUtils.autoResumeAtStartOfRange).toHaveBeenCalledTimes(2);
           });
 
           it('should not try to autoresume when playing and seeking', function () {
             mockDashInstance.isPaused.and.returnValue(false);
 
+            mseStrategy.setCurrentTime();
             eventCallbacks('seeked');
 
             expect(mockDynamicWindowUtils.autoResumeAtStartOfRange).not.toHaveBeenCalled();

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -741,7 +741,6 @@ require(
           });
 
           it('should start autoresume timeout when paused', function () {
-            mseStrategy.setCurrentTime(101);
             mseStrategy.pause();
 
             expect(mockDynamicWindowUtils.autoResumeAtStartOfRange).toHaveBeenCalledTimes(1);
@@ -752,7 +751,6 @@ require(
               disableAutoResume: true
             };
 
-            mseStrategy.setCurrentTime(101);
             mseStrategy.pause(opts);
 
             expect(mockDynamicWindowUtils.autoResumeAtStartOfRange).not.toHaveBeenCalled();
@@ -765,25 +763,20 @@ require(
             expect(timeUtilsMock.calculateSlidingWindowSeekOffset).toHaveBeenCalledTimes(1);
           });
 
-          it('should autoresume when paused and seeking to the start of the sliding window seekable range', function () {
-            mockDynamicWindowUtils.shouldAutoResume.and.returnValue(true);
+          it('should start auto resume timeout when paused and seeking', function () {
             mockDashInstance.isPaused.and.returnValue(true);
 
-            mseStrategy.pause();
-            mseStrategy.setCurrentTime(0);
+            eventCallbacks('seeked');
 
-            expect(mockDynamicWindowUtils.shouldAutoResume).toHaveBeenCalledWith(jasmine.any(Number), jasmine.any(Number));
-            expect(mockDashInstance.play).toHaveBeenCalledTimes(1);
+            expect(mockDynamicWindowUtils.autoResumeAtStartOfRange).toHaveBeenCalledTimes(1);
           });
 
-          it('should not try to autoresume when playing and seeking to the start of the sliding window seekable range', function () {
-            mockDynamicWindowUtils.shouldAutoResume.and.returnValue(true);
+          it('should not try to autoresume when playing and seeking', function () {
             mockDashInstance.isPaused.and.returnValue(false);
 
-            mseStrategy.setCurrentTime(0);
+            eventCallbacks('seeked');
 
-            expect(mockDynamicWindowUtils.shouldAutoResume).toHaveBeenCalledWith(jasmine.any(Number), jasmine.any(Number));
-            expect(mockDashInstance.play).toHaveBeenCalledTimes(0);
+            expect(mockDynamicWindowUtils.autoResumeAtStartOfRange).not.toHaveBeenCalled();
           });
         });
 

--- a/script/playbackstrategy/modifiers/live/restartable.js
+++ b/script/playbackstrategy/modifiers/live/restartable.js
@@ -57,7 +57,7 @@ define(
         function pause (opts) {
           mediaPlayer.pause();
           opts = opts || {};
-          if (opts.disableAutoResume !== true) {
+          if (opts.disableAutoResume !== true && windowType === WindowTypes.SLIDING) {
             DynamicWindowUtils.autoResumeAtStartOfRange(
               getCurrentTime(),
               getSeekableRange(),

--- a/script/playbackstrategy/modifiers/live/seekable.js
+++ b/script/playbackstrategy/modifiers/live/seekable.js
@@ -2,12 +2,13 @@ define(
     'bigscreenplayer/playbackstrategy/modifiers/live/seekable',
   [
     'bigscreenplayer/playbackstrategy/modifiers/mediaplayerbase',
-    'bigscreenplayer/dynamicwindowutils'
+    'bigscreenplayer/dynamicwindowutils',
+    'bigscreenplayer/models/windowtypes'
   ],
-    function (MediaPlayerBase, DynamicWindowUtils) {
+    function (MediaPlayerBase, DynamicWindowUtils, WindowTypes) {
       'use strict';
 
-      function SeekableLivePlayer (mediaPlayer, deviceConfig) {
+      function SeekableLivePlayer (mediaPlayer, deviceConfig, windowType) {
         var AUTO_RESUME_WINDOW_START_CUSHION_SECONDS = 8;
 
         function addEventCallback (thisArg, callback) {
@@ -51,7 +52,17 @@ define(
           },
 
           playFrom: function playFrom (offset) {
+            var postSeekState = mediaPlayer.getState();
             mediaPlayer.playFrom(offset);
+            if (postSeekState === MediaPlayerBase.STATE.PAUSED && windowType === WindowTypes.SLIDING) {
+              DynamicWindowUtils.autoResumeAtStartOfRange(
+                mediaPlayer.getCurrentTime(),
+                mediaPlayer.getSeekableRange(),
+                addEventCallback,
+                removeEventCallback,
+                MediaPlayerBase.unpausedEventCheck,
+                resume);
+            }
           },
 
           pause: function pause (opts) {
@@ -65,13 +76,15 @@ define(
               mediaPlayer.toPlaying();
             } else {
               mediaPlayer.pause();
-              DynamicWindowUtils.autoResumeAtStartOfRange(
-                mediaPlayer.getCurrentTime(),
-                mediaPlayer.getSeekableRange(),
-                addEventCallback,
-                removeEventCallback,
-                MediaPlayerBase.unpausedEventCheck,
-                resume);
+              if (windowType === WindowTypes.SLIDING) {
+                DynamicWindowUtils.autoResumeAtStartOfRange(
+                  mediaPlayer.getCurrentTime(),
+                  mediaPlayer.getSeekableRange(),
+                  addEventCallback,
+                  removeEventCallback,
+                  MediaPlayerBase.unpausedEventCheck,
+                  resume);
+              }
             }
           },
           resume: resume,

--- a/script/playbackstrategy/modifiers/live/seekable.js
+++ b/script/playbackstrategy/modifiers/live/seekable.js
@@ -5,55 +5,77 @@ define(
     'bigscreenplayer/dynamicwindowutils',
     'bigscreenplayer/models/windowtypes'
   ],
-    function (MediaPlayerBase, DynamicWindowUtils, WindowTypes) {
-      'use strict';
-      function SeekableLivePlayer (mediaPlayer, deviceConfig, windowType) {
-        var AUTO_RESUME_WINDOW_START_CUSHION_SECONDS = 8;
+  function (MediaPlayerBase, DynamicWindowUtils, WindowTypes) {
+    'use strict';
+    function SeekableLivePlayer (mediaPlayer, deviceConfig, windowType) {
+      var AUTO_RESUME_WINDOW_START_CUSHION_SECONDS = 8;
 
-        function addEventCallback (thisArg, callback) {
-          mediaPlayer.addEventCallback(thisArg, callback);
-        }
+      function addEventCallback (thisArg, callback) {
+        mediaPlayer.addEventCallback(thisArg, callback);
+      }
 
-        function removeEventCallback (thisArg, callback) {
-          mediaPlayer.removeEventCallback(thisArg, callback);
-        }
+      function removeEventCallback (thisArg, callback) {
+        mediaPlayer.removeEventCallback(thisArg, callback);
+      }
 
-        function removeAllEventCallbacks () {
-          mediaPlayer.removeAllEventCallbacks();
-        }
+      function removeAllEventCallbacks () {
+        mediaPlayer.removeAllEventCallbacks();
+      }
 
-        function resume () {
-          mediaPlayer.resume();
-        }
+      function resume () {
+        mediaPlayer.resume();
+      }
 
-        return ({
-          initialiseMedia: function initialiseMedia (mediaType, sourceUrl, mimeType, sourceContainer, opts) {
-            if (mediaType === MediaPlayerBase.TYPE.AUDIO) {
-              mediaType = MediaPlayerBase.TYPE.LIVE_AUDIO;
-            } else {
-              mediaType = MediaPlayerBase.TYPE.LIVE_VIDEO;
-            }
+      return ({
+        initialiseMedia: function initialiseMedia (mediaType, sourceUrl, mimeType, sourceContainer, opts) {
+          if (mediaType === MediaPlayerBase.TYPE.AUDIO) {
+            mediaType = MediaPlayerBase.TYPE.LIVE_AUDIO;
+          } else {
+            mediaType = MediaPlayerBase.TYPE.LIVE_VIDEO;
+          }
 
-            mediaPlayer.initialiseMedia(mediaType, sourceUrl, mimeType, sourceContainer, opts);
-          },
+          mediaPlayer.initialiseMedia(mediaType, sourceUrl, mimeType, sourceContainer, opts);
+        },
 
-          beginPlayback: function beginPlayback () {
-            var config = deviceConfig;
-            if (config && config.streaming && config.streaming.overrides && config.streaming.overrides.forceBeginPlaybackToEndOfWindow) {
-              mediaPlayer.beginPlaybackFrom(Infinity);
-            } else {
-              mediaPlayer.beginPlayback();
-            }
-          },
+        beginPlayback: function beginPlayback () {
+          var config = deviceConfig;
+          if (config && config.streaming && config.streaming.overrides && config.streaming.overrides.forceBeginPlaybackToEndOfWindow) {
+            mediaPlayer.beginPlaybackFrom(Infinity);
+          } else {
+            mediaPlayer.beginPlayback();
+          }
+        },
 
-          beginPlaybackFrom: function beginPlaybackFrom (offset) {
-            mediaPlayer.beginPlaybackFrom(offset);
-          },
+        beginPlaybackFrom: function beginPlaybackFrom (offset) {
+          mediaPlayer.beginPlaybackFrom(offset);
+        },
 
-          playFrom: function playFrom (offset) {
-            var postSeekState = mediaPlayer.getState();
-            mediaPlayer.playFrom(offset);
-            if (postSeekState === MediaPlayerBase.STATE.PAUSED && windowType === WindowTypes.SLIDING) {
+        playFrom: function playFrom (offset) {
+          var postSeekState = mediaPlayer.getState();
+          mediaPlayer.playFrom(offset);
+          if (postSeekState === MediaPlayerBase.STATE.PAUSED && windowType === WindowTypes.SLIDING) {
+            DynamicWindowUtils.autoResumeAtStartOfRange(
+              mediaPlayer.getCurrentTime(),
+              mediaPlayer.getSeekableRange(),
+              addEventCallback,
+              removeEventCallback,
+              MediaPlayerBase.unpausedEventCheck,
+              resume);
+          }
+        },
+
+        pause: function pause (opts) {
+          opts = opts || {};
+          var secondsUntilStartOfWindow = mediaPlayer.getCurrentTime() - mediaPlayer.getSeekableRange().start;
+
+          if (opts.disableAutoResume) {
+            mediaPlayer.pause();
+          } else if (secondsUntilStartOfWindow <= AUTO_RESUME_WINDOW_START_CUSHION_SECONDS) {
+            mediaPlayer.toPaused();
+            mediaPlayer.toPlaying();
+          } else {
+            mediaPlayer.pause();
+            if (windowType === WindowTypes.SLIDING) {
               DynamicWindowUtils.autoResumeAtStartOfRange(
                 mediaPlayer.getCurrentTime(),
                 mediaPlayer.getSeekableRange(),
@@ -62,75 +84,53 @@ define(
                 MediaPlayerBase.unpausedEventCheck,
                 resume);
             }
-          },
-
-          pause: function pause (opts) {
-            opts = opts || {};
-            var secondsUntilStartOfWindow = mediaPlayer.getCurrentTime() - mediaPlayer.getSeekableRange().start;
-
-            if (opts.disableAutoResume) {
-              mediaPlayer.pause();
-            } else if (secondsUntilStartOfWindow <= AUTO_RESUME_WINDOW_START_CUSHION_SECONDS) {
-              mediaPlayer.toPaused();
-              mediaPlayer.toPlaying();
-            } else {
-              mediaPlayer.pause();
-              if (windowType === WindowTypes.SLIDING) {
-                DynamicWindowUtils.autoResumeAtStartOfRange(
-                  mediaPlayer.getCurrentTime(),
-                  mediaPlayer.getSeekableRange(),
-                  addEventCallback,
-                  removeEventCallback,
-                  MediaPlayerBase.unpausedEventCheck,
-                  resume);
-              }
-            }
-          },
-          resume: resume,
-
-          stop: function stop () {
-            mediaPlayer.stop();
-          },
-
-          reset: function reset () {
-            mediaPlayer.reset();
-          },
-
-          getState: function getState () {
-            return mediaPlayer.getState();
-          },
-
-          getSource: function getSource () {
-            return mediaPlayer.getSource();
-          },
-
-          getCurrentTime: function getCurrentTime () {
-            return mediaPlayer.getCurrentTime();
-          },
-
-          getSeekableRange: function getSeekableRange () {
-            return mediaPlayer.getSeekableRange();
-          },
-
-          getMimeType: function getMimeType () {
-            return mediaPlayer.getMimeType();
-          },
-
-          addEventCallback: addEventCallback,
-
-          removeEventCallback: removeEventCallback,
-
-          removeAllEventCallbacks: removeAllEventCallbacks,
-
-          getPlayerElement: function getPlayerElement () {
-            return mediaPlayer.getPlayerElement();
-          },
-
-          getLiveSupport: function getLiveSupport () {
-            return MediaPlayerBase.LIVE_SUPPORT.SEEKABLE;
           }
-        });
-      }
+        },
+        resume: resume,
 
-      return SeekableLivePlayer;
-    });
+        stop: function stop () {
+          mediaPlayer.stop();
+        },
+
+        reset: function reset () {
+          mediaPlayer.reset();
+        },
+
+        getState: function getState () {
+          return mediaPlayer.getState();
+        },
+
+        getSource: function getSource () {
+          return mediaPlayer.getSource();
+        },
+
+        getCurrentTime: function getCurrentTime () {
+          return mediaPlayer.getCurrentTime();
+        },
+
+        getSeekableRange: function getSeekableRange () {
+          return mediaPlayer.getSeekableRange();
+        },
+
+        getMimeType: function getMimeType () {
+          return mediaPlayer.getMimeType();
+        },
+
+        addEventCallback: addEventCallback,
+
+        removeEventCallback: removeEventCallback,
+
+        removeAllEventCallbacks: removeAllEventCallbacks,
+
+        getPlayerElement: function getPlayerElement () {
+          return mediaPlayer.getPlayerElement();
+        },
+
+        getLiveSupport: function getLiveSupport () {
+          return MediaPlayerBase.LIVE_SUPPORT.SEEKABLE;
+        }
+      });
+    }
+
+    return SeekableLivePlayer;
+  });

--- a/script/playbackstrategy/modifiers/live/seekable.js
+++ b/script/playbackstrategy/modifiers/live/seekable.js
@@ -51,17 +51,7 @@ define(
         },
 
         playFrom: function playFrom (offset) {
-          var postSeekState = mediaPlayer.getState();
           mediaPlayer.playFrom(offset);
-          if (postSeekState === MediaPlayerBase.STATE.PAUSED && windowType === WindowTypes.SLIDING) {
-            DynamicWindowUtils.autoResumeAtStartOfRange(
-              mediaPlayer.getCurrentTime(),
-              mediaPlayer.getSeekableRange(),
-              addEventCallback,
-              removeEventCallback,
-              MediaPlayerBase.unpausedEventCheck,
-              resume);
-          }
         },
 
         pause: function pause (opts) {

--- a/script/playbackstrategy/modifiers/mediaplayerbase.js
+++ b/script/playbackstrategy/modifiers/mediaplayerbase.js
@@ -39,7 +39,7 @@ define(
       };
 
       function unpausedEventCheck (event) {
-        if (event && event.state) {
+        if (event && event.state && event.type !== 'status') {
           return event.state !== STATE.PAUSED;
         } else {
           return undefined;


### PR DESCRIPTION
📺 What

This fixes auto resume not triggering for MSE and native seekable whilst paused and seeking to anywhere other than the start.

> Tickets: IPLAYERTVV1-11210

🛠 How

- Starts auto resume timer if paused and seeking
(MSE is triggered after a 'seeked' event)
(Native seekable is on playFrom if postseekstate was paused.)
- Stops STATUS events clearing auto resume timer for native implementations
- Verifies that only SLIDING windows start the timeout