### PR TITLE
Update isFirstManifest Logic to only compare Hosts 

### DIFF
--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -241,7 +241,7 @@ require(
         });
       });
 
-      fdescribe('isFirstManifest', function () {
+      describe('isFirstManifest', function () {
         it('does not failover if service location is identical to current source cdn besides hash and query', function () {
           var mediaSources = new MediaSources();
           mediaSources.init(

--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -242,6 +242,31 @@ require(
       });
 
       describe('isFirstManifest', function () {
+        it('does not failover if service location is identical to current source cdn besides path', function () {
+          var mediaSources = new MediaSources();
+          mediaSources.init(
+            [
+              { url: 'http://source1.com/path/to/thing.extension', cdn: 'http://cdn1.com' },
+              { url: 'http://source2.com', cdn: 'http://cdn2.com' }],
+            new Date(),
+            WindowTypes.STATIC,
+            LiveSupport.SEEKABLE,
+            testCallbacks);
+
+          expect(mediaSources.currentSource()).toBe('http://source1.com/path/to/thing.extension');
+
+          mediaSources.failover(
+            function () { }, function () { },
+            {
+              duration: 999,
+              currentTime: 1,
+              errorMessage: '',
+              isBufferingTimeoutError: false,
+              serviceLocation: 'http://source1.com/path/to/different/thing.extension'
+            });
+
+          expect(mediaSources.currentSource()).toBe('http://source1.com/path/to/thing.extension');
+        });
         it('does not failover if service location is identical to current source cdn besides hash and query', function () {
           var mediaSources = new MediaSources();
           mediaSources.init(

--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -241,6 +241,33 @@ require(
         });
       });
 
+      fdescribe('isFirstManifest', function () {
+        it('does not failover if service location is identical to current source cdn besides hash and query', function () {
+          var mediaSources = new MediaSources();
+          mediaSources.init(
+            [
+              {url: 'http://source1.com', cdn: 'http://cdn1.com'},
+              {url: 'http://source2.com', cdn: 'http://cdn2.com'}],
+            new Date(),
+            WindowTypes.STATIC,
+            LiveSupport.SEEKABLE,
+            testCallbacks);
+
+          expect(mediaSources.currentSource()).toBe('http://source1.com');
+
+          mediaSources.failover(
+            function () {}, function () {},
+            {
+              duration: 999,
+              currentTime: 1,
+              errorMessage: '',
+              isBufferingTimeoutError: false,
+              serviceLocation: 'http://source1.com?key=value#hash'});
+
+          expect(mediaSources.currentSource()).toBe('http://source1.com');
+        });
+      });
+
       describe('currentSource', function () {
         beforeEach(function () {
           testSources = [

--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -64,8 +64,8 @@ require(
           MediaSources = SquiredMediaSources;
 
           testSources = [
-            {url: 'source1', cdn: 'supplier1'},
-            {url: 'source2', cdn: 'supplier2'}
+            {url: 'http://source1.com/', cdn: 'http://supplier1.com/'},
+            {url: 'http://source2.com/', cdn: 'http://supplier2.com/'}
           ];
           done();
         });
@@ -96,7 +96,7 @@ require(
           mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           testSources[0].url = 'clonetest';
 
-          expect(mediaSources.currentSource()).toEqual('source1');
+          expect(mediaSources.currentSource()).toEqual('http://source1.com/');
         });
 
         it('throws an error when callbacks are undefined', function () {
@@ -203,7 +203,7 @@ require(
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init([{url: 'source1', cdn: 'supplier1'}], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init([{url: 'http://source1.com/', cdn: 'http://supplier1.com/'}], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(onFailureAction).toHaveBeenCalledWith();
@@ -221,8 +221,8 @@ require(
             status: PluginEnums.STATUS.FAILOVER,
             stateType: PluginEnums.TYPE.ERROR,
             isBufferingTimeoutError: true,
-            cdn: 'supplier1',
-            newCdn: 'supplier2',
+            cdn: 'http://supplier1.com/',
+            newCdn: 'http://supplier2.com/',
             isInitialPlay: undefined,
             timeStamp: jasmine.any(Object)
           };
@@ -234,7 +234,7 @@ require(
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init([{url: 'source1', cdn: 'supplier1'}], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init([{url: 'http://source1.com/', cdn: 'http://supplier1.com/'}], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(mockPluginsInterface.onErrorHandled).not.toHaveBeenCalled();
@@ -244,8 +244,8 @@ require(
       describe('currentSource', function () {
         beforeEach(function () {
           testSources = [
-            {url: 'source1', cdn: 'supplier1'},
-            {url: 'source2', cdn: 'supplier2'}
+            {url: 'http://source1.com/', cdn: 'http://supplier1.com/'},
+            {url: 'http://source2.com/', cdn: 'http://supplier2.com/'}
           ];
         });
 
@@ -274,7 +274,7 @@ require(
           var mediaSources = new MediaSources();
           mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
-          expect(mediaSources.availableSources()).toEqual(['source1', 'source2']);
+          expect(mediaSources.availableSources()).toEqual(['http://source1.com/', 'http://source2.com/']);
         });
       });
 

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -79,8 +79,8 @@ define('bigscreenplayer/mediasources',
       // the serviceLocation is set to our first cdn url
       // see manifest modifier - generateBaseUrls
       function isFirstManifest (serviceLocation) {
-        // Matches anything between *:// and /
-        var hostRegex = /\w*?:\/\/(.*?)\//;
+        // Matches anything between *:// and / or the end of the line
+        var hostRegex = /\w*?:\/\/(.*?)(?:\/|$)/;
 
         var serviceLocationHost = hostRegex.exec(serviceLocation);
         var currentUrlHost = hostRegex.exec(getCurrentUrl());

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -80,7 +80,7 @@ define('bigscreenplayer/mediasources',
       // see manifest modifier - generateBaseUrls
       function isFirstManifest (serviceLocation) {
         // Matches anything between *:// and / or the end of the line
-        var hostRegex = /\w*?:\/\/(.*?)(?:\/|$)/;
+        var hostRegex = /\w+?:\/\/(.*?)(?:\/|$)/;
 
         var serviceLocationHost = hostRegex.exec(serviceLocation);
         var currentUrlHost = hostRegex.exec(getCurrentUrl());

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -82,13 +82,15 @@ define('bigscreenplayer/mediasources',
         // Matches anything between *:// and / or the end of the line
         var hostRegex = /\w+?:\/\/(.*?)(?:\/|$)/;
 
-        var serviceLocationHost = hostRegex.exec(serviceLocation);
-        var currentUrlHost = hostRegex.exec(getCurrentUrl());
+        var serviceLocNoQueryHash = stripQueryParamsAndHash(serviceLocation);
+        var currUrlNoQueryHash = stripQueryParamsAndHash(getCurrentUrl());
+
+        var serviceLocationHost = hostRegex.exec(serviceLocNoQueryHash);
+        var currentUrlHost = hostRegex.exec(currUrlNoQueryHash);
 
         return serviceLocationHost && currentUrlHost
           ? serviceLocationHost[1] === currentUrlHost[1]
-          : stripQueryParamsAndHash(serviceLocation) ===
-            stripQueryParamsAndHash(getCurrentUrl());
+          : serviceLocNoQueryHash === currUrlNoQueryHash;
       }
 
       function isFailoverInfoValid (failoverParams) {

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -71,6 +71,10 @@ define('bigscreenplayer/mediasources',
         return isFailoverInfoValid(failoverParams) && hasSourcesToFailoverTo() && (shouldStaticFailover || shouldLiveFailover);
       }
 
+      function stripQueryParamsAndHash (url) {
+        return url.split(/[?#]/)[0];
+      }
+
       // we don't want to failover on the first playback
       // the serviceLocation is set to our first cdn url
       // see manifest modifier - generateBaseUrls
@@ -83,7 +87,8 @@ define('bigscreenplayer/mediasources',
 
         return serviceLocationHost && currentUrlHost
           ? serviceLocationHost[1] === currentUrlHost[1]
-          : serviceLocation === getCurrentUrl();
+          : stripQueryParamsAndHash(serviceLocation) 
+            === stripQueryParamsAndHash(getCurrentUrl());
       }
 
       function isFailoverInfoValid (failoverParams) {

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -75,10 +75,15 @@ define('bigscreenplayer/mediasources',
       // the serviceLocation is set to our first cdn url
       // see manifest modifier - generateBaseUrls
       function isFirstManifest (serviceLocation) {
-        var serviceLocationHost = new URL(serviceLocation).host;
-        var currentUrlHost = new URL(getCurrentUrl()).host;
+        // Matches anything between *:// and /
+        var hostRegex = /\w*?:\/\/(.*?)\//;
 
-        return serviceLocationHost === currentUrlHost;
+        var serviceLocationHost = hostRegex.exec(serviceLocation);
+        var currentUrlHost = hostRegex.exec(getCurrentUrl());
+
+        return serviceLocationHost && currentUrlHost
+          ? serviceLocationHost[1] === currentUrlHost[1]
+          : serviceLocation === getCurrentUrl();
       }
 
       function isFailoverInfoValid (failoverParams) {

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -72,7 +72,7 @@ define('bigscreenplayer/mediasources',
       }
 
       function stripQueryParamsAndHash (url) {
-        return url.split(/[?#]/)[0];
+        return url ? url.split(/[?#]/)[0] : url;
       }
 
       // we don't want to failover on the first playback
@@ -87,8 +87,8 @@ define('bigscreenplayer/mediasources',
 
         return serviceLocationHost && currentUrlHost
           ? serviceLocationHost[1] === currentUrlHost[1]
-          : stripQueryParamsAndHash(serviceLocation) 
-            === stripQueryParamsAndHash(getCurrentUrl());
+          : stripQueryParamsAndHash(serviceLocation) ===
+            stripQueryParamsAndHash(getCurrentUrl());
       }
 
       function isFailoverInfoValid (failoverParams) {

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -75,7 +75,10 @@ define('bigscreenplayer/mediasources',
       // the serviceLocation is set to our first cdn url
       // see manifest modifier - generateBaseUrls
       function isFirstManifest (serviceLocation) {
-        return serviceLocation === getCurrentUrl();
+        var serviceLocationHost = new URL(serviceLocation).host;
+        var currentUrlHost = new URL(getCurrentUrl()).host;
+
+        return serviceLocationHost === currentUrlHost;
       }
 
       function isFailoverInfoValid (failoverParams) {

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -72,7 +72,7 @@ define('bigscreenplayer/mediasources',
       }
 
       function stripQueryParamsAndHash (url) {
-        return url ? url.split(/[?#]/)[0] : url;
+        return typeof (url) === 'string' ? url.split(/[?#]/)[0] : url;
       }
 
       // we don't want to failover on the first playback


### PR DESCRIPTION
📺 What

Currently, in some instances the first CDN is skipped as our check to determine whether it is the first CDN or not fails due to the `serviceLocation` URL from the manifest not always matching the CDN URLs passed in exactly.

> Tickets: IPLAYERTVV1-12007


🛠 How

Updates the logic for `isFirstManifest` to compare the domain of the serviceLocation instead of the full URL. This method uses a regex to pull out the hostname.