### PR TITLE
BaseUrl failover for CDNs without a BaseUrl in the manifest (MSE Strategy)

### DIFF
--- a/script-test/manifest/manifestmodifiertest.js
+++ b/script-test/manifest/manifestmodifiertest.js
@@ -302,7 +302,7 @@ require(
           });
         },
 
-        describe('no base url', function () {
+        describe('no base url on manifest', function () {
           it('should return base url objects', function () {
             var manifest = {
               Period: {}

--- a/script-test/manifest/manifestmodifiertest.js
+++ b/script-test/manifest/manifestmodifiertest.js
@@ -302,13 +302,17 @@ require(
           });
         },
 
-        it('should leave the manifest unchanged if there is no base url', function () {
+        it('should modify the manifest if there is no base url', function () {
           var manifest = {
             Period: {}
           };
 
           var expectedManifest = {
-            Period: {}
+            Period: {},
+            BaseURL_asArray: [
+              { __text: 'https://cdn-a.com/', 'dvb:priority': 0, serviceLocation: 'https://cdn-a.com/' },
+              { __text: 'https://cdn-b.com/', 'dvb:priority': 1, serviceLocation: 'https://cdn-b.com/' }
+            ]
           };
 
           ManifestModifier.generateBaseUrls(manifest, sources);

--- a/script-test/manifest/manifestmodifiertest.js
+++ b/script-test/manifest/manifestmodifiertest.js
@@ -302,22 +302,24 @@ require(
           });
         },
 
-        it('should modify the manifest if there is no base url', function () {
-          var manifest = {
-            Period: {}
-          };
+        describe('no base url', function () {
+          it('should return base url objects', function () {
+            var manifest = {
+              Period: {}
+            };
 
-          var expectedManifest = {
-            Period: {},
-            BaseURL_asArray: [
-              { __text: 'https://cdn-a.com/', 'dvb:priority': 0, serviceLocation: 'https://cdn-a.com/' },
-              { __text: 'https://cdn-b.com/', 'dvb:priority': 1, serviceLocation: 'https://cdn-b.com/' }
-            ]
-          };
+            var expectedManifest = {
+              Period: {},
+              BaseURL_asArray: [
+                { __text: 'https://cdn-a.com/', 'dvb:priority': 0, serviceLocation: 'https://cdn-a.com/' },
+                { __text: 'https://cdn-b.com/', 'dvb:priority': 1, serviceLocation: 'https://cdn-b.com/' }
+              ]
+            };
 
-          ManifestModifier.generateBaseUrls(manifest, sources);
+            ManifestModifier.generateBaseUrls(manifest, sources);
 
-          expect(manifest).toEqual(expectedManifest);
+            expect(manifest).toEqual(expectedManifest);
+          });
         }));
       });
     });

--- a/script/manifest/manifestmodifier.js
+++ b/script/manifest/manifestmodifier.js
@@ -51,7 +51,6 @@ define('bigscreenplayer/manifest/manifestmodifier',
     function generateBaseUrls (manifest, sources) {
       var baseUrl = extractBaseUrl(manifest);
       var baseUrls = [];
-      // if (!baseUrl) return;
 
       function generateBaseUrl (source, priority, serviceLocation) {
         return {

--- a/script/manifest/manifestmodifier.js
+++ b/script/manifest/manifestmodifier.js
@@ -51,7 +51,7 @@ define('bigscreenplayer/manifest/manifestmodifier',
     function generateBaseUrls (manifest, sources) {
       var baseUrl = extractBaseUrl(manifest);
       var baseUrls = [];
-      if (!baseUrl) return;
+      // if (!baseUrl) return;
 
       function generateBaseUrl (source, priority, serviceLocation) {
         return {
@@ -61,7 +61,7 @@ define('bigscreenplayer/manifest/manifestmodifier',
         };
       }
 
-      if (baseUrl.match(/^https?:\/\//)) {
+      if (baseUrl && baseUrl.match(/^https?:\/\//)) {
         var newBaseUrl = generateBaseUrl(baseUrl, 0, sources[0]);
         baseUrls = [newBaseUrl];
 
@@ -70,8 +70,11 @@ define('bigscreenplayer/manifest/manifestmodifier',
         }
       } else {
         baseUrls = sources.map(function (source, priority) {
-          var sourceUrl = new URL(baseUrl, source);
-          return generateBaseUrl(sourceUrl.href, priority, source);
+          if (baseUrl) {
+            var sourceUrl = new URL(baseUrl, source);
+            return generateBaseUrl(sourceUrl.href, priority, source);
+          }
+          return generateBaseUrl(source, priority, source);
         });
       }
 

--- a/script/manifest/manifestmodifier.js
+++ b/script/manifest/manifestmodifier.js
@@ -49,8 +49,20 @@ define('bigscreenplayer/manifest/manifestmodifier',
     }
 
     function generateBaseUrls (manifest, sources) {
+      if (!manifest) return;
       var baseUrl = extractBaseUrl(manifest);
-      var baseUrls = [];
+
+      if (isBaseUrlAbsolute(baseUrl)) {
+        setAbsoluteBaseUrl(baseUrl);
+      } else {
+        if (baseUrl) {
+          setBaseUrlsFromBaseUrl(baseUrl);
+        } else {
+          setBaseUrlsFromSource();
+        }
+      }
+
+      removeUnusedPeriodAttributes();
 
       function generateBaseUrl (source, priority, serviceLocation) {
         return {
@@ -60,26 +72,36 @@ define('bigscreenplayer/manifest/manifestmodifier',
         };
       }
 
-      if (baseUrl && baseUrl.match(/^https?:\/\//)) {
-        var newBaseUrl = generateBaseUrl(baseUrl, 0, sources[0]);
-        baseUrls = [newBaseUrl];
+      function removeUnusedPeriodAttributes () {
+        if (manifest.Period && manifest.Period.BaseURL) delete manifest.Period.BaseURL;
+        if (manifest.Period && manifest.Period.BaseURL_asArray) delete manifest.Period.BaseURL_asArray;
+      }
 
-        if (manifest && (manifest.BaseURL || manifest.Period && manifest.Period.BaseURL)) {
+      function isBaseUrlAbsolute (baseUrl) {
+        return baseUrl && baseUrl.match(/^https?:\/\//);
+      }
+
+      function setAbsoluteBaseUrl (baseUrl) {
+        var newBaseUrl = generateBaseUrl(baseUrl, 0, sources[0]);
+        manifest.BaseURL_asArray = [newBaseUrl];
+
+        if (manifest.BaseURL || manifest.Period && manifest.Period.BaseURL) {
           manifest.BaseURL = newBaseUrl;
         }
-      } else {
-        baseUrls = sources.map(function (source, priority) {
-          if (baseUrl) {
-            var sourceUrl = new URL(baseUrl, source);
-            return generateBaseUrl(sourceUrl.href, priority, source);
-          }
-          return generateBaseUrl(source, priority, source);
+      }
+
+      function setBaseUrlsFromBaseUrl (baseUrl) {
+        manifest.BaseURL_asArray = sources.map(function (source, priority) {
+          var sourceUrl = new URL(baseUrl, source);
+          return generateBaseUrl(sourceUrl.href, priority, source);
         });
       }
 
-      manifest.BaseURL_asArray = baseUrls;
-      if (manifest && manifest.Period && manifest.Period.BaseURL) delete manifest.Period.BaseURL;
-      if (manifest && manifest.Period && manifest.Period.BaseURL_asArray) delete manifest.Period.BaseURL_asArray;
+      function setBaseUrlsFromSource () {
+        manifest.BaseURL_asArray = sources.map(function (source, priority) {
+          return generateBaseUrl(source, priority, source);
+        });
+      }
     }
 
     return {


### PR DESCRIPTION
📺 What

Playback can failover with minimal user impact using the internal dash.js failover mechanism. Normally this would require an array of BaseUrls to be supplied in the Dash MPD, but this works around that mechanism and allows it to be done without.

🛠 How

- Ignore that there isn't a `BaseUrl` in the parsed manifest.
- Assume the content paths are the same across the supplied CDNs (see use of sources in `ManifestUpdater`).
- Refactor the code to be more readable.

✅ Testing 
| Test engineer sign off | ✅ |
| ---- | ---- |