### PR TITLE
Captions fail to parse with timestamps in nested elements

### DIFF
--- a/script-test/domhelpers.js
+++ b/script-test/domhelpers.js
@@ -6,6 +6,19 @@ require(
     'use strict';
 
     describe('DOMHelpers', function () {
+      it('returns false when attribute does not exist', function () {
+        var pTag = document.createElement('p');
+
+        expect(DOMHelpers.hasAttribute(pTag, 'thing')).toBeFalse();
+      });
+
+      it('returns true when attribute exists', function () {
+        var pTag = document.createElement('p');
+        pTag.setAttribute('thing', 'exists');
+
+        expect(DOMHelpers.hasAttribute(pTag, 'thing')).toBeTrue();
+      });
+
       it('Converts an RGBA tuple string to RGB tripple string', function () {
         expect(DOMHelpers.rgbaToRGB('#FFAAFFAA')).toBe('#FFAAFF');
       });

--- a/script/captions.js
+++ b/script/captions.js
@@ -310,7 +310,7 @@ define('bigscreenplayer/captions',
         }
 
         function hasNestedTime (timedPieceNode) {
-          if (!timedPieceNode.getAttribute('begin') || !timedPieceNode.getAttribute('end')) return true;
+          return (!DOMHelpers.hasAttribute(timedPieceNode, 'begin') || !DOMHelpers.hasAttribute(timedPieceNode, 'end'));
         }
 
         function parseNestedTime (timedPieceNode) {
@@ -318,9 +318,9 @@ define('bigscreenplayer/captions',
           var latestEnd;
           for (var i = 0; i < timedPieceNode.childNodes.length; i++) {
             var childNodeTime = {};
-            childNodeTime.start = timedPieceNode.childNodes[i].getAttribute('begin') ? timeStampToSeconds(timedPieceNode.childNodes[i].getAttribute('begin')) : null;
-            childNodeTime.end = timedPieceNode.childNodes[i].getAttribute('end') ? timeStampToSeconds(timedPieceNode.childNodes[i].getAttribute('end')) : null;
-            if (childNodeTime.start && childNodeTime.end) {
+            childNodeTime.start = DOMHelpers.hasAttribute(timedPieceNode.childNodes[i], 'begin') ? timeStampToSeconds(timedPieceNode.childNodes[i].getAttribute('begin')) : null;
+            childNodeTime.end = DOMHelpers.hasAttribute(timedPieceNode.childNodes[i], 'end') ? timeStampToSeconds(timedPieceNode.childNodes[i].getAttribute('end')) : null;
+            if (childNodeTime.start !== null && childNodeTime.end !== null) {
               if (earliestStart === undefined || childNodeTime.start < earliestStart) {
                 earliestStart = childNodeTime.start;
               }
@@ -330,7 +330,7 @@ define('bigscreenplayer/captions',
             }
           }
 
-          if (earliestStart && latestEnd) {
+          if (earliestStart !== undefined && latestEnd !== undefined) {
             return {
               start: earliestStart,
               end: latestEnd

--- a/script/domhelpers.js
+++ b/script/domhelpers.js
@@ -52,13 +52,25 @@ define(
       }
     };
 
+    /**
+     * Safely checks if an attribute exists on an element.
+     * Browsers < DOM Level 2 do not have 'hasAttribute'
+     *
+     * @param {Element} el HTML Element
+     * @param {String} attribute attribute to check for
+     */
+    var hasAttribute = function (el, attribute) {
+      return !!el.getAttribute(attribute);
+    };
+
     return {
       addClass: addClass,
       removeClass: removeClass,
       hasClass: hasClass,
       rgbaToRGB: rgbaToRGB,
       isRGBA: isRGBATuple,
-      safeRemoveElement: safeRemoveElement
+      safeRemoveElement: safeRemoveElement,
+      hasAttribute: hasAttribute
     };
   }
 );


### PR DESCRIPTION
📺 What

Fixes parsing of captions that fail to parse with nested elements.

> Tickets: [IPLAYERTVV1-11477](https://jira.dev.bbc.co.uk/browse/IPLAYERTVV1-11477)


🛠 How

Parse timestamps from nested elements - combine them for earliest/latest rather than a separate TimePiece for each element.


✅ Testing 
[Test Guidelines](https://github.com/bbc/bigscreen-player/wiki/Areas-Impacted)

| Test engineer sign off | :x: |
| ---- | ---- |
