### PR TITLE
Remove auto resume function

### DIFF
--- a/script-test/dynamicwindowutilstest.js
+++ b/script-test/dynamicwindowutilstest.js
@@ -3,32 +3,6 @@ require(
     'bigscreenplayer/dynamicwindowutils'
   ],
   function (DynamicWindowUtils) {
-    describe('shouldAutoResume', function () {
-      it('returns true if we are at the beginning of the playback range', function () {
-        var isAtStart = DynamicWindowUtils.shouldAutoResume(10, 10);
-
-        expect(isAtStart).toBeTrue();
-      });
-
-      it('returns true if we are at the beginning of the playback range within a threshhold', function () {
-        var isAtStart = DynamicWindowUtils.shouldAutoResume(15, 10);
-
-        expect(isAtStart).toBeTrue();
-      });
-
-      it('returns true if we are at the beginning of the playback range at the threshhold', function () {
-        var isAtStart = DynamicWindowUtils.shouldAutoResume(18, 10);
-
-        expect(isAtStart).toBeTrue();
-      });
-
-      it('returns false if we are after the beginning and the threshhold', function () {
-        var isAtStart = DynamicWindowUtils.shouldAutoResume(20, 10);
-
-        expect(isAtStart).toBeFalse();
-      });
-    });
-
     describe('autoResumeAtStartOfRange', function () {
       var resume;
       var addEventCallback;

--- a/script/dynamicwindowutils.js
+++ b/script/dynamicwindowutils.js
@@ -67,13 +67,8 @@ define(
       }
     }
 
-    function shouldAutoResume (seekTime, seekableRangeStart) {
-      return seekTime - seekableRangeStart <= AUTO_RESUME_WINDOW_START_CUSHION_SECONDS;
-    }
-
     return {
       autoResumeAtStartOfRange: autoResumeAtStartOfRange,
-      shouldAutoResume: shouldAutoResume,
       canPause: canPause,
       canSeek: canSeek
     };


### PR DESCRIPTION
📺 What

This removes the `shouldAutoResume` function that was missed in the tidy up of #144 .


🛠 How

Remove the function and accompanying tests.
