### PR TITLE
correct the arguments sent to renderer

### DIFF
--- a/script/subtitles/captionscontainer.js
+++ b/script/subtitles/captionscontainer.js
@@ -16,7 +16,7 @@ define(
 
       // TODO: We don't need this extra Div really... can we get rid of render() and use the passed in container?
       if (captionsURL) {
-        subtitlesRenderer = new Renderer('playerCaptions', captionsURL, mediaPlayer, container, autoStart);
+        subtitlesRenderer = new Renderer('playerCaptions', captionsURL, mediaPlayer, autoStart);
         container.appendChild(subtitlesRenderer.render());
       }
 


### PR DESCRIPTION
📺 What

Fixes bug where incorrect arguments were sent to Renderer from CaptionsContainer, resulting in captions being permanently autostarted.

🛠 How

Pass `autoStart` as the correct (4th) argument into Renderer.
