### PR TITLE
Live subtitles

### DIFF
--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -372,6 +372,7 @@ require(
       });
 
       describe('Live subtitles', function () {
+        var epochStartTimeMilliseconds = 1614769200000; // Wednesday, 3 March 2021 11:00:00
         beforeEach(function () {
           stubCaptions = {
             captionsUrl: 'https://captions/$segment$.test',
@@ -385,8 +386,7 @@ require(
 
         describe('Loading fragments', function () {
           it('should load the first three segments with correct urls on the first update interval', function () {
-            // 1614769200000 = Wednesday, 3 March 2021 11:00:00
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -397,8 +397,8 @@ require(
           });
 
           it('should load the fragment two segments ahead of current time', function () {
-            // 1614769200000 = Wednesday, 3 March 2021 11:00:00
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            // epochStartTimeMilliseconds = Wednesday, 3 March 2021 11:00:00
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -413,7 +413,7 @@ require(
           });
 
           it('should not load a fragment if fragments array already contains it', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -431,7 +431,7 @@ require(
           });
 
           it('only keeps three fragments when playing', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -450,7 +450,7 @@ require(
           });
 
           it('load three new fragments when seeking back to a point where none of the segments are available', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(113.84);
             jasmine.clock().tick(750);
@@ -466,7 +466,7 @@ require(
           });
 
           it('loads three new fragments when seeking forwards to a point where none of the segments are available', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(13.84);
             jasmine.clock().tick(750);
@@ -482,7 +482,7 @@ require(
           });
 
           it('should not load fragments when auto start is false', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, {}, epochStartTimeMilliseconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -491,7 +491,7 @@ require(
           });
 
           it('should load fragments when start is called and autoStart is false', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, {}, epochStartTimeMilliseconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -511,7 +511,7 @@ require(
             loadUrlStubResponseText = 'stuff that might exists before the xml string' + loadUrlStubResponseText;
             mediaPlayer.getCurrentTime.and.returnValue(10);
 
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
             jasmine.clock().tick(750);
 
@@ -519,7 +519,7 @@ require(
           });
 
           it('should stop loading fragments when stop is called', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
             loadUrlMock.calls.reset();
             subtitles.stop();
@@ -531,9 +531,9 @@ require(
           });
 
           it('should not try to load segments when the currentTime is not known by the player', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
-            mediaPlayer.getCurrentTime.and.returnValue(-1614769200000 / 1000);
+            mediaPlayer.getCurrentTime.and.returnValue(-1000);
             jasmine.clock().tick(750);
 
             expect(loadUrlMock).not.toHaveBeenCalled();
@@ -542,7 +542,7 @@ require(
           it('should stop loading fragments when xml transforming has failed', function () {
             imscMock.fromXML.and.throwError();
 
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -560,7 +560,7 @@ require(
               callbackObject.onError();
             });
 
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -578,7 +578,7 @@ require(
               callbackObject.onLoad(null, '', 200);
             });
 
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -595,7 +595,7 @@ require(
         describe('rendering', function () {
           it('should generate and render when time has progressed past a known un-rendered subtitles', function () {
             var times = [[0, 1, 2, 3.84], [0, 3.84, 4, 7.68], [0, 7.68, 9, 9.7, 11.52]];
-            var epochStartTimeSeconds = (1614769200000 / 1000);
+            var epochStartTimeSeconds = (epochStartTimeMilliseconds / 1000);
             var counter = -1;
 
             times = times.map(function (time) {
@@ -622,7 +622,7 @@ require(
             });
 
             mediaPlayer.getCurrentTime.and.returnValue(2);
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(2.750);
             jasmine.clock().tick(750);

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -449,6 +449,9 @@ require(
           it('should not load fragments when auto start is false', function () {
             subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, {}, 1614769200000);
 
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+            jasmine.clock().tick(750);
+
             expect(loadUrlMock).not.toHaveBeenCalled();
           });
 
@@ -475,7 +478,8 @@ require(
             loadUrlMock.calls.reset();
             subtitles.stop();
 
-            jasmine.clock().tick(3.84 * 1000);
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+            jasmine.clock().tick(750);
 
             expect(loadUrlMock).not.toHaveBeenCalled();
           });
@@ -485,9 +489,13 @@ require(
 
             subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
 
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+            jasmine.clock().tick(750);
+
             loadUrlMock.calls.reset();
 
-            jasmine.clock().tick(3.84 * 1000);
+            mediaPlayer.getCurrentTime.and.returnValue(13.84);
+            jasmine.clock().tick(750);
 
             expect(loadUrlMock).not.toHaveBeenCalled();
           });
@@ -497,27 +505,35 @@ require(
               callbackObject.onError();
             });
 
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+            jasmine.clock().tick(750);
 
             loadUrlMock.calls.reset();
 
-            jasmine.clock().tick(3.84 * 1000);
+            mediaPlayer.getCurrentTime.and.returnValue(13.84);
+            jasmine.clock().tick(750);
 
             expect(loadUrlMock).not.toHaveBeenCalled();
           });
 
-          it('should stop loading fragments when the xml response is invalid', function () {
+          it('should not stop loading fragments when the xml response is invalid', function () {
             loadUrlMock.and.callFake(function (url, callbackObject) {
               callbackObject.onLoad(null, '', 200);
             });
 
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+            jasmine.clock().tick(750);
 
             loadUrlMock.calls.reset();
 
-            jasmine.clock().tick(3.84 * 1000);
+            mediaPlayer.getCurrentTime.and.returnValue(13.84);
+            jasmine.clock().tick(750);
 
-            expect(loadUrlMock).not.toHaveBeenCalled();
+            expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512818.test', jasmine.any(Object));
           });
         });
 

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -19,8 +19,6 @@ require(
       var loadUrlStubResponseXml = '<?xml>';
       var loadUrlStubResponseText;
 
-      var counter = 0;
-
       beforeEach(function (done) {
         injector = new Squire();
 
@@ -67,7 +65,6 @@ require(
         jasmine.clock().uninstall();
         imscMock.generateISD.calls.reset();
         imscMock.renderHTML.calls.reset();
-        counter = 0;
       });
 
       function progressTime (mediaPlayerTime) {
@@ -352,24 +349,28 @@ require(
         });
 
         describe('Loading fragments', function () {
-          it('should load the first three segments with correct urls on instantiation', function () {
-            mediaPlayer.getCurrentTime.and.returnValue(10);
+          it('should load the first three segments with correct urls on the first update interval', function () {
             // 1614769200000 = Wednesday, 3 March 2021 11:00:00
             subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+            jasmine.clock().tick(750);
 
             expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512815.test', jasmine.any(Object));
             expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512816.test', jasmine.any(Object));
             expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512817.test', jasmine.any(Object));
           });
 
-          it('should load the fragment two segments ahead of current time at a frequency of segmentLength', function () {
-            mediaPlayer.getCurrentTime.and.returnValue(10);
+          it('should load the fragment two segments ahead of current time', function () {
             // 1614769200000 = Wednesday, 3 March 2021 11:00:00
             subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
 
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+            jasmine.clock().tick(750);
+
             loadUrlMock.calls.reset();
             mediaPlayer.getCurrentTime.and.returnValue(13.84);
-            jasmine.clock().tick(3.84 * 1000);
+            jasmine.clock().tick(750);
 
             // At 13.84 seconds, we should be loading the segment correseponding to 21.52 seconds
             // 1614769221520 = Wednesday, 3 March 2021 11:00:21.52
@@ -377,48 +378,51 @@ require(
           });
 
           it('should not load a fragment if fragments array already contains it', function () {
-            mediaPlayer.getCurrentTime.and.returnValue(10);
             subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+            jasmine.clock().tick(750);
 
             loadUrlMock.calls.reset();
             mediaPlayer.getCurrentTime.and.returnValue(13.84);
-            jasmine.clock().tick(3.84 * 1000);
+            jasmine.clock().tick(750);
 
             expect(loadUrlMock).toHaveBeenCalledOnceWith('https://captions/420512818.test', jasmine.any(Object));
 
             mediaPlayer.getCurrentTime.and.returnValue(13.84); // time hasn't progressed. e.g. in paused state
-            jasmine.clock().tick(3.84 * 1000);
+            jasmine.clock().tick(750);
 
             expect(loadUrlMock).toHaveBeenCalledOnceWith('https://captions/420512818.test', jasmine.any(Object));
           });
 
           it('only keeps three fragments when playing', function () {
-            mediaPlayer.getCurrentTime.and.returnValue(10);
             subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+            jasmine.clock().tick(750);
 
             loadUrlMock.calls.reset();
             mediaPlayer.getCurrentTime.and.returnValue(13.84);
-            jasmine.clock().tick(3.84 * 1000);
+            jasmine.clock().tick(750);
 
             expect(loadUrlMock).toHaveBeenCalledOnceWith('https://captions/420512818.test', jasmine.any(Object));
 
             loadUrlMock.calls.reset();
             mediaPlayer.getCurrentTime.and.returnValue(10);
-            jasmine.clock().tick(3.84 * 1000);
+            jasmine.clock().tick(750);
 
             expect(loadUrlMock).toHaveBeenCalledOnceWith('https://captions/420512815.test', jasmine.any(Object));
           });
 
           it('load three new fragments when seeking back to a point where none of the segments are available', function () {
-            mediaPlayer.getCurrentTime.and.returnValue(100);
             subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
 
             mediaPlayer.getCurrentTime.and.returnValue(113.84);
-            jasmine.clock().tick(3.84 * 1000);
+            jasmine.clock().tick(750);
 
             loadUrlMock.calls.reset();
             mediaPlayer.getCurrentTime.and.returnValue(10);
-            jasmine.clock().tick(3.84 * 1000);
+            jasmine.clock().tick(750);
 
             expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512815.test', jasmine.any(Object));
             expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512816.test', jasmine.any(Object));
@@ -427,15 +431,14 @@ require(
           });
 
           it('loads three new fragments when seeking forwards to a point where none of the segments are available', function () {
-            mediaPlayer.getCurrentTime.and.returnValue(10);
             subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
 
             mediaPlayer.getCurrentTime.and.returnValue(13.84);
-            jasmine.clock().tick(3.84 * 1000);
+            jasmine.clock().tick(750);
 
             loadUrlMock.calls.reset();
             mediaPlayer.getCurrentTime.and.returnValue(100);
-            jasmine.clock().tick(3.84 * 1000);
+            jasmine.clock().tick(750);
 
             expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512838.test', jasmine.any(Object));
             expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512839.test', jasmine.any(Object));
@@ -450,13 +453,18 @@ require(
           });
 
           it('should load fragments when start is called and autoStart is false', function () {
-            mediaPlayer.getCurrentTime.and.returnValue(10);
             subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, {}, 1614769200000);
+
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+            jasmine.clock().tick(750);
 
             expect(loadUrlMock).not.toHaveBeenCalled();
 
             loadUrlMock.calls.reset();
             subtitles.start();
+
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+            jasmine.clock().tick(750);
 
             expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512815.test', jasmine.any(Object));
           });
@@ -514,21 +522,11 @@ require(
         });
 
         describe('rendering', function () {
-          it('should generate and render the first fragment loaded', function () {
-            mediaPlayer.getCurrentTime.and.returnValue(10);
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
-
-            var epochCurrentTime = (1614769200000 / 1000) + 10;
-
-            jasmine.clock().tick(751);
-
-            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(fromXmlReturn, epochCurrentTime);
-            expect(imscMock.renderHTML).toHaveBeenCalledTimes(1);
-          });
-
-          it('should generate and render when when time has progressed passed a known un-rendered subtitle', function () {
-            var times = [[], [1, 3, 8], [0, 8, 11, 13], [0, 13, 15, 18]];
+          it('should generate and render when time has progressed past a known un-rendered subtitles', function () {
+            var times = [[0, 1, 2, 3.84], [0, 3.84, 4, 7.68], [0, 7.68, 9, 9.7, 11.52]];
             var epochStartTimeSeconds = (1614769200000 / 1000);
+            var counter = -1;
+
             times = times.map(function (time) {
               return time.map(function (t) {
                 return t === 0 ? t : t + epochStartTimeSeconds;
@@ -552,25 +550,112 @@ require(
             mediaPlayer.getCurrentTime.and.returnValue(2.750);
             jasmine.clock().tick(750);
 
-            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 1}), epochStartTimeSeconds + 2.750);
+            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 0}), epochStartTimeSeconds + 2.750);
+            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, {});
 
             imscMock.generateISD.calls.reset();
+            imscMock.renderHTML.calls.reset();
             mediaPlayer.getCurrentTime.and.returnValue(3.5);
             jasmine.clock().tick(750);
 
-            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 1}), epochStartTimeSeconds + 3.5);
+            expect(imscMock.generateISD).not.toHaveBeenCalled();
+            expect(imscMock.renderHTML).not.toHaveBeenCalled();
 
             imscMock.generateISD.calls.reset();
-            mediaPlayer.getCurrentTime.and.returnValue(8.5);
+            imscMock.renderHTML.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(4.25);
             jasmine.clock().tick(750);
 
-            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 2}), epochStartTimeSeconds + 8.5);
+            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 1}), epochStartTimeSeconds + 4.25);
+            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, {});
 
             imscMock.generateISD.calls.reset();
-            mediaPlayer.getCurrentTime.and.returnValue(17);
+            imscMock.renderHTML.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(5);
             jasmine.clock().tick(750);
 
-            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 3}), epochStartTimeSeconds + 17);
+            expect(imscMock.generateISD).not.toHaveBeenCalled();
+            expect(imscMock.renderHTML).not.toHaveBeenCalled();
+
+            imscMock.generateISD.calls.reset();
+            imscMock.renderHTML.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(5.75);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).not.toHaveBeenCalled();
+            expect(imscMock.renderHTML).not.toHaveBeenCalled();
+
+            imscMock.generateISD.calls.reset();
+            imscMock.renderHTML.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(6.5);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).not.toHaveBeenCalled();
+            expect(imscMock.renderHTML).not.toHaveBeenCalled();
+
+            imscMock.generateISD.calls.reset();
+            imscMock.renderHTML.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(7.25);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).not.toHaveBeenCalled();
+            expect(imscMock.renderHTML).not.toHaveBeenCalled();
+
+            imscMock.generateISD.calls.reset();
+            imscMock.renderHTML.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(8);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 2}), epochStartTimeSeconds + 8);
+            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, {});
+
+            imscMock.generateISD.calls.reset();
+            imscMock.renderHTML.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(8.75);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).not.toHaveBeenCalled();
+            expect(imscMock.renderHTML).not.toHaveBeenCalled();
+
+            imscMock.generateISD.calls.reset();
+            imscMock.renderHTML.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(9.5);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 2}), epochStartTimeSeconds + 9.5);
+            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, {});
+
+            imscMock.generateISD.calls.reset();
+            imscMock.renderHTML.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(10.25);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 2}), epochStartTimeSeconds + 10.25);
+            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, {});
+
+            imscMock.generateISD.calls.reset();
+            imscMock.renderHTML.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(11);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).not.toHaveBeenCalled();
+            expect(imscMock.renderHTML).not.toHaveBeenCalled();
+
+            imscMock.generateISD.calls.reset();
+            imscMock.renderHTML.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(11.75);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 2}), epochStartTimeSeconds + 11.75);
+            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, {});
+
+            imscMock.generateISD.calls.reset();
+            imscMock.renderHTML.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(11.75);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).not.toHaveBeenCalled();
+            expect(imscMock.renderHTML).not.toHaveBeenCalled();
           });
         });
 
@@ -579,6 +664,8 @@ require(
           mediaPlayer.getCurrentTime.and.returnValue(10);
 
           subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+
+          jasmine.clock().tick(750);
 
           expect(imscMock.fromXML).toHaveBeenCalledWith('<tt xmlns="http://www.w3.org/ns/ttml"></tt>');
         });

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -484,6 +484,15 @@ require(
             expect(loadUrlMock).not.toHaveBeenCalled();
           });
 
+          it('should not try to load segments when the currentTime is not known by the player', function () {
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+
+            mediaPlayer.getCurrentTime.and.returnValue(-1614769200000 / 1000);
+            jasmine.clock().tick(750);
+
+            expect(loadUrlMock).not.toHaveBeenCalled();
+          });
+
           it('should stop loading fragments when xml transforming has failed', function () {
             imscMock.fromXML.and.throwError();
 

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -34,6 +34,12 @@ require(
         fromXmlReturn = {
           getMediaTimeEvents: function () {
             return [1, 3, 8];
+          },
+          head: {
+            styling: {}
+          },
+          body: {
+            contents: []
           }
         };
 
@@ -565,7 +571,13 @@ require(
                 getMediaTimeEvents: function () {
                   return times[counter];
                 },
-                mockCallId: counter
+                mockCallId: counter,
+                head: {
+                  styling: {}
+                },
+                body: {
+                  contents: []
+                }
               };
             });
 

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -89,10 +89,17 @@ require(
           expect(subtitles).toEqual(jasmine.objectContaining({start: jasmine.any(Function), stop: jasmine.any(Function), updatePosition: jasmine.any(Function), tearDown: jasmine.any(Function)}));
         });
 
-        it('Calls fromXML on creation with the text property of the response argument', function () {
+        it('Calls fromXML on creation with the extracted XML from the text property of the response argument', function () {
           subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement);
 
           expect(imscMock.fromXML).toHaveBeenCalledWith('<tt xmlns="http://www.w3.org/ns/ttml"></tt>');
+        });
+
+        it('Calls fromXML on creation with the original text property of the response argument if expected header is not found', function () {
+          loadUrlStubResponseText = '<?xml version="1.0" encoding="utf-8" extra property="something"?><tt xmlns="http://www.w3.org/ns/ttml"></tt>';
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement);
+
+          expect(imscMock.fromXML).toHaveBeenCalledWith(loadUrlStubResponseText);
         });
 
         it('autoplay argument starts the update loop', function () {

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -372,7 +372,7 @@ require(
       });
 
       describe('Live subtitles', function () {
-        var epochStartTimeMilliseconds = 1614769200000; // Wednesday, 3 March 2021 11:00:00
+        var epochStartTimeSeconds = 1614769200; // Wednesday, 3 March 2021 11:00:00
         beforeEach(function () {
           stubCaptions = {
             captionsUrl: 'https://captions/$segment$.test',
@@ -386,7 +386,7 @@ require(
 
         describe('Loading fragments', function () {
           it('should load the first three segments with correct urls on the first update interval', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -397,8 +397,8 @@ require(
           });
 
           it('should load the fragment two segments ahead of current time', function () {
-            // epochStartTimeMilliseconds = Wednesday, 3 March 2021 11:00:00
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            // epochStartTimeSeconds = Wednesday, 3 March 2021 11:00:00
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -413,7 +413,7 @@ require(
           });
 
           it('should not load a fragment if fragments array already contains it', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -431,7 +431,7 @@ require(
           });
 
           it('only keeps three fragments when playing', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -450,7 +450,7 @@ require(
           });
 
           it('load three new fragments when seeking back to a point where none of the segments are available', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(113.84);
             jasmine.clock().tick(750);
@@ -466,7 +466,7 @@ require(
           });
 
           it('loads three new fragments when seeking forwards to a point where none of the segments are available', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(13.84);
             jasmine.clock().tick(750);
@@ -482,7 +482,7 @@ require(
           });
 
           it('should not load fragments when auto start is false', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -491,7 +491,7 @@ require(
           });
 
           it('should load fragments when start is called and autoStart is false', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -511,7 +511,7 @@ require(
             loadUrlStubResponseText = 'stuff that might exists before the xml string' + loadUrlStubResponseText;
             mediaPlayer.getCurrentTime.and.returnValue(10);
 
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             jasmine.clock().tick(750);
 
@@ -519,7 +519,7 @@ require(
           });
 
           it('should stop loading fragments when stop is called', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             loadUrlMock.calls.reset();
             subtitles.stop();
@@ -531,7 +531,7 @@ require(
           });
 
           it('should not try to load segments when the currentTime is not known by the player', function () {
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(-1000);
             jasmine.clock().tick(750);
@@ -542,7 +542,7 @@ require(
           it('should stop loading fragments when xml transforming has failed', function () {
             imscMock.fromXML.and.throwError();
 
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -560,7 +560,7 @@ require(
               callbackObject.onError();
             });
 
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -578,7 +578,7 @@ require(
               callbackObject.onLoad(null, '', 200);
             });
 
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -595,7 +595,6 @@ require(
         describe('rendering', function () {
           it('should generate and render when time has progressed past a known un-rendered subtitles', function () {
             var times = [[0, 1, 2, 3.84], [0, 3.84, 4, 7.68], [0, 7.68, 9, 9.7, 11.52]];
-            var epochStartTimeSeconds = (epochStartTimeMilliseconds / 1000);
             var counter = -1;
 
             times = times.map(function (time) {
@@ -622,7 +621,7 @@ require(
             });
 
             mediaPlayer.getCurrentTime.and.returnValue(2);
-            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeMilliseconds);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(2.750);
             jasmine.clock().tick(750);

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -485,6 +485,17 @@ require(
             expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512815.test', jasmine.any(Object));
           });
 
+          it('calls fromXML with xml string where responseText contains more than a simple xml string', function () {
+            loadUrlStubResponseText = 'stuff that might exists before the xml string' + loadUrlStubResponseText;
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+
+            jasmine.clock().tick(750);
+
+            expect(imscMock.fromXML).toHaveBeenCalledWith('<tt xmlns="http://www.w3.org/ns/ttml"></tt>');
+          });
+
           it('should stop loading fragments when stop is called', function () {
             subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
 
@@ -701,17 +712,6 @@ require(
             expect(imscMock.generateISD).not.toHaveBeenCalled();
             expect(imscMock.renderHTML).not.toHaveBeenCalled();
           });
-        });
-
-        it('calls fromXML with xml string where responseText contains more than a simple xml string', function () {
-          loadUrlStubResponseText = 'stuff that might exists before the xml string' + loadUrlStubResponseText;
-          mediaPlayer.getCurrentTime.and.returnValue(10);
-
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
-
-          jasmine.clock().tick(750);
-
-          expect(imscMock.fromXML).toHaveBeenCalledWith('<tt xmlns="http://www.w3.org/ns/ttml"></tt>');
         });
       });
     });

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -13,7 +13,9 @@ require(
       var fromXmlReturn;
       var mediaPlayer;
       var subtitles;
-      var stubCaptionsUrl = 'http://stub-captions.test';
+      var stubCaptions = {
+        captionsUrl: 'http://stub-captions.test'
+      };
 
       var loadUrlMock;
       var loadUrlStubResponseXml = '<?xml>';
@@ -70,19 +72,19 @@ require(
         });
 
         it('is constructed with the correct interface', function () {
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, false, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement);
 
           expect(subtitles).toEqual(jasmine.objectContaining({start: jasmine.any(Function), stop: jasmine.any(Function), updatePosition: jasmine.any(Function), tearDown: jasmine.any(Function)}));
         });
 
         it('Calls fromXML on creation with the text property of the response argument', function () {
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, false, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement);
 
           expect(imscMock.fromXML).toHaveBeenCalledWith(loadUrlStubResponseText);
         });
 
         it('autoplay argument starts the update loop', function () {
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, true, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement);
           progressTime(1.5);
 
           expect(imscMock.generateISD).toHaveBeenCalledTimes(1);
@@ -92,7 +94,7 @@ require(
 
         it('fires tranformError plugin if IMSC throws an exception when parsing', function () {
           imscMock.fromXML.and.throwError();
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, true, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement);
 
           expect(pluginsMock.interface.onSubtitlesTransformError).toHaveBeenCalledTimes(1);
         });
@@ -101,7 +103,7 @@ require(
           loadUrlMock.and.callFake(function (url, callbackObject) {
             callbackObject.onError();
           });
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, false, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement);
 
           expect(pluginsMock.interface.onSubtitlesLoadError).toHaveBeenCalledTimes(1);
         });
@@ -110,20 +112,20 @@ require(
           loadUrlMock.and.callFake(function (url, callbackObject) {
             callbackObject.onLoad(null, '', 200);
           });
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, false, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement);
 
           expect(pluginsMock.interface.onSubtitlesTransformError).toHaveBeenCalledTimes(1);
         });
 
         it('does not attempt to load subtitles if there is no captions url', function () {
-          subtitles = ImscSubtitles(mediaPlayer, undefined, false, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, {captionsUrl: undefined}, false, mockParentElement);
 
           expect(loadUrlMock).not.toHaveBeenCalled();
         });
 
         it('does not try to generate and render when xml transforming has failed', function () {
           imscMock.fromXML.and.throwError();
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, true, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement);
 
           progressTime(1.5);
 
@@ -132,15 +134,15 @@ require(
         });
 
         it('Should load the captions url', function () {
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, true, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement);
 
-          expect(loadUrlMock).toHaveBeenCalledWith(stubCaptionsUrl, jasmine.any(Object));
+          expect(loadUrlMock).toHaveBeenCalledWith(stubCaptions.captionsUrl, jasmine.any(Object));
         });
       });
 
       describe('update interval', function () {
         beforeEach(function () {
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, false, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement);
         });
 
         afterEach(function () {
@@ -149,7 +151,7 @@ require(
 
         it('cannot start when xml transforming has failed', function () {
           imscMock.fromXML.and.throwError();
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, false, mockParentElement);
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement);
 
           subtitles.start();
           progressTime(1.5);
@@ -169,7 +171,7 @@ require(
         it('overrides the subtitles styling metadata with supplied defaults when rendering', function () {
           var styleOpts = { backgroundColour: 'black', fontFamily: 'Arial' };
           var expectedOpts = { spanBackgroundColorAdjust: { transparent: 'black' }, fontFamily: 'Arial' };
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, false, mockParentElement, styleOpts);
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, styleOpts);
 
           subtitles.start();
           progressTime(9);
@@ -192,7 +194,7 @@ require(
           var customStyleOpts = { size: 0.7, lineHeight: 0.9 };
           var expectedOpts = { spanBackgroundColorAdjust: { transparent: 'black' }, fontFamily: 'Arial', sizeAdjust: 0.7, lineHeightAdjust: 0.9 };
 
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, false, mockParentElement, defaultStyleOpts);
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, defaultStyleOpts);
 
           subtitles.start();
           subtitles.customise(customStyleOpts, true);
@@ -317,7 +319,7 @@ require(
 
       describe('example rendering', function () {
         it('should call fromXML, generate and render when renderExample is called', function () {
-          subtitles = ImscSubtitles(mediaPlayer, stubCaptionsUrl, false, mockParentElement, {});
+          subtitles = ImscSubtitles(mediaPlayer, stubCaptions, false, mockParentElement, {});
           imscMock.fromXML.calls.reset();
 
           subtitles.renderExample('', {}, {});

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -19,6 +19,8 @@ require(
       var loadUrlStubResponseXml = '<?xml>';
       var loadUrlStubResponseText;
 
+      var counter = 0;
+
       beforeEach(function (done) {
         injector = new Squire();
 
@@ -36,7 +38,9 @@ require(
             return [1, 3, 8];
           }
         };
+
         imscMock = jasmine.createSpyObj('imscjs-lib', ['fromXML', 'generateISD', 'renderHTML']);
+        imscMock.generateISD.and.returnValue({ contents: ['mockContents'] });
         imscMock.fromXML.and.returnValue(fromXmlReturn);
 
         pluginInterfaceMock = jasmine.createSpyObj('interfaceMock', ['onSubtitlesRenderError', 'onSubtitlesTransformError', 'onSubtitlesLoadError']);
@@ -63,6 +67,7 @@ require(
         jasmine.clock().uninstall();
         imscMock.generateISD.calls.reset();
         imscMock.renderHTML.calls.reset();
+        counter = 0;
       });
 
       function progressTime (mediaPlayerTime) {
@@ -180,7 +185,7 @@ require(
           subtitles.start();
           progressTime(9);
 
-          expect(imscMock.renderHTML).toHaveBeenCalledWith(undefined, jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, expectedOpts);
+          expect(imscMock.renderHTML).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, expectedOpts);
         });
 
         it('overrides the subtitles styling metadata with supplied custom styles when rendering', function () {
@@ -190,7 +195,7 @@ require(
           subtitles.start();
           subtitles.customise(styleOpts, true);
 
-          expect(imscMock.renderHTML).toHaveBeenCalledWith(undefined, jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, expectedOpts);
+          expect(imscMock.renderHTML).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, expectedOpts);
         });
 
         it('merges the current subtitles styling metadata with new supplied custom styles when rendering', function () {
@@ -203,7 +208,7 @@ require(
           subtitles.start();
           subtitles.customise(customStyleOpts, true);
 
-          expect(imscMock.renderHTML).toHaveBeenCalledWith(undefined, jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, expectedOpts);
+          expect(imscMock.renderHTML).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, expectedOpts);
         });
 
         it('does not render custom styles when subtitles are not enabled', function () {
@@ -340,6 +345,10 @@ require(
             captionsUrl: 'https://captions/$segment$.test',
             segmentLength: 3.84
           };
+        });
+
+        afterEach(function () {
+          subtitles.stop();
         });
 
         describe('Loading fragments', function () {
@@ -504,8 +513,70 @@ require(
           });
         });
 
+        describe('rendering', function () {
+          it('should generate and render the first fragment loaded', function () {
+            mediaPlayer.getCurrentTime.and.returnValue(10);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+
+            var epochCurrentTime = (1614769200000 / 1000) + 10;
+
+            jasmine.clock().tick(751);
+
+            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(fromXmlReturn, epochCurrentTime);
+            expect(imscMock.renderHTML).toHaveBeenCalledTimes(1);
+          });
+
+          it('should generate and render when when time has progressed passed a known un-rendered subtitle', function () {
+            var times = [[], [1, 3, 8], [0, 8, 11, 13], [0, 13, 15, 18]];
+            var epochStartTimeSeconds = (1614769200000 / 1000);
+            times = times.map(function (time) {
+              return time.map(function (t) {
+                return t === 0 ? t : t + epochStartTimeSeconds;
+              });
+            });
+
+            imscMock.fromXML.and.callFake(function () {
+              counter = counter + 1;
+
+              return {
+                getMediaTimeEvents: function () {
+                  return times[counter];
+                },
+                mockCallId: counter
+              };
+            });
+
+            mediaPlayer.getCurrentTime.and.returnValue(2);
+            subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
+
+            mediaPlayer.getCurrentTime.and.returnValue(2.750);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 1}), epochStartTimeSeconds + 2.750);
+
+            imscMock.generateISD.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(3.5);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 1}), epochStartTimeSeconds + 3.5);
+
+            imscMock.generateISD.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(8.5);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 2}), epochStartTimeSeconds + 8.5);
+
+            imscMock.generateISD.calls.reset();
+            mediaPlayer.getCurrentTime.and.returnValue(17);
+            jasmine.clock().tick(750);
+
+            expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 3}), epochStartTimeSeconds + 17);
+          });
+        });
+
         it('calls fromXML with xml string where responseText contains more than a simple xml string', function () {
           loadUrlStubResponseText = 'stuff that might exists before the xml string' + loadUrlStubResponseText;
+          mediaPlayer.getCurrentTime.and.returnValue(10);
 
           subtitles = ImscSubtitles(mediaPlayer, stubCaptions, true, mockParentElement, {}, 1614769200000);
 

--- a/script-test/subtitles/legacysubtitles.js
+++ b/script-test/subtitles/legacysubtitles.js
@@ -6,30 +6,39 @@ require(
   function (Squire, TransportControlPosition) {
     'use strict';
 
-    var injector = new Squire();
+    var injector;
     var mockRendererSpy;
     var legacySubtitles;
     var LegacySubtitlesWithMocks;
     var parentElement = document.createElement('div');
-
-    var mockText = '<tt xmlns="http://www.w3.org/2006/10/ttaf1"> </tt>';
-    var parser = new DOMParser();
-    var mockXml = parser.parseFromString(mockText, 'application/xml');
-    var mockResponse = {
-      text: mockText,
-      xml: mockXml
-    };
+    var loadUrlMock;
+    var loadUrlStubResponseXml = '<?xml>';
+    var loadUrlStubResponseText = 'loadUrlStubResponseText';
+    var pluginInterfaceMock;
+    var pluginsMock;
+    var stubCaptionsUrl = 'http://stub-captions.test';
 
     describe('Legacy Subtitles', function () {
       beforeEach(function (done) {
+        injector = new Squire();
         mockRendererSpy = jasmine.createSpyObj('mockRenderer', ['start', 'stop', 'render']);
         var mockRendererConstructor = function () {
           return mockRendererSpy;
         };
         mockRendererSpy.render.and.returnValue(document.createElement('div'));
 
+        loadUrlMock = jasmine.createSpy();
+        loadUrlMock.and.callFake(function (url, callbackObject) {
+          callbackObject.onLoad(loadUrlStubResponseXml, loadUrlStubResponseText, 200);
+        });
+
+        pluginInterfaceMock = jasmine.createSpyObj('interfaceMock', ['onSubtitlesRenderError', 'onSubtitlesTransformError', 'onSubtitlesLoadError']);
+        pluginsMock = { interface: pluginInterfaceMock };
+
         injector.mock({
-          'bigscreenplayer/subtitles/renderer': mockRendererConstructor
+          'bigscreenplayer/subtitles/renderer': mockRendererConstructor,
+          'bigscreenplayer/utils/loadurl': loadUrlMock,
+          'bigscreenplayer/plugins': pluginsMock
         });
         injector.require(['bigscreenplayer/subtitles/legacysubtitles'], function (LegacySubtitles) {
           LegacySubtitlesWithMocks = LegacySubtitles;
@@ -39,24 +48,54 @@ require(
 
       afterEach(function () {
         legacySubtitles.tearDown();
+        mockRendererSpy.start.calls.reset();
+        mockRendererSpy.stop.calls.reset();
+        mockRendererSpy.render.calls.reset();
+      });
+
+      it('Should load the captions url', function () {
+        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
+
+        expect(loadUrlMock).toHaveBeenCalledWith(stubCaptionsUrl, jasmine.any(Object));
       });
 
       it('Has a player subtitles class', function () {
-        legacySubtitles = new LegacySubtitlesWithMocks(null, mockResponse, false, parentElement);
+        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
 
         expect(parentElement.firstChild.className).toContain('playerCaptions');
       });
 
+      it('Should fire onSubtitlesLoadError plugin if loading of XML fails', function () {
+        loadUrlMock.and.callFake(function (url, callbackObject) {
+          callbackObject.onError();
+        });
+        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
+
+        expect(pluginsMock.interface.onSubtitlesLoadError).toHaveBeenCalledTimes(1);
+      });
+
+      it('Should fire subtitleTransformError if responseXML from the loader is invalid', function () {
+        loadUrlMock.and.callFake(function (url, callbackObject) {
+          callbackObject.onLoad(null, '', 200);
+        });
+        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
+
+        expect(pluginsMock.interface.onSubtitlesTransformError).toHaveBeenCalledTimes(1);
+      });
+
       describe('Start', function () {
         it('Starts if there is valid xml in the response object', function () {
-          legacySubtitles = new LegacySubtitlesWithMocks(null, mockResponse, false, parentElement);
+          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
           legacySubtitles.start();
 
           expect(mockRendererSpy.start).toHaveBeenCalledWith();
         });
 
         it('Does not start subtitles if there is invalid xml in the response object', function () {
-          legacySubtitles = new LegacySubtitlesWithMocks(null, {xml: undefined}, false, parentElement);
+          loadUrlMock.and.callFake(function (url, callbackObject) {
+            callbackObject.onError();
+          });
+          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
           legacySubtitles.start();
 
           expect(mockRendererSpy.start).not.toHaveBeenCalledWith();
@@ -65,14 +104,18 @@ require(
 
       describe('Stop', function () {
         it('Stops the subtitles if there is valid xml in the response object', function () {
-          legacySubtitles = new LegacySubtitlesWithMocks(null, mockResponse, false, parentElement);
+          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
           legacySubtitles.stop();
 
           expect(mockRendererSpy.stop).toHaveBeenCalledWith();
         });
 
         it('Does not stop the subtitles if there is is invalid xml in the response object', function () {
-          legacySubtitles = new LegacySubtitlesWithMocks(null, {xml: undefined}, false, parentElement);
+          loadUrlMock.and.callFake(function (url, callbackObject) {
+            callbackObject.onError();
+          });
+
+          legacySubtitles = new LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
           legacySubtitles.stop();
 
           expect(mockRendererSpy.stop).not.toHaveBeenCalledWith();
@@ -81,7 +124,7 @@ require(
 
       describe('Updating position', function () {
         beforeEach(function () {
-          legacySubtitles = new LegacySubtitlesWithMocks(null, mockResponse, true, parentElement);
+          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, true, parentElement);
         });
 
         [

--- a/script-test/subtitles/legacysubtitles.js
+++ b/script-test/subtitles/legacysubtitles.js
@@ -16,7 +16,9 @@ require(
     var loadUrlStubResponseText = 'loadUrlStubResponseText';
     var pluginInterfaceMock;
     var pluginsMock;
-    var stubCaptionsUrl = 'http://stub-captions.test';
+    var stubCaptions = {
+      captionsUrl: 'http://stub-captions.test'
+    };
 
     describe('Legacy Subtitles', function () {
       beforeEach(function (done) {
@@ -54,13 +56,13 @@ require(
       });
 
       it('Should load the captions url', function () {
-        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
+        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
 
-        expect(loadUrlMock).toHaveBeenCalledWith(stubCaptionsUrl, jasmine.any(Object));
+        expect(loadUrlMock).toHaveBeenCalledWith(stubCaptions.captionsUrl, jasmine.any(Object));
       });
 
       it('Has a player subtitles class', function () {
-        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
+        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
 
         expect(parentElement.firstChild.className).toContain('playerCaptions');
       });
@@ -69,7 +71,7 @@ require(
         loadUrlMock.and.callFake(function (url, callbackObject) {
           callbackObject.onError();
         });
-        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
+        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
 
         expect(pluginsMock.interface.onSubtitlesLoadError).toHaveBeenCalledTimes(1);
       });
@@ -78,14 +80,14 @@ require(
         loadUrlMock.and.callFake(function (url, callbackObject) {
           callbackObject.onLoad(null, '', 200);
         });
-        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
+        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
 
         expect(pluginsMock.interface.onSubtitlesTransformError).toHaveBeenCalledTimes(1);
       });
 
       describe('Start', function () {
         it('Starts if there is valid xml in the response object', function () {
-          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
+          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
           legacySubtitles.start();
 
           expect(mockRendererSpy.start).toHaveBeenCalledWith();
@@ -95,7 +97,7 @@ require(
           loadUrlMock.and.callFake(function (url, callbackObject) {
             callbackObject.onError();
           });
-          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
+          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
           legacySubtitles.start();
 
           expect(mockRendererSpy.start).not.toHaveBeenCalledWith();
@@ -104,7 +106,7 @@ require(
 
       describe('Stop', function () {
         it('Stops the subtitles if there is valid xml in the response object', function () {
-          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
+          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
           legacySubtitles.stop();
 
           expect(mockRendererSpy.stop).toHaveBeenCalledWith();
@@ -115,7 +117,7 @@ require(
             callbackObject.onError();
           });
 
-          legacySubtitles = new LegacySubtitlesWithMocks(null, stubCaptionsUrl, false, parentElement);
+          legacySubtitles = new LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
           legacySubtitles.stop();
 
           expect(mockRendererSpy.stop).not.toHaveBeenCalledWith();
@@ -124,7 +126,7 @@ require(
 
       describe('Updating position', function () {
         beforeEach(function () {
-          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptionsUrl, true, parentElement);
+          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, true, parentElement);
         });
 
         [

--- a/script-test/subtitles/subtitles.js
+++ b/script-test/subtitles/subtitles.js
@@ -207,14 +207,48 @@ require(
         });
 
         describe('available', function () {
-          it('returns true if a url exists at construction', function () {
-            var subtitles = Subtitles(null, stubCaptions, true, null);
+          it('should return true if VOD and url exists', function () {
+            var subtitles = Subtitles(null, {captionsUrl: 'http://captions.example.test'}, true, null);
 
             expect(subtitles.available()).toEqual(true);
           });
 
-          it('returns false if no url exists at construction', function () {
+          it('should return true if LIVE, url exists and no override', function () {
+            var subtitles = Subtitles(null, {captionsUrl: 'http://captions.example.test', segmentLength: 3.84}, true, null);
+
+            expect(subtitles.available()).toEqual(true);
+          });
+
+          it('should return true if VOD, url exists and legacy override exists', function () {
+            window.bigscreenPlayer = {
+              overrides: {
+                legacySubtitles: true
+              }
+            };
+            var subtitles = Subtitles(null, {captionsUrl: 'http://captions.example.test'}, true, null);
+
+            expect(subtitles.available()).toEqual(true);
+          });
+
+          it('should return false if LIVE, url exists and legacy override exists', function () {
+            window.bigscreenPlayer = {
+              overrides: {
+                legacySubtitles: true
+              }
+            };
+            var subtitles = Subtitles(null, {captionsUrl: 'http://captions.example.test', segmentLength: 3.84}, true, null);
+
+            expect(subtitles.available()).toEqual(false);
+          });
+
+          it('should return false if VOD and no url exists', function () {
             var subtitles = Subtitles(null, {captionsUrl: undefined}, true, null);
+
+            expect(subtitles.available()).toEqual(false);
+          });
+
+          it('should return false if LIVE and no url exists', function () {
+            var subtitles = Subtitles(null, {captionsUrl: undefined, segmentLength: 3.84}, true, null);
 
             expect(subtitles.available()).toEqual(false);
           });

--- a/script-test/subtitles/subtitles.js
+++ b/script-test/subtitles/subtitles.js
@@ -5,6 +5,9 @@ require(
     var Subtitles;
     var subtitlesMock;
     var injector;
+    var stubCaptions = {
+      captionsUrl: 'http://captions.example.test'
+    };
 
     describe('Subtitles', function () {
       beforeEach(function () {
@@ -37,10 +40,9 @@ require(
 
           it('implementation is available when legacy subtitles override is true', function () {
             var mockMediaPlayer = {};
-            var url = 'http://captions.example.test';
             var autoStart = true;
             var mockPlaybackElement = document.createElement('div');
-            Subtitles(mockMediaPlayer, url, autoStart, mockPlaybackElement);
+            Subtitles(mockMediaPlayer, stubCaptions, autoStart, mockPlaybackElement);
 
             expect(subtitlesMock).toHaveBeenCalledTimes(1);
           });
@@ -62,11 +64,10 @@ require(
 
           it('implementation is available when legacy subtitles override is false', function () {
             var mockMediaPlayer = {};
-            var url = 'http://captions.example.test';
             var autoStart = true;
             var mockPlaybackElement = document.createElement('div');
 
-            Subtitles(mockMediaPlayer, url, autoStart, mockPlaybackElement);
+            Subtitles(mockMediaPlayer, stubCaptions, autoStart, mockPlaybackElement);
 
             expect(subtitlesMock).toHaveBeenCalledTimes(1);
           });
@@ -104,20 +105,19 @@ require(
         describe('construction', function () {
           it('calls subtitles strategy with the correct arguments', function () {
             var mockMediaPlayer = {};
-            var url = 'http://captions.example.test';
             var autoStart = true;
             var mockPlaybackElement = document.createElement('div');
             var customDefaultStyle = {};
 
-            Subtitles(mockMediaPlayer, url, autoStart, mockPlaybackElement, customDefaultStyle);
+            Subtitles(mockMediaPlayer, stubCaptions, autoStart, mockPlaybackElement, customDefaultStyle);
 
-            expect(subtitlesContainer).toHaveBeenCalledWith(mockMediaPlayer, url, autoStart, mockPlaybackElement, customDefaultStyle);
+            expect(subtitlesContainer).toHaveBeenCalledWith(mockMediaPlayer, stubCaptions, autoStart, mockPlaybackElement, customDefaultStyle);
           });
         });
 
         describe('show', function () {
           it('should start subtitles when enabled and available', function () {
-            var subtitles = Subtitles(null, 'http://some-url.test', null, null);
+            var subtitles = Subtitles(null, stubCaptions, null, null);
             subtitles.enable();
             subtitles.show();
 
@@ -125,7 +125,7 @@ require(
           });
 
           it('should not start subtitles when disabled and available', function () {
-            var subtitles = Subtitles(null, 'http://some-url.test', null, null);
+            var subtitles = Subtitles(null, stubCaptions, null, null);
             subtitles.disable();
             subtitles.show();
 
@@ -133,7 +133,7 @@ require(
           });
 
           it('should not start subtitles when enabled and unavailable', function () {
-            var subtitles = Subtitles(null, undefined, null, null);
+            var subtitles = Subtitles(null, {captionsUrl: undefined}, null, null);
             subtitles.enable();
             subtitles.show();
 
@@ -141,7 +141,7 @@ require(
           });
 
           it('should not start subtitles when disabled and unavailable', function () {
-            var subtitles = Subtitles(null, undefined, null, null);
+            var subtitles = Subtitles(null, {captionsUrl: undefined}, null, null);
             subtitles.disable();
             subtitles.show();
 
@@ -151,7 +151,7 @@ require(
 
         describe('hide', function () {
           it('should stop subtitles when available', function () {
-            var subtitles = Subtitles(null, 'http://some-url.test', null, null);
+            var subtitles = Subtitles(null, stubCaptions, null, null);
             subtitles.hide();
 
             expect(subtitlesContainerSpies.stop).toHaveBeenCalledWith();
@@ -160,7 +160,7 @@ require(
 
         describe('enable', function () {
           it('should set enabled state to true', function () {
-            var subtitles = Subtitles(null, 'http://some-url.test', null, null);
+            var subtitles = Subtitles(null, stubCaptions, null, null);
             subtitles.enable();
 
             expect(subtitles.enabled()).toEqual(true);
@@ -169,7 +169,7 @@ require(
 
         describe('disable', function () {
           it('should set enabled state to false', function () {
-            var subtitles = Subtitles(null, 'http://some-url.test', null, null);
+            var subtitles = Subtitles(null, stubCaptions, null, null);
             subtitles.disable();
 
             expect(subtitlesContainerSpies.stop).not.toHaveBeenCalled();
@@ -179,26 +179,26 @@ require(
 
         describe('enabled', function () {
           it('should return true if subtitles are enabled at construction', function () {
-            var subtitles = Subtitles(null, undefined, true, null);
+            var subtitles = Subtitles(null, {captionsUrl: undefined}, true, null);
 
             expect(subtitles.enabled()).toEqual(true);
           });
 
           it('should return true if subtitles are enabled by an api call', function () {
-            var subtitles = Subtitles(null, undefined, false, null);
+            var subtitles = Subtitles(null, {captionsUrl: undefined}, false, null);
             subtitles.enable();
 
             expect(subtitles.enabled()).toEqual(true);
           });
 
           it('should return false if subtitles are disabled at construction', function () {
-            var subtitles = Subtitles(null, undefined, false, null);
+            var subtitles = Subtitles(null, {captionsUrl: undefined}, false, null);
 
             expect(subtitles.enabled()).toEqual(false);
           });
 
           it('should return true if subtitles are disabled by an api call', function () {
-            var subtitles = Subtitles(null, undefined, true, null);
+            var subtitles = Subtitles(null, {captionsUrl: undefined}, true, null);
             subtitles.disable();
 
             expect(subtitles.enabled()).toEqual(false);
@@ -207,13 +207,13 @@ require(
 
         describe('available', function () {
           it('returns true if a url exists at construction', function () {
-            var subtitles = Subtitles(null, 'http://some-url.test', true, null);
+            var subtitles = Subtitles(null, stubCaptions, true, null);
 
             expect(subtitles.available()).toEqual(true);
           });
 
           it('returns false if no url exists at construction', function () {
-            var subtitles = Subtitles(null, undefined, true, null);
+            var subtitles = Subtitles(null, {captionsUrl: undefined}, true, null);
 
             expect(subtitles.available()).toEqual(false);
           });
@@ -221,7 +221,7 @@ require(
 
         describe('setPosition', function () {
           it('calls through to subtitlesContainer updatePosition', function () {
-            var subtitles = Subtitles(null, 'http://some-url.test', true, null);
+            var subtitles = Subtitles(null, stubCaptions, true, null);
             subtitles.setPosition('pos');
 
             expect(subtitlesContainerSpies.updatePosition).toHaveBeenCalledWith('pos');
@@ -230,7 +230,7 @@ require(
 
         describe('customise', function () {
           it('passes through custom style object and enabled state to subtitlesContainer customise function', function () {
-            var subtitles = Subtitles(null, 'http://some-url.test', true, null);
+            var subtitles = Subtitles(null, stubCaptions, true, null);
             var customStyleObj = { size: 0.7 };
             subtitles.customise(customStyleObj);
 
@@ -240,7 +240,7 @@ require(
 
         describe('renderExample', function () {
           it('calls subtitlesContainer renderExample function with correct values', function () {
-            var subtitles = Subtitles(null, 'http://some-url.test', true, null);
+            var subtitles = Subtitles(null, stubCaptions, true, null);
             var exampleUrl = '';
             var customStyleObj = { size: 0.7 };
             var safePosition = { left: 30, top: 0 };
@@ -252,7 +252,7 @@ require(
 
         describe('clearExample', function () {
           it('calls subtitlesContainer clearExample function ', function () {
-            var subtitles = Subtitles(null, 'http://some-url.test', true, null);
+            var subtitles = Subtitles(null, stubCaptions, true, null);
             subtitles.clearExample();
 
             expect(subtitlesContainerSpies.clearExample).toHaveBeenCalledTimes(1);
@@ -261,7 +261,7 @@ require(
 
         describe('tearDown', function () {
           it('calls through to subtitlesContainer tearDown', function () {
-            var subtitles = Subtitles(null, 'http://some-url.test', true, null);
+            var subtitles = Subtitles(null, stubCaptions, true, null);
             subtitles.tearDown();
 
             expect(subtitlesContainerSpies.tearDown).toHaveBeenCalledTimes(1);

--- a/script-test/subtitles/subtitles.js
+++ b/script-test/subtitles/subtitles.js
@@ -108,10 +108,11 @@ require(
             var autoStart = true;
             var mockPlaybackElement = document.createElement('div');
             var customDefaultStyle = {};
+            var windowStartTime = '123456';
 
-            Subtitles(mockMediaPlayer, stubCaptions, autoStart, mockPlaybackElement, customDefaultStyle);
+            Subtitles(mockMediaPlayer, stubCaptions, autoStart, mockPlaybackElement, customDefaultStyle, windowStartTime);
 
-            expect(subtitlesContainer).toHaveBeenCalledWith(mockMediaPlayer, stubCaptions, autoStart, mockPlaybackElement, customDefaultStyle);
+            expect(subtitlesContainer).toHaveBeenCalledWith(mockMediaPlayer, stubCaptions, autoStart, mockPlaybackElement, customDefaultStyle, windowStartTime);
           });
         });
 

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -135,7 +135,8 @@ define('bigscreenplayer/bigscreenplayer',
           bigscreenPlayerData.media.captions || { captionsUrl: bigscreenPlayerData.media.captionsUrl },
           enableSubtitles,
           playbackElement,
-          bigscreenPlayerData.media.subtitleCustomisation
+          bigscreenPlayerData.media.subtitleCustomisation,
+          getWindowStartTime()
         );
 
         if (enableSubtitles) {

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -132,7 +132,7 @@ define('bigscreenplayer/bigscreenplayer',
 
         subtitles = Subtitles(
           playerComponent,
-          bigscreenPlayerData.media.captionsUrl,
+          bigscreenPlayerData.media.captions || { captionsUrl: bigscreenPlayerData.media.captionsUrl },
           enableSubtitles,
           playbackElement,
           bigscreenPlayerData.media.subtitleCustomisation

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -136,7 +136,7 @@ define('bigscreenplayer/bigscreenplayer',
           enableSubtitles,
           playbackElement,
           bigscreenPlayerData.media.subtitleCustomisation,
-          getWindowStartTime()
+          getWindowStartTime() / 1000
         );
 
         if (enableSubtitles) {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -224,14 +224,14 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         if (liveSubtitles) {
           xml.head.styling.initials = {
             'http://www.w3.org/ns/ttml#styling displayAlign': 'after',
-            'http://www.w3.org/ns/ttml#styling lineHeight': '143%',
+            'http://www.w3.org/ns/ttml#styling lineHeight': '133%',
             'http://www.w3.org/ns/ttml#styling overflow': 'visible'
           };
 
           for (var i = 0; i < xml.body.contents.length; i++) {
             for (var j = 0; j < xml.body.contents[i].contents.length; j++) {
               xml.body.contents[i].contents[j].styleAttrs['http://www.w3.org/ns/ttml#styling fontFamily'] = ['ReithSans', 'Arial', 'Roboto', 'proportionalSansSerif', 'default'];
-              xml.body.contents[i].contents[j].styleAttrs['http://www.w3.org/ns/ttml#styling fontSize'].value = 101;
+              xml.body.contents[i].contents[j].styleAttrs['http://www.w3.org/ns/ttml#styling fontSize'].value = 94;
             }
           }
         }

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -42,11 +42,8 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function calculateSegmentNumber (offset) {
-        var currentTime = mediaPlayer.getCurrentTime();
-        if (currentTime > 0) {
-          var epochSeconds = (windowStartTime / 1000) + mediaPlayer.getCurrentTime();
-          return Math.floor(epochSeconds / captions.segmentLength) + offset;
-        }
+        var epochSeconds = (windowStartTime / 1000) + mediaPlayer.getCurrentTime();
+        return Math.floor(epochSeconds / captions.segmentLength) + offset;
       }
 
       function loadSegment (url, segmentNumber) {
@@ -69,7 +66,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
 
               segments.push({
                 xml: xml,
-                times: times,
+                times: times || [0],
                 previousSubtitleIndex: null,
                 number: segmentNumber
               });
@@ -218,13 +215,13 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       function start () {
         if (captions.captionsUrl && !captions.segmentLength) {
           loadSegment(captions.captionsUrl, 123456); // TODO - fix so random segment number isn't required for VOD.
-        } else if (captions.captionsUrl && captions.segmentLength) {
-          segmentInterval = setInterval(loadAllRequiredSegments, captions.segmentLength * 1000);
-          loadAllRequiredSegments(); // TODO - address concerns with currentTime not being ready on startup of live subs.
         }
 
         updateInterval = setInterval(function () {
           var time = captions.segmentLength ? (windowStartTime / 1000) + mediaPlayer.getCurrentTime() : mediaPlayer.getCurrentTime();
+          if (captions.segmentLength) {
+            loadAllRequiredSegments();
+          }
           update(time);
         }, 750);
       }

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -14,9 +14,9 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       var exampleSubtitlesElement;
       var imscRenderOpts = transformStyleOptions(defaultStyleOpts);
       var updateInterval;
-      var segmentInterval;
       var SEGMENTS_TO_KEEP = 3;
       var segments = [];
+      var liveSubtitles = !!captions.segmentLength;
 
       if (autoStart) {
         start();
@@ -47,13 +47,10 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function loadSegment (url, segmentNumber) {
-        if (!segmentNumber) {
-          return;
-        }
         url = url.replace('$segment$', segmentNumber);
         LoadURL(url, {
           onLoad: function (responseXML, responseText, status) {
-            if (!responseXML && !captions.segmentLength) {
+            if (!responseXML && !liveSubtitles) {
               DebugTool.info('Error: responseXML is invalid.');
               Plugins.interface.onSubtitlesTransformError();
               stop();
@@ -213,13 +210,13 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function start () {
-        if (captions.captionsUrl && !captions.segmentLength) {
-          loadSegment(captions.captionsUrl, 123456); // TODO - fix so random segment number isn't required for VOD.
+        if (!liveSubtitles && captions.captionsUrl) {
+          loadSegment(captions.captionsUrl);
         }
 
         updateInterval = setInterval(function () {
-          var time = captions.segmentLength ? (windowStartTime / 1000) + mediaPlayer.getCurrentTime() : mediaPlayer.getCurrentTime();
-          if (captions.segmentLength) {
+          var time = liveSubtitles ? (windowStartTime / 1000) + mediaPlayer.getCurrentTime() : mediaPlayer.getCurrentTime();
+          if (liveSubtitles) {
             loadAllRequiredSegments();
           }
           update(time);
@@ -228,7 +225,6 @@ define('bigscreenplayer/subtitles/imscsubtitles',
 
       function stop () {
         clearInterval(updateInterval);
-        clearInterval(segmentInterval);
         removeCurrentSubtitlesElement();
       }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -237,13 +237,17 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         return time > ((windowStartTime / 1000) / captions.segmentLength);
       }
 
+      function getCurrentTime () {
+        return liveSubtitles ? (windowStartTime / 1000) + mediaPlayer.getCurrentTime() : mediaPlayer.getCurrentTime();
+      }
+
       function start () {
         if (!liveSubtitles && captions.captionsUrl) {
           loadSegment(captions.captionsUrl);
         }
 
         updateInterval = setInterval(function () {
-          var time = liveSubtitles ? (windowStartTime / 1000) + mediaPlayer.getCurrentTime() : mediaPlayer.getCurrentTime();
+          var time = getCurrentTime();
           if (liveSubtitles && timeIsValid(time)) {
             loadAllRequiredSegments();
           }
@@ -259,8 +263,8 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       function customise (styleOpts, enabled) {
         var customStyleOptions = transformStyleOptions(styleOpts);
         imscRenderOpts = Utils.merge(imscRenderOpts, customStyleOptions);
-        if (enabled && !liveSubtitles) {
-          render(mediaPlayer.getCurrentTime());
+        if (enabled) {
+          update(getCurrentTime());
         }
       }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -209,6 +209,10 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         }
       }
 
+      function timeIsValid (time) {
+        return time > ((windowStartTime / 1000) / captions.segmentLength);
+      }
+
       function start () {
         if (!liveSubtitles && captions.captionsUrl) {
           loadSegment(captions.captionsUrl);
@@ -216,7 +220,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
 
         updateInterval = setInterval(function () {
           var time = liveSubtitles ? (windowStartTime / 1000) + mediaPlayer.getCurrentTime() : mediaPlayer.getCurrentTime();
-          if (liveSubtitles) {
+          if (liveSubtitles && timeIsValid(time)) {
             loadAllRequiredSegments();
           }
           update(time);

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -9,15 +9,15 @@ define('bigscreenplayer/subtitles/imscsubtitles',
   ],
   function (IMSC, DOMHelpers, DebugTool, Plugins, Utils, LoadURL) {
     'use strict';
-    return function (mediaPlayer, url, autoStart, parentElement, defaultStyleOpts) {
+    return function (mediaPlayer, captions, autoStart, parentElement, defaultStyleOpts) {
       var currentSubtitlesElement;
       var exampleSubtitlesElement;
       var imscRenderOpts = transformStyleOptions(defaultStyleOpts);
       var updateInterval;
       var fragments = [];
 
-      if (url) {
-        LoadURL(url, {
+      if (captions.captionsUrl) {
+        LoadURL(captions.captionsUrl, {
           onLoad: function (responseXML, responseText, status) {
             if (!responseXML) {
               DebugTool.info('Error: responseXML is invalid.');

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -62,7 +62,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
               var times = xml.getMediaTimeEvents();
 
               segments.push({
-                xml: xml,
+                xml: modifyStyling(xml),
                 times: times || [0],
                 previousSubtitleIndex: null,
                 number: segmentNumber
@@ -207,7 +207,6 @@ define('bigscreenplayer/subtitles/imscsubtitles',
 
       function renderHTML (xml, currentTime, subsElement, styleOpts, renderHeight, renderWidth) {
         try {
-          modifyStyling(xml);
           var isd = IMSC.generateISD(xml, currentTime);
           IMSC.renderHTML(isd, subsElement, null, renderHeight, renderWidth, false, null, null, false, styleOpts);
         } catch (e) {
@@ -231,6 +230,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
             }
           }
         }
+        return xml;
       }
 
       function timeIsValid (time) {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -79,6 +79,9 @@ define('bigscreenplayer/subtitles/imscsubtitles',
           },
           onError: function (error) {
             DebugTool.info('Error loading subtitles data: ' + error);
+            DebugTool.info('Media player current time: ' + mediaPlayer.getCurrentTime());
+            DebugTool.info('Attempted to load url: ' + url);
+            DebugTool.info('Approx highest segment number available: ' + Math.floor(((Date.now() / 1000) - 10) / captions.segmentLength));
             Plugins.interface.onSubtitlesLoadError();
             stop();
           }
@@ -143,7 +146,10 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         var segment = getSegmentToRender(currentTime);
 
         if (segment) {
+          DebugTool.keyValue({key: 'segmentToRender', value: 'true'});
           render(currentTime, segment.xml);
+        } else {
+          DebugTool.keyValue({key: 'segmentToRender', value: 'false'});
         }
       }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -213,7 +213,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function modifyStyling (xml) {
-        if (liveSubtitles) {
+        if (liveSubtitles && xml && xml.head && xml.head.styling) {
           xml.head.styling.initials = defaultStyleOpts.initials;
         }
         return xml;

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -227,7 +227,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function timeIsValid (time) {
-        return time > ((windowStartTime / 1000) / captions.segmentLength);
+        return time > (windowStartTime / 1000);
       }
 
       function getCurrentTime () {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -16,6 +16,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       var updateInterval;
       var SEGMENTS_TO_KEEP = 3;
       var segments = [];
+      var currentSegmentRendered = {};
       var liveSubtitles = !!captions.segmentLength;
 
       if (autoStart) {
@@ -166,6 +167,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
             var lastOne = segments[i].times.length === j + 1;
             if (currentTime >= segments[i].times[j] && (lastOne || currentTime < segments[i].times[j + 1]) && segments[i].previousSubtitleIndex !== j && segments[i].times[j] !== 0) {
               segment = segments[i];
+              currentSegmentRendered = segments[i];
               segments[i].previousSubtitleIndex = j;
               break;
             }
@@ -269,7 +271,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         var customStyleOptions = transformStyleOptions(styleOpts);
         imscRenderOpts = Utils.merge(imscRenderOpts, customStyleOptions);
         if (enabled) {
-          update(getCurrentTime());
+          render(getCurrentTime(), currentSegmentRendered && currentSegmentRendered.xml);
         }
       }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -85,9 +85,6 @@ define('bigscreenplayer/subtitles/imscsubtitles',
           },
           onError: function (error) {
             DebugTool.info('Error loading subtitles data: ' + error);
-            DebugTool.info('Media player current time: ' + mediaPlayer.getCurrentTime());
-            DebugTool.info('Attempted to load url: ' + url);
-            DebugTool.info('Approx highest segment number available: ' + Math.floor(((Date.now() / 1000) - 10) / captions.segmentLength));
             Plugins.interface.onSubtitlesLoadError();
             stop();
           }

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -149,10 +149,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         var segment = getSegmentToRender(currentTime);
 
         if (segment) {
-          DebugTool.keyValue({key: 'segmentToRender', value: 'true'});
           render(currentTime, segment.xml);
-        } else {
-          DebugTool.keyValue({key: 'segmentToRender', value: 'false'});
         }
       }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -31,8 +31,8 @@ define('bigscreenplayer/subtitles/imscsubtitles',
 
         for (var i = 0; i < SEGMENTS_TO_KEEP; i++) {
           var segmentNumber = calculateSegmentNumber(i);
-          var alreadyLoaded = segments.some(function (fragment) {
-            return fragment.segmentNumber === segmentNumber;
+          var alreadyLoaded = segments.some(function (segment) {
+            return segment.number === segmentNumber;
           });
 
           if (!alreadyLoaded) {
@@ -68,26 +68,11 @@ define('bigscreenplayer/subtitles/imscsubtitles',
                 xml: xml,
                 times: times,
                 previousSubtitleIndex: null,
-                segmentNumber: segmentNumber
+                number: segmentNumber
               });
 
-              var direction;
-              if (segments.length > SEGMENTS_TO_KEEP && (segments[SEGMENTS_TO_KEEP].segmentNumber < segments[SEGMENTS_TO_KEEP - 1].segmentNumber)) {
-                direction = 'backwards';
-              } else {
-                direction = 'forwards';
-              }
-
-              segments.sort(function (a, b) {
-                return a.segmentNumber - b.segmentNumber;
-              });
-
-              if (direction === 'forwards') {
-                if (segments.length > SEGMENTS_TO_KEEP) {
-                  segments.splice(0, 1);
-                }
-              } else {
-                segments.pop();
+              if (segments.length > SEGMENTS_TO_KEEP) {
+                pruneSegments();
               }
 
               if (autoStart) {
@@ -103,6 +88,21 @@ define('bigscreenplayer/subtitles/imscsubtitles',
             Plugins.interface.onSubtitlesLoadError();
           }
         });
+      }
+
+      function pruneSegments () {
+        // Before sorting, check if we've gone back in time, so we know whether to prune from front or back of array
+        var seekedBack = segments[SEGMENTS_TO_KEEP].number < segments[SEGMENTS_TO_KEEP - 1].number;
+
+        segments.sort(function (a, b) {
+          return a.number - b.number;
+        });
+
+        if (seekedBack) {
+          segments.pop();
+        } else {
+          segments.splice(0, 1);
+        }
       }
 
       // Opts: { backgroundColour: string (css colour, hex), fontFamily: string , size: number, lineHeight: number }

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -36,6 +36,11 @@ define('bigscreenplayer/subtitles/imscsubtitles',
           }
         }
 
+        if (SEGMENTS_TO_KEEP === segmentsToLoad.length) {
+          // This is to ensure when seeking to a point with no subtitles, don't leave previous subtitle displayed.
+          removeCurrentSubtitlesElement();
+        }
+
         segmentsToLoad.forEach(function (segmentNumber) {
           loadSegment(captions.captionsUrl, segmentNumber);
         });

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -249,17 +249,19 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function start () {
-        if (!liveSubtitles && captions.captionsUrl) {
-          loadSegment(captions.captionsUrl);
-        }
-
-        updateInterval = setInterval(function () {
-          var time = getCurrentTime();
-          if (liveSubtitles && timeIsValid(time)) {
-            loadAllRequiredSegments();
+        if (captions.captionsUrl) {
+          if (!liveSubtitles) {
+            loadSegment(captions.captionsUrl);
           }
-          update(time);
-        }, 750);
+
+          updateInterval = setInterval(function () {
+            var time = getCurrentTime();
+            if (liveSubtitles && timeIsValid(time)) {
+              loadAllRequiredSegments();
+            }
+            update(time);
+          }, 750);
+        }
       }
 
       function stop () {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -182,7 +182,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         currentSubtitlesElement.style.position = 'absolute';
         parentElement.appendChild(currentSubtitlesElement);
 
-        return renderHTML(xml, currentTime, currentSubtitlesElement, imscRenderOpts, parentElement.clientHeight, parentElement.clientWidth);
+        renderHTML(xml, currentTime, currentSubtitlesElement, imscRenderOpts, parentElement.clientHeight, parentElement.clientWidth);
       }
 
       function renderExample (exampleXmlString, styleOpts, safePosition) {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -202,6 +202,18 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       function renderHTML (xml, currentTime, subsElement, styleOpts, renderHeight, renderWidth) {
         try {
           var isd = IMSC.generateISD(xml, currentTime);
+          for (var i = 0; i < isd.contents.length; i++) {
+            if (isd.contents[i].kind === 'region') {
+              isd.contents[i].styleAttrs['http://www.w3.org/ns/ttml#styling displayAlign'] = 'after';
+              isd.contents[i].styleAttrs['http://www.w3.org/ns/ttml#styling overflow'] = 'visible';
+              // for (var j = 0; j < isd.contents[i].contents.length; j++) {
+              //   for (var k = 0; k < isd.contents[i].contents[j].contents.length; k++) {
+              //     isd.contents[i].contents[j].contents[k].styleAttrs['http://www.w3.org/ns/ttml#styling fontSize'] = '117%';
+              //     isd.contents[i].contents[j].contents[k].styleAttrs['http://www.w3.org/ns/ttml#styling lineHeight'] = '120%';
+              //   }
+              // }
+            }
+          }
           IMSC.renderHTML(isd, subsElement, null, renderHeight, renderWidth, false, null, null, false, styleOpts);
         } catch (e) {
           DebugTool.info('Exception while rendering subtitles: ' + e);
@@ -217,6 +229,8 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         if (!liveSubtitles && captions.captionsUrl) {
           loadSegment(captions.captionsUrl);
         }
+
+        customise({fontFamily: 'ReithSans, Arial, Roboto, proportionalSansSerif, default'});
 
         updateInterval = setInterval(function () {
           var time = liveSubtitles ? (windowStartTime / 1000) + mediaPlayer.getCurrentTime() : mediaPlayer.getCurrentTime();
@@ -235,7 +249,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       function customise (styleOpts, enabled) {
         var customStyleOptions = transformStyleOptions(styleOpts);
         imscRenderOpts = Utils.merge(imscRenderOpts, customStyleOptions);
-        if (enabled) {
+        if (enabled && !liveSubtitles) {
           render(mediaPlayer.getCurrentTime());
         }
       }

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -5,11 +5,12 @@ define('bigscreenplayer/subtitles/imscsubtitles',
     'bigscreenplayer/debugger/debugtool',
     'bigscreenplayer/plugins',
     'bigscreenplayer/utils/playbackutils',
-    'bigscreenplayer/utils/loadurl'
+    'bigscreenplayer/utils/loadurl',
+    'bigscreenplayer/utils/timeutils'
   ],
-  function (IMSC, DOMHelpers, DebugTool, Plugins, Utils, LoadURL) {
+  function (IMSC, DOMHelpers, DebugTool, Plugins, Utils, LoadURL, TimeUtils) {
     'use strict';
-    return function (mediaPlayer, captions, autoStart, parentElement, defaultStyleOpts, windowStartTime) {
+    return function (mediaPlayer, captions, autoStart, parentElement, defaultStyleOpts, windowStartEpochSeconds) {
       var currentSubtitlesElement;
       var exampleSubtitlesElement;
       var imscRenderOpts = transformStyleOptions(defaultStyleOpts);
@@ -25,9 +26,9 @@ define('bigscreenplayer/subtitles/imscsubtitles',
 
       function loadAllRequiredSegments () {
         var segmentsToLoad = [];
-
+        var currentSegment = TimeUtils.calculateSegmentNumber(windowStartEpochSeconds + mediaPlayer.getCurrentTime(), captions.segmentLength);
         for (var i = 0; i < SEGMENTS_TO_KEEP; i++) {
-          var segmentNumber = calculateSegmentNumber(i);
+          var segmentNumber = currentSegment + i;
           var alreadyLoaded = segments.some(function (segment) {
             return segment.number === segmentNumber;
           });
@@ -45,11 +46,6 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         segmentsToLoad.forEach(function (segmentNumber) {
           loadSegment(captions.captionsUrl, segmentNumber);
         });
-      }
-
-      function calculateSegmentNumber (offset) {
-        var epochSeconds = (windowStartTime / 1000) + mediaPlayer.getCurrentTime();
-        return Math.floor(epochSeconds / captions.segmentLength) + offset;
       }
 
       function loadSegment (url, segmentNumber) {
@@ -224,11 +220,11 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function timeIsValid (time) {
-        return time > (windowStartTime / 1000);
+        return time > windowStartEpochSeconds;
       }
 
       function getCurrentTime () {
-        return liveSubtitles ? (windowStartTime / 1000) + mediaPlayer.getCurrentTime() : mediaPlayer.getCurrentTime();
+        return liveSubtitles ? windowStartEpochSeconds + mediaPlayer.getCurrentTime() : mediaPlayer.getCurrentTime();
       }
 
       function start () {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -224,18 +224,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
 
       function modifyStyling (xml) {
         if (liveSubtitles) {
-          xml.head.styling.initials = {
-            'http://www.w3.org/ns/ttml#styling displayAlign': 'after',
-            'http://www.w3.org/ns/ttml#styling lineHeight': '133%',
-            'http://www.w3.org/ns/ttml#styling overflow': 'visible'
-          };
-
-          for (var i = 0; i < xml.body.contents.length; i++) {
-            for (var j = 0; j < xml.body.contents[i].contents.length; j++) {
-              xml.body.contents[i].contents[j].styleAttrs['http://www.w3.org/ns/ttml#styling fontFamily'] = ['ReithSans', 'Arial', 'Roboto', 'proportionalSansSerif', 'default'];
-              xml.body.contents[i].contents[j].styleAttrs['http://www.w3.org/ns/ttml#styling fontSize'].value = 94;
-            }
-          }
+          xml.head.styling.initials = defaultStyleOpts.initials;
         }
         return xml;
       }

--- a/script/subtitles/legacysubtitles.js
+++ b/script/subtitles/legacysubtitles.js
@@ -10,12 +10,12 @@ define(
   function (Renderer, TransportControlPosition, DOMHelpers, LoadURL, DebugTool, Plugins) {
     'use strict';
 
-    return function (mediaPlayer, url, autoStart, parentElement) {
+    return function (mediaPlayer, captions, autoStart, parentElement) {
       var container = document.createElement('div');
       var subtitlesRenderer;
 
-      if (url) {
-        LoadURL(url, {
+      if (captions.captionsUrl) {
+        LoadURL(captions.captionsUrl, {
           onLoad: function (responseXML, responseText, status) {
             if (!responseXML) {
               DebugTool.info('Error: responseXML is invalid.');

--- a/script/subtitles/subtitles.js
+++ b/script/subtitles/subtitles.js
@@ -1,43 +1,13 @@
 define('bigscreenplayer/subtitles/subtitles',
   [
-    'bigscreenplayer/subtitles/' + (window.bigscreenPlayer.overrides && window.bigscreenPlayer.overrides.legacySubtitles ? 'legacysubtitles' : 'imscsubtitles'),
-    'bigscreenplayer/utils/loadurl',
-    'bigscreenplayer/debugger/debugtool',
-    'bigscreenplayer/plugins'
+    'bigscreenplayer/subtitles/' + (window.bigscreenPlayer.overrides && window.bigscreenPlayer.overrides.legacySubtitles ? 'legacysubtitles' : 'imscsubtitles')
   ],
-  function (SubtitlesContainer, LoadURL, DebugTool, Plugins) {
+  function (SubtitlesContainer) {
     'use strict';
-    // playbackStrategy, captionsURL, isSubtitlesEnabled(), playbackElement TODO: change the ordering of this, doesn't make sense.
     return function (mediaPlayer, url, autoStart, playbackElement, defaultStyleOpts) {
-      var subtitlesContainer;
       var subtitlesEnabled = autoStart;
       var subtitlesAvailable = !!url;
-
-      if (subtitlesAvailable) {
-        DebugTool.info('Loading subtitles from: ' + url);
-        LoadURL(url, {
-          onLoad: function (responseXML, responseText, status) {
-            if (!responseXML) {
-              DebugTool.info('Error: responseXML is invalid.');
-              Plugins.interface.onSubtitlesTransformError();
-              return;
-            }
-
-            var response = {
-              text: responseText,
-              xml: responseXML
-            };
-
-            if (status === 200) {
-              subtitlesContainer = SubtitlesContainer(mediaPlayer, response, autoStart, playbackElement, defaultStyleOpts);
-            }
-          },
-          onError: function (error) {
-            DebugTool.info('Error loading subtitles data: ' + error);
-            Plugins.interface.onSubtitlesLoadError();
-          }
-        });
-      }
+      var subtitlesContainer = SubtitlesContainer(mediaPlayer, url, autoStart, playbackElement, defaultStyleOpts);
 
       function enable () {
         subtitlesEnabled = true;
@@ -48,13 +18,13 @@ define('bigscreenplayer/subtitles/subtitles',
       }
 
       function show () {
-        if (available() && enabled() && subtitlesContainer) {
+        if (available() && enabled()) {
           subtitlesContainer.start();
         }
       }
 
       function hide () {
-        if (available() && subtitlesContainer) {
+        if (available()) {
           subtitlesContainer.stop();
         }
       }
@@ -68,33 +38,23 @@ define('bigscreenplayer/subtitles/subtitles',
       }
 
       function setPosition (position) {
-        if (subtitlesContainer) {
-          subtitlesContainer.updatePosition(position);
-        }
+        subtitlesContainer.updatePosition(position);
       }
 
       function customise (styleOpts) {
-        if (subtitlesContainer) {
-          subtitlesContainer.customise(styleOpts, subtitlesEnabled);
-        }
+        subtitlesContainer.customise(styleOpts, subtitlesEnabled);
       }
 
       function renderExample (exampleXmlString, styleOpts, safePosition) {
-        if (subtitlesContainer) {
-          subtitlesContainer.renderExample(exampleXmlString, styleOpts, safePosition);
-        }
+        subtitlesContainer.renderExample(exampleXmlString, styleOpts, safePosition);
       }
 
       function clearExample () {
-        if (subtitlesContainer) {
-          subtitlesContainer.clearExample();
-        }
+        subtitlesContainer.clearExample();
       }
 
       function tearDown () {
-        if (subtitlesContainer) {
-          subtitlesContainer.tearDown();
-        }
+        subtitlesContainer.tearDown();
       }
 
       return {

--- a/script/subtitles/subtitles.js
+++ b/script/subtitles/subtitles.js
@@ -4,10 +4,10 @@ define('bigscreenplayer/subtitles/subtitles',
   ],
   function (SubtitlesContainer) {
     'use strict';
-    return function (mediaPlayer, captions, autoStart, playbackElement, defaultStyleOpts) {
+    return function (mediaPlayer, captions, autoStart, playbackElement, defaultStyleOpts, windowStartTime) {
       var subtitlesEnabled = autoStart;
       var subtitlesAvailable = !!captions.captionsUrl;
-      var subtitlesContainer = SubtitlesContainer(mediaPlayer, captions, autoStart, playbackElement, defaultStyleOpts);
+      var subtitlesContainer = SubtitlesContainer(mediaPlayer, captions, autoStart, playbackElement, defaultStyleOpts, windowStartTime);
 
       function enable () {
         subtitlesEnabled = true;

--- a/script/subtitles/subtitles.js
+++ b/script/subtitles/subtitles.js
@@ -6,7 +6,7 @@ define('bigscreenplayer/subtitles/subtitles',
     'use strict';
     return function (mediaPlayer, captions, autoStart, playbackElement, defaultStyleOpts, windowStartTime) {
       var subtitlesEnabled = autoStart;
-      var subtitlesAvailable = !!captions.captionsUrl;
+      var liveSubtitles = captions.segmentLength;
       var subtitlesContainer = SubtitlesContainer(mediaPlayer, captions, autoStart, playbackElement, defaultStyleOpts, windowStartTime);
 
       function enable () {
@@ -34,7 +34,11 @@ define('bigscreenplayer/subtitles/subtitles',
       }
 
       function available () {
-        return subtitlesAvailable;
+        if (liveSubtitles && (window.bigscreenPlayer.overrides && window.bigscreenPlayer.overrides.legacySubtitles)) {
+          return false;
+        } else {
+          return !!captions.captionsUrl;
+        }
       }
 
       function setPosition (position) {

--- a/script/subtitles/subtitles.js
+++ b/script/subtitles/subtitles.js
@@ -4,10 +4,10 @@ define('bigscreenplayer/subtitles/subtitles',
   ],
   function (SubtitlesContainer) {
     'use strict';
-    return function (mediaPlayer, url, autoStart, playbackElement, defaultStyleOpts) {
+    return function (mediaPlayer, captions, autoStart, playbackElement, defaultStyleOpts) {
       var subtitlesEnabled = autoStart;
-      var subtitlesAvailable = !!url;
-      var subtitlesContainer = SubtitlesContainer(mediaPlayer, url, autoStart, playbackElement, defaultStyleOpts);
+      var subtitlesAvailable = !!captions.captionsUrl;
+      var subtitlesContainer = SubtitlesContainer(mediaPlayer, captions, autoStart, playbackElement, defaultStyleOpts);
 
       function enable () {
         subtitlesEnabled = true;

--- a/script/utils/timeutils.js
+++ b/script/utils/timeutils.js
@@ -36,11 +36,16 @@ define(
       return dashRelativeTime - ((Date.now() - slidingWindowPausedTime) / 1000);
     }
 
+    function calculateSegmentNumber (epochTimeInSeconds, segmentLength) {
+      return Math.floor(epochTimeInSeconds / segmentLength);
+    }
+
     return {
       durationToSeconds: durationToSeconds,
       convertToSeekableVideoTime: convertToSeekableVideoTime,
       convertToVideoTime: convertToVideoTime,
-      calculateSlidingWindowSeekOffset: calculateSlidingWindowSeekOffset
+      calculateSlidingWindowSeekOffset: calculateSlidingWindowSeekOffset,
+      calculateSegmentNumber: calculateSegmentNumber
     };
   }
 );


### PR DESCRIPTION
📺 What

Adds ability to display subtitles for LIVE content

> Tickets: IPLAYERTVV1-11997

🛠 How

Moves loading of captions xml into subtitle containers (imsc and legacy). For live playback using imsc.js, individual fragments are downloaded when needed. The correct segment to render is determined and passed to imsc.js.


✅ Testing [Semi-optional]
[MANDATORY for contributions being tested and released by the contributing team]

[Test Guidelines](https://github.com/bbc/bigscreen-player/wiki/Areas-Impacted)

| Test engineer sign off | :x: |
| ---- | ---- |

[How will this change be tested?]

♿  Accessibility [optional]

Adds the ability to display subtitles for live content.