### PR TITLE
Live edge change

### DIFF
--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -744,22 +744,29 @@ require(
           expect(bigscreenPlayer.isPlayingAtLiveEdge()).toEqual(false);
         });
 
-        it('should return true when playing live and current time is within tolerance of seekable range end', function () {
+        it('should return true on when playback has been started from the live point', function () {
           initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
-
-          mockPlayerComponentInstance.getCurrentTime.and.returnValue(100);
-          mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 105});
 
           expect(bigscreenPlayer.isPlayingAtLiveEdge()).toEqual(true);
         });
 
-        it('should return false when playing live and current time is outside the tolerance of seekable range end', function () {
+        it('should return false when playing live and pause event is recieved', function () {
           initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
-
-          mockPlayerComponentInstance.getCurrentTime.and.returnValue(95);
-          mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 105});
+          mockEventHook({data: {state: MediaState.PAUSED}});
 
           expect(bigscreenPlayer.isPlayingAtLiveEdge()).toEqual(false);
+        });
+
+        it('should return true when seeking to end and current time is within tolerance of the seekable range end', function () {
+          initialiseBigscreenPlayer({windowType: WindowTypes.SLIDING});
+          mockEventHook({data: {state: MediaState.PAUSED}});
+
+          mockPlayerComponentInstance.getCurrentTime.and.returnValue(50);
+          mockPlayerComponentInstance.getSeekableRange.and.returnValue({start: 0, end: 105});
+
+          bigscreenPlayer.setCurrentTime(100);
+
+          expect(bigscreenPlayer.isPlayingAtLiveEdge()).toEqual(true);
         });
       });
 

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -29,7 +29,7 @@ define('bigscreenplayer/bigscreenplayer',
       var resizer;
       var pauseTrigger;
       var isSeeking = false;
-      var endOfStream;
+      var endOfStream = false;
       var windowType;
       var mediaSources;
       var playbackElement;

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -267,7 +267,8 @@ define('bigscreenplayer/bigscreenplayer',
           return playerComponent ? playerComponent.getSeekableRange() : {};
         },
         isPlayingAtLiveEdge: function () {
-          return !!playerComponent && windowType !== WindowTypes.STATIC && Math.abs(this.getSeekableRange().end - this.getCurrentTime()) < END_OF_STREAM_TOLERANCE;
+          // prefer this 'user intent' method of determining this, as some devices don't start up close enough to live
+          return endOfStream;
         },
         getLiveWindowData: function () {
           if (windowType === WindowTypes.STATIC) {


### PR DESCRIPTION
📺 What

Update the `isPlayingAtLiveEdge` API function.

> Tickets: N/A

🛠 How

Moves the `isPlayingAtLiveEdge` function to follow the same pattern as the stored `endOfStream` state which is returned through time updates and state changes. This is due to some devices not playing close enough to the live edge when started up for this function to report the playback as live.