### PR TITLE
Subtitle Customisation Defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9353,7 +9353,7 @@
       "dev": true
     },
     "smp-imsc": {
-      "version": "github:bbc/imscJS#bdd85308319916877d1535dc620f514f2879744e",
+      "version": "github:bbc/imscJS#13dc9a5dd84db694b1043770cd6903e628885323",
       "from": "github:bbc/imscJS#nm-size-adjust",
       "requires": {
         "sax": "1.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9353,8 +9353,8 @@
       "dev": true
     },
     "smp-imsc": {
-      "version": "github:bbc/imscjs#cd70792905e0084cff31762086bae5f627283c1f",
-      "from": "github:bbc/imscjs#v1.0.0",
+      "version": "github:bbc/imscJS#bdd85308319916877d1535dc620f514f2879744e",
+      "from": "github:bbc/imscJS#nm-size-adjust",
       "requires": {
         "sax": "1.2.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9353,8 +9353,8 @@
       "dev": true
     },
     "smp-imsc": {
-      "version": "github:bbc/imscJS#13dc9a5dd84db694b1043770cd6903e628885323",
-      "from": "github:bbc/imscJS#nm-size-adjust",
+      "version": "github:bbc/imscJS#a95e3495e2bdafbf9ce04a71ac6c8525e5eff349",
+      "from": "github:bbc/imscJS#v1.0.3",
       "requires": {
         "sax": "1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "dashjs": "github:bbc/dash.js#smp-v3.0.0-7",
-    "smp-imsc": "github:bbc/imscJS#nm-size-adjust"
+    "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "dashjs": "github:bbc/dash.js#smp-v3.0.0-7",
-    "smp-imsc": "github:bbc/imscjs#v1.0.0"
+    "smp-imsc": "github:bbc/imscJS#nm-size-adjust"
   },
   "repository": {
     "type": "git",

--- a/script-test/playercomponenttest.js
+++ b/script-test/playercomponenttest.js
@@ -162,7 +162,7 @@ require(
           var opts = {subtitlesEnabled: true};
           setUpPlayerComponent(opts);
 
-          expect(mockSubtitlesConstructor).toHaveBeenCalledWith(jasmine.anything(), corePlaybackData.media.captionsUrl, opts.subtitlesEnabled, playbackElement);
+          expect(mockSubtitlesConstructor).toHaveBeenCalledWith(jasmine.anything(), corePlaybackData.media.captionsUrl, opts.subtitlesEnabled, jasmine.any(HTMLDivElement), undefined);
         });
       });
 

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -128,7 +128,7 @@ require(
 
         it('overrides the subtitles styling metadata with supplied defaults when rendering', function () {
           var styleOpts = { backgroundColour: 'black', fontFamily: 'Arial' };
-          var expectedOpts = { spanBackgroundColorAdjust: { transparent: 'black', black: 'black' }, fontFamily: 'Arial' };
+          var expectedOpts = { spanBackgroundColorAdjust: { transparent: 'black' }, fontFamily: 'Arial' };
           subtitles = ImscSubtitles(mediaPlayer, { xml: '', text: stubResponse }, false, mockParentElement, styleOpts);
 
           subtitles.start();

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -100,7 +100,7 @@ require(
 
       describe('update interval', function () {
         beforeEach(function () {
-          subtitles = ImscSubtitles(mediaPlayer, {xml: '', text: stubResponse}, false, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, { xml: '', text: stubResponse }, false, mockParentElement);
         });
 
         afterEach(function () {
@@ -109,7 +109,7 @@ require(
 
         it('cannot start when xml transforming has failed', function () {
           imscMock.fromXML.and.throwError();
-          subtitles = ImscSubtitles(mediaPlayer, {xml: '', text: stubResponse}, false, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, { xml: '', text: stubResponse }, false, mockParentElement);
 
           subtitles.start();
           progressTime(1.5);
@@ -124,6 +124,17 @@ require(
 
           expect(imscMock.generateISD).not.toHaveBeenCalled();
           expect(imscMock.renderHTML).not.toHaveBeenCalled();
+        });
+
+        it('overrides the subtitles styling metadata with supplied defaults when rendering', function () {
+          var styleOpts = { backgroundColour: 'black', fontFamily: 'Arial' };
+          var expectedOpts = { spanBackgroundColorAdjust: { transparent: 'black', black: 'black' }, fontFamily: 'Arial' };
+          subtitles = ImscSubtitles(mediaPlayer, { xml: '', text: stubResponse }, false, mockParentElement, styleOpts);
+
+          subtitles.start();
+          progressTime(9);
+
+          expect(imscMock.renderHTML).toHaveBeenCalledWith(undefined, jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, expectedOpts);
         });
 
         it('does not try to generate and render when the initial current time is less than the first subtitle time', function () {

--- a/script-test/subtitles/subtitles.js
+++ b/script-test/subtitles/subtitles.js
@@ -122,10 +122,11 @@ require(
             var url = 'http://captions.example.test';
             var autoStart = true;
             var mockPlaybackElement = document.createElement('div');
+            var customDefaultStyle = {};
 
-            Subtitles(mockMediaPlayer, url, autoStart, mockPlaybackElement);
+            Subtitles(mockMediaPlayer, url, autoStart, mockPlaybackElement, customDefaultStyle);
 
-            expect(subtitlesContainer).toHaveBeenCalledWith(mockMediaPlayer, jasmine.objectContaining({text: stubResponse, xml: stubResponse}), autoStart, mockPlaybackElement);
+            expect(subtitlesContainer).toHaveBeenCalledWith(mockMediaPlayer, jasmine.objectContaining({text: stubResponse, xml: stubResponse}), autoStart, mockPlaybackElement, customDefaultStyle);
           });
 
           it('fires onSubtitlesLoadError plugin if loading of XML fails', function () {

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -40,7 +40,7 @@ define(
 
       bubbleErrorCleared();
 
-      var subtitles = Subtitles(playbackStrategy, captionsURL, enableSubtitles, playbackElement);
+      var subtitles = Subtitles(playbackStrategy, captionsURL, enableSubtitles, playbackElement, bigscreenPlayerData.media.subtitleCustomisation);
       initialMediaPlay(bigscreenPlayerData.media, bigscreenPlayerData.initialPlaybackTime);
 
       function play () {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -33,7 +33,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         var customStyles = {};
 
         if (opts.backgroundColour) {
-          customStyles.spanBackgroundColorAdjust = {transparent: opts.backgroundColour, black: opts.backgroundColour};
+          customStyles.spanBackgroundColorAdjust = {transparent: opts.backgroundColour};
         }
 
         if (opts.fontFamily) {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -26,7 +26,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         Plugins.interface.onSubtitlesTransformError();
       }
 
-      // Opts: { backgroundColour: string (css colour, hex), fontFamily: string }
+      // Opts: { backgroundColour: string (css colour, hex), fontFamily: string , size: number, lineHeight: number }
       function transformStyleOptions (opts) {
         if (opts === undefined) return;
 
@@ -39,6 +39,15 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         if (opts.fontFamily) {
           customStyles.fontFamily = opts.fontFamily;
         }
+
+        if (opts.size) {
+          customStyles.sizeAdjust = opts.size;
+        }
+
+        if (opts.lineHeight) {
+          customStyles.lineHeightAdjust = opts.lineHeight;
+        }
+
         return customStyles;
       }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -7,9 +7,10 @@ define('bigscreenplayer/subtitles/imscsubtitles',
   ],
   function (IMSC, DOMHelpers, DebugTool, Plugins) {
     'use strict';
-    return function (mediaPlayer, response, autoStart, parentElement) {
+    return function (mediaPlayer, response, autoStart, parentElement, defaultStyleOpts) {
       var currentSubtitlesElement;
       var previousSubtitlesIndex = null;
+      var imscRenderOpts = transformStyleOptions(defaultStyleOpts);
       var updateInterval;
       var xml;
       var times = [];
@@ -23,6 +24,22 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       } catch (e) {
         DebugTool.info('Error transforming captions : ' + e);
         Plugins.interface.onSubtitlesTransformError();
+      }
+
+      // Opts: { backgroundColour: string (css colour, hex), fontFamily: string }
+      function transformStyleOptions (opts) {
+        if (opts === undefined) return;
+
+        var customStyles = {};
+
+        if (opts.backgroundColour) {
+          customStyles.spanBackgroundColorAdjust = {transparent: opts.backgroundColour, black: opts.backgroundColour};
+        }
+
+        if (opts.fontFamily) {
+          customStyles.fontFamily = opts.fontFamily;
+        }
+        return customStyles;
       }
 
       function nextSubtitleIndex (currentTime) {
@@ -61,7 +78,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
 
           try {
             var isd = IMSC.generateISD(xml, currentTime);
-            IMSC.renderHTML(isd, currentSubtitlesElement, null, parentElement.clientHeight, parentElement.clientWidth, false, null, null, false);
+            IMSC.renderHTML(isd, currentSubtitlesElement, null, parentElement.clientHeight, parentElement.clientWidth, false, null, null, false, imscRenderOpts);
           } catch (e) {
             DebugTool.info('Exception while rendering subtitles: ' + e);
             Plugins.interface.onSubtitlesRenderError();

--- a/script/subtitles/subtitles.js
+++ b/script/subtitles/subtitles.js
@@ -8,7 +8,7 @@ define('bigscreenplayer/subtitles/subtitles',
   function (SubtitlesContainer, LoadURL, DebugTool, Plugins) {
     'use strict';
     // playbackStrategy, captionsURL, isSubtitlesEnabled(), playbackElement TODO: change the ordering of this, doesn't make sense.
-    return function (mediaPlayer, url, autoStart, playbackElement) {
+    return function (mediaPlayer, url, autoStart, playbackElement, defaultStyleOpts) {
       var subtitlesContainer;
       var subtitlesEnabled = autoStart;
       var subtitlesAvailable = !!url;
@@ -29,7 +29,7 @@ define('bigscreenplayer/subtitles/subtitles',
             };
 
             if (status === 200) {
-              subtitlesContainer = SubtitlesContainer(mediaPlayer, response, autoStart, playbackElement);
+              subtitlesContainer = SubtitlesContainer(mediaPlayer, response, autoStart, playbackElement, defaultStyleOpts);
             }
           },
           onError: function (error) {


### PR DESCRIPTION
📺 What

Allow subtitles customisation options to passed into BSP on initialisation.

> Tickets: [IPLAYERTVV1-11933](https://jira.dev.bbc.co.uk/browse/IPLAYERTVV1-11933)

🛠 How

Add a subtitles customisation object to bigscreenPlayerData.
Take `bbc/imscJS#v1.0.3` which has an API for customising subtitles appearance.

✅ Testing 

| Test engineer sign off | :x: |
| ---- | ---- |