### PR TITLE
Fix postinstall script exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:version": "node ./buildVersion.js",
     "build:copy:script": "cp -R ./script/ ./dist/script/",
     "build:copy:files": "cp package.json package-lock.json CONTRIBUTING.md README.md LICENSE ./dist/",
-    "postinstall": "test -f ./buildVersion.js && npm run build:version"
+    "postinstall": "[[ -f ./buildVersion.js ]] && npm run build:version || echo 'Version already set.'"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
📺 What

This fixes the `exit 1` status from using versioned builds.

Due to #160 the `postinstall` step builds the runtime version file with `buildVersion.js`. This only works when running with bigscreen-player installed as a github npm dependency.

> Tickets: N/A


🛠 How

Just echo out if `buildVersion.js` isn't in the package (This is true when it is from NPM).
