### PR TITLE
Subtitle CDN failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ require(
       media: {
         mimeType: 'video/mp4',
         bitrate: 8940,         // Displayed by Debug Tool
-        captionsUrl: 'https://www.somelovelycaptionsurl.com/captions',
         codec: 'h264',
         kind: MediaKind.VIDEO, // Can be VIDEO, or AUDIO
         urls: [
@@ -74,10 +73,16 @@ require(
             cdn: 'cdn2'
           }
         ],
-        captions: {
-          captionsUrl: 'https://www.somelovelycaptionsurl.com/captions/$segment$', // $segment$ required for replacement
-          segmentLength: 3.84 // Required to calculate live subtitle segment to fetch & live subtitle URL.
-        },
+        captions: [{
+            captionsUrl: 'https://www.somelovelycaptionsurl.com/captions/$segment$', // $segment$ required for replacement for live
+            segmentLength: 3.84 // Required to calculate live subtitle segment to fetch & live subtitle URL.
+            cdn: 'cdn1' // Displayed by Debug Tool
+          }, {
+            captionsUrl: 'https://www.somelovelycaptionsurl2.com/captions/$segment$',
+            segmentLength: 3.84 
+            cdn: 'cdn1' 
+          },
+        ],
         subtitleCustomisation: {
           size: 0.75,
           lineHeight: 1.10,

--- a/README.md
+++ b/README.md
@@ -74,15 +74,16 @@ require(
           }
         ],
         captions: [{
-            captionsUrl: 'https://www.somelovelycaptionsurl.com/captions/$segment$', // $segment$ required for replacement for live
+            url: 'https://www.somelovelycaptionsurl.com/captions/$segment$', // $segment$ required for replacement for live
             segmentLength: 3.84 // Required to calculate live subtitle segment to fetch & live subtitle URL.
             cdn: 'cdn1' // Displayed by Debug Tool
           }, {
-            captionsUrl: 'https://www.somelovelycaptionsurl2.com/captions/$segment$',
+            url: 'https://www.somelovelycaptionsurl2.com/captions/$segment$',
             segmentLength: 3.84 
             cdn: 'cdn1' 
           },
         ],
+        captionsUrl: 'https://www.somelovelycaptionsurl.com/captions/' // NB This paramater is being depreciated in favour of the captions array shown above. 
         subtitleCustomisation: {
           size: 0.75,
           lineHeight: 1.10,

--- a/development/index.js
+++ b/development/index.js
@@ -15,7 +15,7 @@ require (['bigscreenplayer/bigscreenplayer'], function(BigscreenPlayer){
   let minimalData = {
     initialPlaybackTime: 30,
     media: {
-      captionsUrl: '',
+      captions: [],
         type: 'application/dash+xml',
         mimeType: 'video/mp4',
         kind: 'video',

--- a/development/index.js
+++ b/development/index.js
@@ -10,7 +10,7 @@ require (['bigscreenplayer/bigscreenplayer'], function(BigscreenPlayer){
   playbackElement.style.width = '1280px';
 
   let windowType = 'staticWindow';
-  let enableSubtitles = true;
+  let enableSubtitles = false;
   
   let minimalData = {
     initialPlaybackTime: 30,

--- a/development/index.js
+++ b/development/index.js
@@ -10,7 +10,7 @@ require (['bigscreenplayer/bigscreenplayer'], function(BigscreenPlayer){
   playbackElement.style.width = '1280px';
 
   let windowType = 'staticWindow';
-  let enableSubtitles = false;
+  let enableSubtitles = true;
   
   let minimalData = {
     initialPlaybackTime: 30,

--- a/development/index.js
+++ b/development/index.js
@@ -16,19 +16,17 @@ require (['bigscreenplayer/bigscreenplayer'], function(BigscreenPlayer){
     initialPlaybackTime: 30,
     media: {
       captions: [],
-        type: 'application/dash+xml',
-        mimeType: 'video/mp4',
-        kind: 'video',
-        urls: [
-          {
-            // Content from DASH IF testing assests (used in their reference player)
-            // https://reference.dashif.org/dash.js/v2.9.2/samples/dash-if-reference-player/index.htm
-            url: 'https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd',
-            cdn: 'dash.akamaized.net'
-          }
-        ]
-      }
-    };
+      type: 'application/dash+xml',
+      mimeType: 'video/mp4',
+      kind: 'video',
+      urls: [{
+        // Content from DASH IF testing assests (used in their reference player)
+        // https://reference.dashif.org/dash.js/v2.9.2/samples/dash-if-reference-player/index.htm
+        url: 'https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd',
+        cdn: 'dash.akamaized.net'
+      }]
+    }
+  };
 
   // Useful for testing legacy subtitles implementation
   function setUpCaptionsContainerCSS() {

--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -84,7 +84,10 @@ require(
       }
 
       if (options.subtitlesAvailable) {
-        bigscreenPlayerData.media.captionsUrl = 'captions';
+        bigscreenPlayerData.media.captions = {
+          segmentLength: 1,
+          urls: ['captions1', 'captions2']
+        };
       }
 
       var callbacks;
@@ -98,7 +101,7 @@ require(
       beforeEach(function (done) {
         mediaSourcesMock = function () {
           return {
-            init: function (urls, serverDate, windowType, liveSupport, callbacks) {
+            init: function (urls, captionUrls, serverDate, windowType, liveSupport, callbacks) {
               mediaSourcesCallbackSuccessSpy = spyOn(callbacks, 'onSuccess').and.callThrough();
               mediaSourcesCallbackErrorSpy = spyOn(callbacks, 'onError').and.callThrough();
               if (forceMediaSourcesConstructionFailure) {

--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -84,10 +84,16 @@ require(
       }
 
       if (options.subtitlesAvailable) {
-        bigscreenPlayerData.media.captions = {
-          segmentLength: 1,
-          urls: ['captions1', 'captions2']
-        };
+        bigscreenPlayerData.media.captions = [
+          {
+            url: 'captions1',
+            segmentLength: 3.84
+          },
+          {
+            url: 'captions2',
+            segmentLength: 3.84
+          }
+        ];
       }
 
       var callbacks;

--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -17,7 +17,7 @@ require(
       var MediaSources;
 
       var testSources;
-      var testCaptionSources;
+      var testSubtitlesSources;
       var testCallbacks;
       var triggerManifestLoadError = false;
 
@@ -68,7 +68,7 @@ require(
             {url: 'http://source1.com/', cdn: 'http://supplier1.com/'},
             {url: 'http://source2.com/', cdn: 'http://supplier2.com/'}
           ];
-          testCaptionSources = [
+          testSubtitlesSources = [
             {url: 'http://source1.com/', cdn: 'http://supplier1.com/'},
             {url: 'http://source2.com/', cdn: 'http://supplier2.com/'}
           ];
@@ -91,14 +91,14 @@ require(
         it('throws an error when initialised with no sources', function () {
           expect(function () {
             var mediaSources = new MediaSources();
-            mediaSources.init([], testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+            mediaSources.init([], testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
             mediaSources.currentSource();
           }).toThrow(new Error('Media Sources urls are undefined'));
         });
 
         it('clones the urls', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           testSources[0].url = 'clonetest';
 
           expect(mediaSources.currentSource()).toEqual('http://source1.com/');
@@ -107,37 +107,37 @@ require(
         it('throws an error when callbacks are undefined', function () {
           expect(function () {
             var mediaSources = new MediaSources();
-            mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {});
+            mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {});
           }).toThrow(new Error('Media Sources callbacks are undefined'));
 
           expect(function () {
             var mediaSources = new MediaSources();
-            mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {onSuccess: function () {}});
+            mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {onSuccess: function () {}});
           }).toThrow(new Error('Media Sources callbacks are undefined'));
 
           expect(function () {
             var mediaSources = new MediaSources();
-            mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {onError: function () {}});
+            mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {onError: function () {}});
           }).toThrow(new Error('Media Sources callbacks are undefined'));
         });
 
         it('calls onSuccess callback immediately for STATIC window content', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(testCallbacks.onSuccess).toHaveBeenCalledWith();
         });
 
         it('calls onSuccess callback immediately for LIVE content on a PLAYABLE device', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.SLIDING, LiveSupport.PLAYABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.SLIDING, LiveSupport.PLAYABLE, testCallbacks);
 
           expect(testCallbacks.onSuccess).toHaveBeenCalledWith();
         });
 
         it('calls onSuccess callback when manifest loader returns on success for SLIDING window content', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(testCallbacks.onSuccess).toHaveBeenCalledWith();
         });
@@ -147,7 +147,7 @@ require(
           triggerFailOnce = true;
           var mediaSources = new MediaSources();
 
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(testCallbacks.onSuccess).toHaveBeenCalledTimes(1);
         });
@@ -155,14 +155,14 @@ require(
         it('calls onError callback when manifest loader fails and there are insufficent sources to failover to', function () {
           triggerManifestLoadError = true;
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(testCallbacks.onError).toHaveBeenCalledWith({error: 'manifest'});
         });
 
         it('sets time data correcly when manifest loader successfully returns', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(mediaSources.time()).toEqual(mockTimeObject);
         });
@@ -184,7 +184,7 @@ require(
 
           var serverDate = new Date();
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, serverDate, WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, serverDate, WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           mockManifestLoader.load.calls.reset();
 
@@ -197,7 +197,7 @@ require(
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(postFailoverAction).toHaveBeenCalledWith();
@@ -208,7 +208,7 @@ require(
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init([{url: 'http://source1.com/', cdn: 'http://supplier1.com/'}], testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init([{url: 'http://source1.com/', cdn: 'http://supplier1.com/'}], testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(onFailureAction).toHaveBeenCalledWith();
@@ -219,7 +219,7 @@ require(
           var failoverInfo = {errorMessage: 'test error', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           var pluginData = {
@@ -239,7 +239,7 @@ require(
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init([{url: 'http://source1.com/', cdn: 'http://supplier1.com/'}], testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init([{url: 'http://source1.com/', cdn: 'http://supplier1.com/'}], testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(mockPluginsInterface.onErrorHandled).not.toHaveBeenCalled();
@@ -253,7 +253,7 @@ require(
             [
               { url: 'http://source1.com/path/to/thing.extension', cdn: 'http://cdn1.com' },
               { url: 'http://source2.com', cdn: 'http://cdn2.com' }],
-            testCaptionSources,
+            testSubtitlesSources,
             new Date(),
             WindowTypes.STATIC,
             LiveSupport.SEEKABLE,
@@ -280,7 +280,7 @@ require(
             [
               {url: 'http://source1.com', cdn: 'http://cdn1.com'},
               {url: 'http://source2.com', cdn: 'http://cdn2.com'}],
-            testCaptionSources,
+            testSubtitlesSources,
             new Date(),
             WindowTypes.STATIC,
             LiveSupport.SEEKABLE,
@@ -311,7 +311,7 @@ require(
 
         it('returns the first media source url', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(mediaSources.currentSource()).toBe(testSources[0].url);
         });
@@ -322,26 +322,26 @@ require(
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(mediaSources.currentSource()).toBe(testSources[1].url);
         });
       });
 
-      describe('currentCaptionsSource', function () {
-        it('returns the first caption source url', function () {
+      describe('currentSubtitlesSource', function () {
+        it('returns the first subtitles source url', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
-          expect(mediaSources.currentSubtitlesSource()).toBe(testCaptionSources[0].url);
+          expect(mediaSources.currentSubtitlesSource()).toBe(testSubtitlesSources[0].url);
         });
       });
 
       describe('availableSources', function () {
         it('returns an array of media source urls', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(mediaSources.availableSources()).toEqual(['http://source1.com/', 'http://source2.com/']);
         });
@@ -352,7 +352,7 @@ require(
         describe('when window type is STATIC', function () {
           beforeEach(function () {
             mediaSources = new MediaSources();
-            mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+            mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           });
 
           it('should failover if current time is greater than 5 seconds from duration', function () {
@@ -406,7 +406,7 @@ require(
             it('should not reload the manifest', function () {
               mediaSources = new MediaSources();
               mockTransferFormat = TransferFormats.DASH;
-              mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.GROWING, LiveSupport.SEEKABLE, testCallbacks);
+              mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.GROWING, LiveSupport.SEEKABLE, testCallbacks);
 
               var mediaSourceCallbacks = jasmine.createSpyObj('mediaSourceCallbacks', ['onSuccess', 'onError']);
 
@@ -427,7 +427,7 @@ require(
             it('should reload the manifest', function () {
               mediaSources = new MediaSources();
               mockTransferFormat = TransferFormats.HLS;
-              mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.GROWING, LiveSupport.SEEKABLE, testCallbacks);
+              mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.GROWING, LiveSupport.SEEKABLE, testCallbacks);
 
               var mediaSourceCallbacks = jasmine.createSpyObj('mediaSourceCallbacks', ['onSuccess', 'onError']);
 
@@ -450,7 +450,7 @@ require(
         var mediaSources;
         beforeEach(function () {
           mediaSources = new MediaSources();
-          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
         });
 
         it('updates the mediasources time data', function () {

--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -334,7 +334,7 @@ require(
           var mediaSources = new MediaSources();
           mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
-          expect(mediaSources.currentCaptionsSource()).toBe(testCaptionSources[0].url);
+          expect(mediaSources.currentSubtitlesSource()).toBe(testCaptionSources[0].url);
         });
       });
 

--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -370,8 +370,8 @@ require(
           mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failoverSubtitles(postFailoverAction, onFailureAction);
 
-          expect(postFailoverAction).toHaveBeenCalledWith();
-          expect(onFailureAction).not.toHaveBeenCalledWith();
+          expect(postFailoverAction).toHaveBeenCalledTimes(1);
+          expect(onFailureAction).not.toHaveBeenCalled();
         });
 
         it('When there are no more subtitles sources to failover to, it calls failure action callback', function () {
@@ -379,8 +379,8 @@ require(
           mediaSources.init(testSources, [{url: 'http://subtitlessource1.com/', cdn: 'http://supplier1.com/'}], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failoverSubtitles(postFailoverAction, onFailureAction);
 
-          expect(onFailureAction).toHaveBeenCalledWith();
-          expect(postFailoverAction).not.toHaveBeenCalledWith();
+          expect(onFailureAction).toHaveBeenCalledTimes(1);
+          expect(postFailoverAction).not.toHaveBeenCalled();
         });
       });
 

--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -17,6 +17,7 @@ require(
       var MediaSources;
 
       var testSources;
+      var testCaptionSources;
       var testCallbacks;
       var triggerManifestLoadError = false;
 
@@ -67,6 +68,7 @@ require(
             {url: 'http://source1.com/', cdn: 'http://supplier1.com/'},
             {url: 'http://source2.com/', cdn: 'http://supplier2.com/'}
           ];
+          testCaptionSources = ['http://source1.com/', 'http://source2.com/'];
           done();
         });
       });
@@ -86,14 +88,14 @@ require(
         it('throws an error when initialised with no sources', function () {
           expect(function () {
             var mediaSources = new MediaSources();
-            mediaSources.init([], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+            mediaSources.init([], testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
             mediaSources.currentSource();
           }).toThrow(new Error('Media Sources urls are undefined'));
         });
 
         it('clones the urls', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           testSources[0].url = 'clonetest';
 
           expect(mediaSources.currentSource()).toEqual('http://source1.com/');
@@ -102,37 +104,37 @@ require(
         it('throws an error when callbacks are undefined', function () {
           expect(function () {
             var mediaSources = new MediaSources();
-            mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {});
+            mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {});
           }).toThrow(new Error('Media Sources callbacks are undefined'));
 
           expect(function () {
             var mediaSources = new MediaSources();
-            mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {onSuccess: function () {}});
+            mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {onSuccess: function () {}});
           }).toThrow(new Error('Media Sources callbacks are undefined'));
 
           expect(function () {
             var mediaSources = new MediaSources();
-            mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {onError: function () {}});
+            mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {onError: function () {}});
           }).toThrow(new Error('Media Sources callbacks are undefined'));
         });
 
         it('calls onSuccess callback immediately for STATIC window content', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(testCallbacks.onSuccess).toHaveBeenCalledWith();
         });
 
         it('calls onSuccess callback immediately for LIVE content on a PLAYABLE device', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, new Date(), WindowTypes.SLIDING, LiveSupport.PLAYABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.SLIDING, LiveSupport.PLAYABLE, testCallbacks);
 
           expect(testCallbacks.onSuccess).toHaveBeenCalledWith();
         });
 
         it('calls onSuccess callback when manifest loader returns on success for SLIDING window content', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(testCallbacks.onSuccess).toHaveBeenCalledWith();
         });
@@ -142,7 +144,7 @@ require(
           triggerFailOnce = true;
           var mediaSources = new MediaSources();
 
-          mediaSources.init(testSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(testCallbacks.onSuccess).toHaveBeenCalledTimes(1);
         });
@@ -150,14 +152,14 @@ require(
         it('calls onError callback when manifest loader fails and there are insufficent sources to failover to', function () {
           triggerManifestLoadError = true;
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(testCallbacks.onError).toHaveBeenCalledWith({error: 'manifest'});
         });
 
         it('sets time data correcly when manifest loader successfully returns', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(mediaSources.time()).toEqual(mockTimeObject);
         });
@@ -179,7 +181,7 @@ require(
 
           var serverDate = new Date();
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, serverDate, WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, serverDate, WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           mockManifestLoader.load.calls.reset();
 
@@ -192,7 +194,7 @@ require(
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(postFailoverAction).toHaveBeenCalledWith();
@@ -203,7 +205,7 @@ require(
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init([{url: 'http://source1.com/', cdn: 'http://supplier1.com/'}], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init([{url: 'http://source1.com/', cdn: 'http://supplier1.com/'}], testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(onFailureAction).toHaveBeenCalledWith();
@@ -214,7 +216,7 @@ require(
           var failoverInfo = {errorMessage: 'test error', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           var pluginData = {
@@ -234,7 +236,7 @@ require(
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init([{url: 'http://source1.com/', cdn: 'http://supplier1.com/'}], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init([{url: 'http://source1.com/', cdn: 'http://supplier1.com/'}], testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(mockPluginsInterface.onErrorHandled).not.toHaveBeenCalled();
@@ -248,6 +250,7 @@ require(
             [
               { url: 'http://source1.com/path/to/thing.extension', cdn: 'http://cdn1.com' },
               { url: 'http://source2.com', cdn: 'http://cdn2.com' }],
+            testCaptionSources,
             new Date(),
             WindowTypes.STATIC,
             LiveSupport.SEEKABLE,
@@ -267,12 +270,14 @@ require(
 
           expect(mediaSources.currentSource()).toBe('http://source1.com/path/to/thing.extension');
         });
+
         it('does not failover if service location is identical to current source cdn besides hash and query', function () {
           var mediaSources = new MediaSources();
           mediaSources.init(
             [
               {url: 'http://source1.com', cdn: 'http://cdn1.com'},
               {url: 'http://source2.com', cdn: 'http://cdn2.com'}],
+            testCaptionSources,
             new Date(),
             WindowTypes.STATIC,
             LiveSupport.SEEKABLE,
@@ -303,7 +308,7 @@ require(
 
         it('returns the first media source url', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(mediaSources.currentSource()).toBe(testSources[0].url);
         });
@@ -314,7 +319,7 @@ require(
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(mediaSources.currentSource()).toBe(testSources[1].url);
@@ -324,7 +329,7 @@ require(
       describe('availableSources', function () {
         it('returns an array of media source urls', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(mediaSources.availableSources()).toEqual(['http://source1.com/', 'http://source2.com/']);
         });
@@ -335,7 +340,7 @@ require(
         describe('when window type is STATIC', function () {
           beforeEach(function () {
             mediaSources = new MediaSources();
-            mediaSources.init(testSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+            mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           });
 
           it('should failover if current time is greater than 5 seconds from duration', function () {
@@ -389,7 +394,7 @@ require(
             it('should not reload the manifest', function () {
               mediaSources = new MediaSources();
               mockTransferFormat = TransferFormats.DASH;
-              mediaSources.init(testSources, new Date(), WindowTypes.GROWING, LiveSupport.SEEKABLE, testCallbacks);
+              mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.GROWING, LiveSupport.SEEKABLE, testCallbacks);
 
               var mediaSourceCallbacks = jasmine.createSpyObj('mediaSourceCallbacks', ['onSuccess', 'onError']);
 
@@ -410,7 +415,7 @@ require(
             it('should reload the manifest', function () {
               mediaSources = new MediaSources();
               mockTransferFormat = TransferFormats.HLS;
-              mediaSources.init(testSources, new Date(), WindowTypes.GROWING, LiveSupport.SEEKABLE, testCallbacks);
+              mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.GROWING, LiveSupport.SEEKABLE, testCallbacks);
 
               var mediaSourceCallbacks = jasmine.createSpyObj('mediaSourceCallbacks', ['onSuccess', 'onError']);
 
@@ -433,7 +438,7 @@ require(
         var mediaSources;
         beforeEach(function () {
           mediaSources = new MediaSources();
-          mediaSources.init(testSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
         });
 
         it('updates the mediasources time data', function () {

--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -68,7 +68,10 @@ require(
             {url: 'http://source1.com/', cdn: 'http://supplier1.com/'},
             {url: 'http://source2.com/', cdn: 'http://supplier2.com/'}
           ];
-          testCaptionSources = ['http://source1.com/', 'http://source2.com/'];
+          testCaptionSources = [
+            {url: 'http://source1.com/', cdn: 'http://supplier1.com/'},
+            {url: 'http://source2.com/', cdn: 'http://supplier2.com/'}
+          ];
           done();
         });
       });
@@ -323,6 +326,15 @@ require(
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(mediaSources.currentSource()).toBe(testSources[1].url);
+        });
+      });
+
+      describe('currentCaptionsSource', function () {
+        it('returns the first caption source url', function () {
+          var mediaSources = new MediaSources();
+          mediaSources.init(testSources, testCaptionSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+
+          expect(mediaSources.currentCaptionsSource()).toBe(testCaptionSources[0].url);
         });
       });
 

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -132,7 +132,7 @@ require(
         mediaSourcesTimeSpy = spyOn(mediaSources, 'time');
         mediaSourcesTimeSpy.and.callThrough();
         spyOn(mediaSources, 'failover').and.callThrough();
-        mediaSources.init(cdnArray, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, mediaSourceCallbacks);
+        mediaSources.init(cdnArray, [], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, mediaSourceCallbacks);
 
         testManifestObject = {
           type: 'manifestLoaded',

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -29,18 +29,18 @@ require(
       beforeEach(function (done) {
         injector = new Squire();
 
-        exampleUrl = 'http://stub-captions.test';
+        exampleUrl = 'http://stub-subtitles.test';
         loadUrlStubResponseText = '<?xml version="1.0" encoding="utf-8"?><tt xmlns="http://www.w3.org/ns/ttml"></tt>';
         segmentLength = undefined;
         epochStartTimeMilliseconds = undefined;
 
         mediaPlayer = jasmine.createSpyObj('mediaPlayer', ['getCurrentTime']);
         mockMediaSources = {
-          currentCaptionsSource: function () {
+          currentSubtitlesSource: function () {
             return exampleUrl;
           },
-          failoverCaptions: function () {},
-          currentCaptionsSegmentLength: function () {
+          failoverSubtitles: function () {},
+          currentSubtitlesSegmentLength: function () {
             return segmentLength;
           },
           time: function () {
@@ -190,7 +190,7 @@ require(
           subtitles.stop();
         });
 
-        it('Should load the captions url', function () {
+        it('Should load the subtitles url', function () {
           subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
           expect(loadUrlMock).toHaveBeenCalledWith(exampleUrl, jasmine.any(Object));
@@ -234,7 +234,7 @@ require(
           expect(pluginsMock.interface.onSubtitlesTransformError).toHaveBeenCalledTimes(1);
         });
 
-        it('does not attempt to load subtitles if there is no captions url', function () {
+        it('does not attempt to load subtitles if there is no subtitles url', function () {
           exampleUrl = undefined;
           subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
@@ -393,7 +393,7 @@ require(
 
       describe('Live subtitles', function () {
         beforeEach(function () {
-          exampleUrl = 'https://captions/$segment$.test';
+          exampleUrl = 'https://subtitles/$segment$.test';
           segmentLength = 3.84;
           epochStartTimeMilliseconds = 1614769200000; // Wednesday, 3 March 2021 11:00:00
         });
@@ -409,9 +409,9 @@ require(
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
 
-            expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512815.test', jasmine.any(Object));
-            expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512816.test', jasmine.any(Object));
-            expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512817.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledWith('https://subtitles/420512815.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledWith('https://subtitles/420512816.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledWith('https://subtitles/420512817.test', jasmine.any(Object));
           });
 
           it('should load the fragment two segments ahead of current time', function () {
@@ -427,7 +427,7 @@ require(
 
             // At 13.84 seconds, we should be loading the segment correseponding to 21.52 seconds
             // 1614769221520 = Wednesday, 3 March 2021 11:00:21.52
-            expect(loadUrlMock).toHaveBeenCalledOnceWith('https://captions/420512818.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledOnceWith('https://subtitles/420512818.test', jasmine.any(Object));
           });
 
           it('should not load a fragment if fragments array already contains it', function () {
@@ -440,12 +440,12 @@ require(
             mediaPlayer.getCurrentTime.and.returnValue(13.84);
             jasmine.clock().tick(750);
 
-            expect(loadUrlMock).toHaveBeenCalledOnceWith('https://captions/420512818.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledOnceWith('https://subtitles/420512818.test', jasmine.any(Object));
 
             mediaPlayer.getCurrentTime.and.returnValue(13.84); // time hasn't progressed. e.g. in paused state
             jasmine.clock().tick(750);
 
-            expect(loadUrlMock).toHaveBeenCalledOnceWith('https://captions/420512818.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledOnceWith('https://subtitles/420512818.test', jasmine.any(Object));
           });
 
           it('only keeps three fragments when playing', function () {
@@ -458,13 +458,13 @@ require(
             mediaPlayer.getCurrentTime.and.returnValue(13.84);
             jasmine.clock().tick(750);
 
-            expect(loadUrlMock).toHaveBeenCalledOnceWith('https://captions/420512818.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledOnceWith('https://subtitles/420512818.test', jasmine.any(Object));
 
             loadUrlMock.calls.reset();
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
 
-            expect(loadUrlMock).toHaveBeenCalledOnceWith('https://captions/420512815.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledOnceWith('https://subtitles/420512815.test', jasmine.any(Object));
           });
 
           it('load three new fragments when seeking back to a point where none of the segments are available', function () {
@@ -477,9 +477,9 @@ require(
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
 
-            expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512815.test', jasmine.any(Object));
-            expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512816.test', jasmine.any(Object));
-            expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512817.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledWith('https://subtitles/420512815.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledWith('https://subtitles/420512816.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledWith('https://subtitles/420512817.test', jasmine.any(Object));
             expect(loadUrlMock).toHaveBeenCalledTimes(3);
           });
 
@@ -493,9 +493,9 @@ require(
             mediaPlayer.getCurrentTime.and.returnValue(100);
             jasmine.clock().tick(750);
 
-            expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512838.test', jasmine.any(Object));
-            expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512839.test', jasmine.any(Object));
-            expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512840.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledWith('https://subtitles/420512838.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledWith('https://subtitles/420512839.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledWith('https://subtitles/420512840.test', jasmine.any(Object));
             expect(loadUrlMock).toHaveBeenCalledTimes(3);
           });
 
@@ -522,7 +522,7 @@ require(
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
 
-            expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512815.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledWith('https://subtitles/420512815.test', jasmine.any(Object));
           });
 
           it('calls fromXML with xml string where responseText contains more than a simple xml string', function () {
@@ -606,7 +606,7 @@ require(
             mediaPlayer.getCurrentTime.and.returnValue(13.84);
             jasmine.clock().tick(750);
 
-            expect(loadUrlMock).toHaveBeenCalledWith('https://captions/420512818.test', jasmine.any(Object));
+            expect(loadUrlMock).toHaveBeenCalledWith('https://subtitles/420512818.test', jasmine.any(Object));
           });
         });
 

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -564,23 +564,23 @@ require(
             expect(loadUrlMock).not.toHaveBeenCalled();
           });
 
-          it('should stop loading fragments when the XML fails to load', function () {
-            loadUrlMock.and.callFake(function (url, callbackObject) {
-              callbackObject.onError();
-            });
+          // it('should stop loading fragments when the XML fails to load', function () {
+          //   loadUrlMock.and.callFake(function (url, callbackObject) {
+          //     callbackObject.onError();
+          //   });
 
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
+          //   subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
-            mediaPlayer.getCurrentTime.and.returnValue(10);
-            jasmine.clock().tick(750);
+          //   mediaPlayer.getCurrentTime.and.returnValue(10);
+          //   jasmine.clock().tick(750);
 
-            loadUrlMock.calls.reset();
+          //   loadUrlMock.calls.reset();
 
-            mediaPlayer.getCurrentTime.and.returnValue(13.84);
-            jasmine.clock().tick(750);
+          //   mediaPlayer.getCurrentTime.and.returnValue(13.84);
+          //   jasmine.clock().tick(750);
 
-            expect(loadUrlMock).not.toHaveBeenCalled();
-          });
+          //   expect(loadUrlMock).not.toHaveBeenCalled();
+          // });
 
           it('should not stop loading fragments when the xml response is invalid', function () {
             loadUrlMock.and.callFake(function (url, callbackObject) {

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -32,7 +32,8 @@ require(
         mockMediaSources = {
           currentCaptionsSource: function () {
             return exampleUrl;
-          }
+          },
+          failoverCaptions: function () {}
         };
 
         jasmine.clock().install();

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -425,7 +425,7 @@ require(
           subtitles.stop();
         });
 
-        describe('Loading fragments', function () {
+        describe('Loading segments', function () {
           it('should load the first three segments with correct urls on the first update interval', function () {
             subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
@@ -437,7 +437,7 @@ require(
             expect(loadUrlMock).toHaveBeenCalledWith('https://subtitles/420512817.test', jasmine.any(Object));
           });
 
-          it('should load the fragment two segments ahead of current time', function () {
+          it('should load the segment two segments ahead of current time', function () {
             // epochStartTimeSeconds = Wednesday, 3 March 2021 11:00:00
             subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
@@ -453,7 +453,7 @@ require(
             expect(loadUrlMock).toHaveBeenCalledOnceWith('https://subtitles/420512818.test', jasmine.any(Object));
           });
 
-          it('should not load a fragment if fragments array already contains it', function () {
+          it('should not load a segment if segments array already contains it', function () {
             subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
@@ -471,7 +471,7 @@ require(
             expect(loadUrlMock).toHaveBeenCalledOnceWith('https://subtitles/420512818.test', jasmine.any(Object));
           });
 
-          it('only keeps three fragments when playing', function () {
+          it('only keeps three segments when playing', function () {
             subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
@@ -490,7 +490,7 @@ require(
             expect(loadUrlMock).toHaveBeenCalledOnceWith('https://subtitles/420512815.test', jasmine.any(Object));
           });
 
-          it('load three new fragments when seeking back to a point where none of the segments are available', function () {
+          it('load three new segments when seeking back to a point where none of the segments are available', function () {
             subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
             mediaPlayer.getCurrentTime.and.returnValue(113.84);
@@ -506,7 +506,7 @@ require(
             expect(loadUrlMock).toHaveBeenCalledTimes(3);
           });
 
-          it('loads three new fragments when seeking forwards to a point where none of the segments are available', function () {
+          it('loads three new segments when seeking forwards to a point where none of the segments are available', function () {
             subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
             mediaPlayer.getCurrentTime.and.returnValue(13.84);
@@ -522,7 +522,7 @@ require(
             expect(loadUrlMock).toHaveBeenCalledTimes(3);
           });
 
-          it('should not load fragments when auto start is false', function () {
+          it('should not load segments when auto start is false', function () {
             subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {});
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
@@ -531,7 +531,7 @@ require(
             expect(loadUrlMock).not.toHaveBeenCalled();
           });
 
-          it('should load fragments when start is called and autoStart is false', function () {
+          it('should load segments when start is called and autoStart is false', function () {
             subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {});
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
@@ -559,7 +559,7 @@ require(
             expect(imscMock.fromXML).toHaveBeenCalledWith('<tt xmlns="http://www.w3.org/ns/ttml"></tt>');
           });
 
-          it('should stop loading fragments when stop is called', function () {
+          it('should stop loading segments when stop is called', function () {
             subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
             loadUrlMock.calls.reset();
@@ -580,7 +580,7 @@ require(
             expect(loadUrlMock).not.toHaveBeenCalled();
           });
 
-          it('should stop loading fragments when xml transforming has failed', function () {
+          it('should stop loading segments when xml transforming has failed', function () {
             imscMock.fromXML.and.throwError();
 
             subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
@@ -596,7 +596,7 @@ require(
             expect(loadUrlMock).not.toHaveBeenCalled();
           });
 
-          it('should not stop loading fragments when the xml response is invalid', function () {
+          it('should not stop loading segments when the xml response is invalid', function () {
             loadUrlMock.and.callFake(function (url, callbackObject) {
               callbackObject.onLoad(null, '', 200);
             });

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -30,7 +30,7 @@ require(
 
         mediaPlayer = jasmine.createSpyObj('mediaPlayer', ['getCurrentTime']);
         mockMediaSources = {
-          getCurrentCaptionsUrl: function () {
+          currentCaptionsSource: function () {
             return exampleUrl;
           }
         };

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -94,13 +94,13 @@ require(
         });
 
         it('is constructed with the correct interface', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, null);
 
           expect(subtitles).toEqual(jasmine.objectContaining({start: jasmine.any(Function), stop: jasmine.any(Function), updatePosition: jasmine.any(Function), tearDown: jasmine.any(Function)}));
         });
 
         it('autoplay argument starts the update loop', function () {
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, null);
           progressTime(1.5);
 
           expect(imscMock.generateISD).toHaveBeenCalledTimes(1);
@@ -113,7 +113,7 @@ require(
         it('overrides the subtitles styling metadata with supplied defaults when rendering', function () {
           var styleOpts = { backgroundColour: 'black', fontFamily: 'Arial' };
           var expectedOpts = { spanBackgroundColorAdjust: { transparent: 'black' }, fontFamily: 'Arial' };
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, styleOpts, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, styleOpts, null);
 
           subtitles.start();
           progressTime(9);
@@ -122,7 +122,7 @@ require(
         });
 
         it('overrides the subtitles styling metadata with supplied custom styles when rendering', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, null);
 
           var styleOpts = { size: 0.7, lineHeight: 0.9 };
           var expectedOpts = { sizeAdjust: 0.7, lineHeightAdjust: 0.9 };
@@ -140,7 +140,7 @@ require(
           var customStyleOpts = { size: 0.7, lineHeight: 0.9 };
           var expectedOpts = { spanBackgroundColorAdjust: { transparent: 'black' }, fontFamily: 'Arial', sizeAdjust: 0.7, lineHeightAdjust: 0.9 };
 
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, defaultStyleOpts, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, defaultStyleOpts, null);
 
           mediaPlayer.getCurrentTime.and.returnValue(1);
 
@@ -151,7 +151,7 @@ require(
         });
 
         it('does not render custom styles when subtitles are not enabled', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, null);
 
           var subsEnabled = false;
           subtitles.start();
@@ -163,7 +163,7 @@ require(
 
       describe('example rendering', function () {
         it('should call fromXML, generate and render when renderExample is called', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, null);
           imscMock.fromXML.calls.reset();
 
           subtitles.renderExample('', {}, {});
@@ -180,27 +180,27 @@ require(
         });
 
         it('Should load the captions url', function () {
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, null);
 
           expect(loadUrlMock).toHaveBeenCalledWith(exampleUrl, jasmine.any(Object));
         });
 
         it('Calls fromXML on creation with the extracted XML from the text property of the response argument', function () {
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, null);
 
           expect(imscMock.fromXML).toHaveBeenCalledWith('<tt xmlns="http://www.w3.org/ns/ttml"></tt>');
         });
 
         it('Calls fromXML on creation with the original text property of the response argument if expected header is not found', function () {
           loadUrlStubResponseText = '<?xml version="1.0" encoding="utf-8" extra property="something"?><tt xmlns="http://www.w3.org/ns/ttml"></tt>';
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, null);
 
           expect(imscMock.fromXML).toHaveBeenCalledWith(loadUrlStubResponseText);
         });
 
         it('fires tranformError plugin if IMSC throws an exception when parsing', function () {
           imscMock.fromXML.and.throwError();
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, null);
 
           expect(pluginsMock.interface.onSubtitlesTransformError).toHaveBeenCalledTimes(1);
         });
@@ -209,7 +209,7 @@ require(
           loadUrlMock.and.callFake(function (url, callbackObject) {
             callbackObject.onError();
           });
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, null);
 
           expect(pluginsMock.interface.onSubtitlesLoadError).toHaveBeenCalledTimes(1);
         });
@@ -218,21 +218,21 @@ require(
           loadUrlMock.and.callFake(function (url, callbackObject) {
             callbackObject.onLoad(null, '', 200);
           });
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, null);
 
           expect(pluginsMock.interface.onSubtitlesTransformError).toHaveBeenCalledTimes(1);
         });
 
         it('does not attempt to load subtitles if there is no captions url', function () {
           exampleUrl = undefined;
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, null);
 
           expect(loadUrlMock).not.toHaveBeenCalled();
         });
 
         it('cannot start when xml transforming has failed', function () {
           imscMock.fromXML.and.throwError();
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, null);
 
           progressTime(1.5);
 
@@ -241,7 +241,7 @@ require(
         });
 
         it('does not try to generate and render when current time is undefined', function () {
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, null);
 
           progressTime(undefined);
 
@@ -251,7 +251,7 @@ require(
 
         it('does not try to generate and render when xml transforming has failed', function () {
           imscMock.fromXML.and.throwError();
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, null);
 
           progressTime(1.5);
 
@@ -260,7 +260,7 @@ require(
         });
 
         it('does not try to generate and render when the initial current time is less than the first subtitle time', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, null);
 
           subtitles.start();
 
@@ -271,7 +271,7 @@ require(
         });
 
         it('does attempt to generate and render when the initial current time is greater than the final subtitle time', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, null);
 
           subtitles.start();
           progressTime(9);
@@ -287,7 +287,7 @@ require(
         });
 
         it('does attempt to generate and render when the initial current time is mid way through a stream', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, null);
 
           subtitles.start();
 
@@ -299,7 +299,7 @@ require(
         });
 
         it('only generate and render when there are new subtitles to display', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, null);
 
           subtitles.start();
 
@@ -328,7 +328,7 @@ require(
         });
 
         it('no longer attempts any rendering if subtitles have been stopped', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, null);
 
           subtitles.start();
           progressTime(1.5);
@@ -344,7 +344,7 @@ require(
         });
 
         it('no longer attempts any rendering if subtitles have been torn down', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, null);
 
           subtitles.start();
           progressTime(1.5);
@@ -360,7 +360,7 @@ require(
         });
 
         it('fires onSubtitlesRenderError plugin if IMSC throws an exception when rendering', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, null);
           imscMock.renderHTML.and.throwError();
 
           subtitles.start();
@@ -370,7 +370,7 @@ require(
         });
 
         it('fires onSubtitlesRenderError plugin if IMSC throws an exception when generating ISD', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, null, mockMediaSources);
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, null);
           imscMock.generateISD.and.throwError();
 
           subtitles.start();
@@ -393,7 +393,7 @@ require(
 
         describe('Loading fragments', function () {
           it('should load the first three segments with correct urls on the first update interval', function () {
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -405,7 +405,7 @@ require(
 
           it('should load the fragment two segments ahead of current time', function () {
             // epochStartTimeSeconds = Wednesday, 3 March 2021 11:00:00
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -420,7 +420,7 @@ require(
           });
 
           it('should not load a fragment if fragments array already contains it', function () {
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -438,7 +438,7 @@ require(
           });
 
           it('only keeps three fragments when playing', function () {
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -457,7 +457,7 @@ require(
           });
 
           it('load three new fragments when seeking back to a point where none of the segments are available', function () {
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(113.84);
             jasmine.clock().tick(750);
@@ -473,7 +473,7 @@ require(
           });
 
           it('loads three new fragments when seeking forwards to a point where none of the segments are available', function () {
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(13.84);
             jasmine.clock().tick(750);
@@ -489,7 +489,7 @@ require(
           });
 
           it('should not load fragments when auto start is false', function () {
-            subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -498,7 +498,7 @@ require(
           });
 
           it('should load fragments when start is called and autoStart is false', function () {
-            subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -518,7 +518,7 @@ require(
             loadUrlStubResponseText = 'stuff that might exists before the xml string' + loadUrlStubResponseText;
             mediaPlayer.getCurrentTime.and.returnValue(10);
 
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             jasmine.clock().tick(750);
 
@@ -526,7 +526,7 @@ require(
           });
 
           it('should stop loading fragments when stop is called', function () {
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             loadUrlMock.calls.reset();
             subtitles.stop();
@@ -538,7 +538,7 @@ require(
           });
 
           it('should not try to load segments when the currentTime is not known by the player', function () {
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(-1000);
             jasmine.clock().tick(750);
@@ -549,7 +549,7 @@ require(
           it('should stop loading fragments when xml transforming has failed', function () {
             imscMock.fromXML.and.throwError();
 
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -567,7 +567,7 @@ require(
               callbackObject.onError();
             });
 
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -585,7 +585,7 @@ require(
               callbackObject.onLoad(null, '', 200);
             });
 
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(10);
             jasmine.clock().tick(750);
@@ -628,7 +628,7 @@ require(
             });
 
             mediaPlayer.getCurrentTime.and.returnValue(2);
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, {}, epochStartTimeSeconds, mockMediaSources);
+            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {}, epochStartTimeSeconds);
 
             mediaPlayer.getCurrentTime.and.returnValue(2.750);
             jasmine.clock().tick(750);

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -14,7 +14,7 @@ require(
       var mediaPlayer;
       var subtitles;
       var mockMediaSources;
-      var exampleUrl;
+      var subtitlesUrl;
       var segmentLength;
       var epochStartTimeMilliseconds;
       var avalailableSourceCount;
@@ -30,14 +30,14 @@ require(
       beforeEach(function (done) {
         injector = new Squire();
 
-        exampleUrl = 'http://stub-subtitles.test';
+        subtitlesUrl = 'http://stub-subtitles.test';
         loadUrlStubResponseText = '<?xml version="1.0" encoding="utf-8"?><tt xmlns="http://www.w3.org/ns/ttml"></tt>';
         segmentLength = undefined;
         epochStartTimeMilliseconds = undefined;
 
         mediaPlayer = jasmine.createSpyObj('mediaPlayer', ['getCurrentTime']);
         mockMediaSources = jasmine.createSpyObj('mockMediaSources', ['currentSubtitlesSource', 'failoverSubtitles', 'currentSubtitlesSegmentLength', 'time']);
-        mockMediaSources.currentSubtitlesSource.and.callFake(function () { return exampleUrl; });
+        mockMediaSources.currentSubtitlesSource.and.callFake(function () { return subtitlesUrl; });
         mockMediaSources.failoverSubtitles.and.callFake(function (postFailoverAction, failoverErrorAction) {
           if (avalailableSourceCount > 1) {
             avalailableSourceCount--;
@@ -196,7 +196,7 @@ require(
         it('Should load the subtitles url', function () {
           subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
-          expect(loadUrlMock).toHaveBeenCalledWith(exampleUrl, jasmine.any(Object));
+          expect(loadUrlMock).toHaveBeenCalledWith(subtitlesUrl, jasmine.any(Object));
         });
 
         it('Should load the next available url if loading of first XML fails', function () {
@@ -258,7 +258,7 @@ require(
         });
 
         it('does not attempt to load subtitles if there is no subtitles url', function () {
-          exampleUrl = undefined;
+          subtitlesUrl = undefined;
           subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
           expect(loadUrlMock).not.toHaveBeenCalled();
@@ -416,7 +416,7 @@ require(
 
       describe('Live subtitles', function () {
         beforeEach(function () {
-          exampleUrl = 'https://subtitles/$segment$.test';
+          subtitlesUrl = 'https://subtitles/$segment$.test';
           segmentLength = 3.84;
           epochStartTimeMilliseconds = 1614769200000; // Wednesday, 3 March 2021 11:00:00
         });

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -564,24 +564,6 @@ require(
             expect(loadUrlMock).not.toHaveBeenCalled();
           });
 
-          // it('should stop loading fragments when the XML fails to load', function () {
-          //   loadUrlMock.and.callFake(function (url, callbackObject) {
-          //     callbackObject.onError();
-          //   });
-
-          //   subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
-
-          //   mediaPlayer.getCurrentTime.and.returnValue(10);
-          //   jasmine.clock().tick(750);
-
-          //   loadUrlMock.calls.reset();
-
-          //   mediaPlayer.getCurrentTime.and.returnValue(13.84);
-          //   jasmine.clock().tick(750);
-
-          //   expect(loadUrlMock).not.toHaveBeenCalled();
-          // });
-
           it('should not stop loading fragments when the xml response is invalid', function () {
             loadUrlMock.and.callFake(function (url, callbackObject) {
               callbackObject.onLoad(null, '', 200);

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -216,15 +216,6 @@ require(
           expect(pluginsMock.interface.onSubtitlesTransformError).toHaveBeenCalledTimes(1);
         });
 
-        it('fires onSubtitlesLoadError plugin if loading of XML fails', function () {
-          loadUrlMock.and.callFake(function (url, callbackObject) {
-            callbackObject.onError();
-          });
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
-
-          expect(pluginsMock.interface.onSubtitlesLoadError).toHaveBeenCalledTimes(1);
-        });
-
         it('fires subtitleTransformError if responseXML from the loader is invalid', function () {
           loadUrlMock.and.callFake(function (url, callbackObject) {
             callbackObject.onLoad(null, '', 200);

--- a/script-test/subtitles/legacysubtitles.js
+++ b/script-test/subtitles/legacysubtitles.js
@@ -35,10 +35,10 @@ require(
 
         exampleUrl = 'http://stub-captions.test';
         mockMediaSources = {
-          currentCaptionsSource: function () {
+          currentSubtitlesSource: function () {
             return exampleUrl;
           },
-          failoverCaptions: function () {}
+          failoverSubtitles: function () {}
         };
 
         pluginInterfaceMock = jasmine.createSpyObj('interfaceMock', ['onSubtitlesRenderError', 'onSubtitlesTransformError', 'onSubtitlesLoadError']);
@@ -62,7 +62,7 @@ require(
         mockRendererSpy.render.calls.reset();
       });
 
-      it('Should load the captions url', function () {
+      it('Should load the subtitles url', function () {
         legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
 
         expect(loadUrlMock).toHaveBeenCalledWith(exampleUrl, jasmine.any(Object));

--- a/script-test/subtitles/legacysubtitles.js
+++ b/script-test/subtitles/legacysubtitles.js
@@ -34,12 +34,8 @@ require(
         });
 
         exampleUrl = 'http://stub-captions.test';
-        mockMediaSources = {
-          currentSubtitlesSource: function () {
-            return exampleUrl;
-          },
-          failoverSubtitles: function () {}
-        };
+        mockMediaSources = jasmine.createSpyObj('mockMediaSources', ['currentSubtitlesSource', 'failoverSubtitles']);
+        mockMediaSources.currentSubtitlesSource.and.returnValue(exampleUrl);
 
         pluginInterfaceMock = jasmine.createSpyObj('interfaceMock', ['onSubtitlesRenderError', 'onSubtitlesTransformError', 'onSubtitlesLoadError']);
         pluginsMock = { interface: pluginInterfaceMock };
@@ -81,6 +77,15 @@ require(
         legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
 
         expect(pluginsMock.interface.onSubtitlesTransformError).toHaveBeenCalledTimes(1);
+      });
+
+      it('Should try to failover to the next url if responseXML from the loader is invalid', function () {
+        loadUrlMock.and.callFake(function (url, callbackObject) {
+          callbackObject.onError();
+        });
+        legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
+
+        expect(mockMediaSources.failoverSubtitles).toHaveBeenCalledTimes(1);
       });
 
       describe('Start', function () {

--- a/script-test/subtitles/legacysubtitles.js
+++ b/script-test/subtitles/legacysubtitles.js
@@ -16,7 +16,7 @@ require(
     var loadUrlStubResponseText = 'loadUrlStubResponseText';
     var pluginInterfaceMock;
     var pluginsMock;
-    var exampleUrl;
+    var subtitlesUrl;
     var mockMediaSources;
     var avalailableSourceCount;
 
@@ -34,9 +34,9 @@ require(
           callbackObject.onLoad(loadUrlStubResponseXml, loadUrlStubResponseText, 200);
         });
 
-        exampleUrl = 'http://stub-captions.test';
+        subtitlesUrl = 'http://stub-captions.test';
         mockMediaSources = jasmine.createSpyObj('mockMediaSources', ['currentSubtitlesSource', 'failoverSubtitles']);
-        mockMediaSources.currentSubtitlesSource.and.returnValue(exampleUrl);
+        mockMediaSources.currentSubtitlesSource.and.returnValue(subtitlesUrl);
         mockMediaSources.failoverSubtitles.and.callFake(function (postFailoverAction, failoverErrorAction) {
           if (avalailableSourceCount > 1) {
             avalailableSourceCount--;
@@ -70,7 +70,7 @@ require(
       it('Should load the subtitles url', function () {
         legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
 
-        expect(loadUrlMock).toHaveBeenCalledWith(exampleUrl, jasmine.any(Object));
+        expect(loadUrlMock).toHaveBeenCalledWith(subtitlesUrl, jasmine.any(Object));
       });
 
       it('Has a player subtitles class', function () {

--- a/script-test/subtitles/legacysubtitles.js
+++ b/script-test/subtitles/legacysubtitles.js
@@ -74,15 +74,6 @@ require(
         expect(parentElement.firstChild.className).toContain('playerCaptions');
       });
 
-      it('Should fire onSubtitlesLoadError plugin if loading of XML fails', function () {
-        loadUrlMock.and.callFake(function (url, callbackObject) {
-          callbackObject.onError();
-        });
-        legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
-
-        expect(pluginsMock.interface.onSubtitlesLoadError).toHaveBeenCalledTimes(1);
-      });
-
       it('Should fire subtitleTransformError if responseXML from the loader is invalid', function () {
         loadUrlMock.and.callFake(function (url, callbackObject) {
           callbackObject.onLoad(null, '', 200);

--- a/script-test/subtitles/legacysubtitles.js
+++ b/script-test/subtitles/legacysubtitles.js
@@ -16,9 +16,8 @@ require(
     var loadUrlStubResponseText = 'loadUrlStubResponseText';
     var pluginInterfaceMock;
     var pluginsMock;
-    var stubCaptions = {
-      captionsUrl: 'http://stub-captions.test'
-    };
+    var exampleUrl;
+    var mockMediaSources;
 
     describe('Legacy Subtitles', function () {
       beforeEach(function (done) {
@@ -33,6 +32,14 @@ require(
         loadUrlMock.and.callFake(function (url, callbackObject) {
           callbackObject.onLoad(loadUrlStubResponseXml, loadUrlStubResponseText, 200);
         });
+
+        exampleUrl = 'http://stub-captions.test';
+        mockMediaSources = {
+          currentCaptionsSource: function () {
+            return exampleUrl;
+          },
+          failoverCaptions: function () {}
+        };
 
         pluginInterfaceMock = jasmine.createSpyObj('interfaceMock', ['onSubtitlesRenderError', 'onSubtitlesTransformError', 'onSubtitlesLoadError']);
         pluginsMock = { interface: pluginInterfaceMock };
@@ -56,13 +63,13 @@ require(
       });
 
       it('Should load the captions url', function () {
-        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
+        legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
 
-        expect(loadUrlMock).toHaveBeenCalledWith(stubCaptions.captionsUrl, jasmine.any(Object));
+        expect(loadUrlMock).toHaveBeenCalledWith(exampleUrl, jasmine.any(Object));
       });
 
       it('Has a player subtitles class', function () {
-        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
+        legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
 
         expect(parentElement.firstChild.className).toContain('playerCaptions');
       });
@@ -71,7 +78,7 @@ require(
         loadUrlMock.and.callFake(function (url, callbackObject) {
           callbackObject.onError();
         });
-        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
+        legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
 
         expect(pluginsMock.interface.onSubtitlesLoadError).toHaveBeenCalledTimes(1);
       });
@@ -80,14 +87,14 @@ require(
         loadUrlMock.and.callFake(function (url, callbackObject) {
           callbackObject.onLoad(null, '', 200);
         });
-        legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
+        legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
 
         expect(pluginsMock.interface.onSubtitlesTransformError).toHaveBeenCalledTimes(1);
       });
 
       describe('Start', function () {
         it('Starts if there is valid xml in the response object', function () {
-          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
+          legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
           legacySubtitles.start();
 
           expect(mockRendererSpy.start).toHaveBeenCalledWith();
@@ -97,7 +104,7 @@ require(
           loadUrlMock.and.callFake(function (url, callbackObject) {
             callbackObject.onError();
           });
-          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
+          legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
           legacySubtitles.start();
 
           expect(mockRendererSpy.start).not.toHaveBeenCalledWith();
@@ -106,7 +113,7 @@ require(
 
       describe('Stop', function () {
         it('Stops the subtitles if there is valid xml in the response object', function () {
-          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
+          legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
           legacySubtitles.stop();
 
           expect(mockRendererSpy.stop).toHaveBeenCalledWith();
@@ -117,7 +124,7 @@ require(
             callbackObject.onError();
           });
 
-          legacySubtitles = new LegacySubtitlesWithMocks(null, stubCaptions, false, parentElement);
+          legacySubtitles = new LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
           legacySubtitles.stop();
 
           expect(mockRendererSpy.stop).not.toHaveBeenCalledWith();
@@ -126,7 +133,7 @@ require(
 
       describe('Updating position', function () {
         beforeEach(function () {
-          legacySubtitles = LegacySubtitlesWithMocks(null, stubCaptions, true, parentElement);
+          legacySubtitles = LegacySubtitlesWithMocks(null, true, parentElement, mockMediaSources);
         });
 
         [

--- a/script-test/subtitles/subtitles.js
+++ b/script-test/subtitles/subtitles.js
@@ -7,7 +7,7 @@ require(
     var injector;
     var mediaSourcesMock;
     var subtitlesAvailable;
-    var segmentLength = 3.84;
+    var live;
 
     describe('Subtitles', function () {
       mediaSourcesMock = {
@@ -17,12 +17,16 @@ require(
           } else {
             return '';
           }
+        },
+        currentCaptionsSegmentLength: function () {
+          return live ? 3.84 : undefined;
         }
       };
 
       beforeEach(function () {
         injector = new Squire();
         subtitlesAvailable = true;
+        live = false;
       });
 
       afterEach(function () {
@@ -53,7 +57,7 @@ require(
             var mockMediaPlayer = {};
             var autoStart = true;
             var mockPlaybackElement = document.createElement('div');
-            Subtitles(mockMediaPlayer, null, autoStart, mockPlaybackElement);
+            Subtitles(mockMediaPlayer, autoStart, mockPlaybackElement, null, null, mediaSourcesMock);
 
             expect(subtitlesMock).toHaveBeenCalledTimes(1);
           });
@@ -78,7 +82,7 @@ require(
             var autoStart = true;
             var mockPlaybackElement = document.createElement('div');
 
-            Subtitles(mockMediaPlayer, null, autoStart, mockPlaybackElement);
+            Subtitles(mockMediaPlayer, autoStart, mockPlaybackElement, null, null, mediaSourcesMock);
 
             expect(subtitlesMock).toHaveBeenCalledTimes(1);
           });
@@ -121,15 +125,15 @@ require(
             var customDefaultStyle = {};
             var windowStartTime = '123456';
 
-            Subtitles(mockMediaPlayer, null, autoStart, mockPlaybackElement, customDefaultStyle, windowStartTime, mediaSourcesMock);
+            Subtitles(mockMediaPlayer, autoStart, mockPlaybackElement, customDefaultStyle, windowStartTime, mediaSourcesMock);
 
-            expect(subtitlesContainer).toHaveBeenCalledWith(mockMediaPlayer, null, autoStart, mockPlaybackElement, customDefaultStyle, windowStartTime, mediaSourcesMock);
+            expect(subtitlesContainer).toHaveBeenCalledWith(mockMediaPlayer, autoStart, mockPlaybackElement, customDefaultStyle, windowStartTime, mediaSourcesMock);
           });
         });
 
         describe('show', function () {
           it('should start subtitles when enabled and available', function () {
-            var subtitles = Subtitles(null, null, null, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
             subtitles.enable();
             subtitles.show();
 
@@ -137,7 +141,7 @@ require(
           });
 
           it('should not start subtitles when disabled and available', function () {
-            var subtitles = Subtitles(null, null, null, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
             subtitles.disable();
             subtitles.show();
 
@@ -146,7 +150,7 @@ require(
 
           it('should not start subtitles when enabled and unavailable', function () {
             subtitlesAvailable = false;
-            var subtitles = Subtitles(null, null, null, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
             subtitles.enable();
             subtitles.show();
 
@@ -155,7 +159,7 @@ require(
 
           it('should not start subtitles when disabled and unavailable', function () {
             subtitlesAvailable = false;
-            var subtitles = Subtitles(null, null, null, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
             subtitles.disable();
             subtitles.show();
 
@@ -165,7 +169,7 @@ require(
 
         describe('hide', function () {
           it('should stop subtitles when available', function () {
-            var subtitles = Subtitles(null, null, null, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
             subtitles.hide();
 
             expect(subtitlesContainerSpies.stop).toHaveBeenCalledWith();
@@ -174,7 +178,7 @@ require(
 
         describe('enable', function () {
           it('should set enabled state to true', function () {
-            var subtitles = Subtitles(null, null, null, null);
+            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
             subtitles.enable();
 
             expect(subtitles.enabled()).toEqual(true);
@@ -183,7 +187,7 @@ require(
 
         describe('disable', function () {
           it('should set enabled state to false', function () {
-            var subtitles = Subtitles(null, null, null, null);
+            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
             subtitles.disable();
 
             expect(subtitlesContainerSpies.stop).not.toHaveBeenCalled();
@@ -193,26 +197,26 @@ require(
 
         describe('enabled', function () {
           it('should return true if subtitles are enabled at construction', function () {
-            var subtitles = Subtitles(null, null, true, null);
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
 
             expect(subtitles.enabled()).toEqual(true);
           });
 
           it('should return true if subtitles are enabled by an api call', function () {
-            var subtitles = Subtitles(null, null, false, null);
+            var subtitles = Subtitles(null, false, null, null, null, mediaSourcesMock);
             subtitles.enable();
 
             expect(subtitles.enabled()).toEqual(true);
           });
 
           it('should return false if subtitles are disabled at construction', function () {
-            var subtitles = Subtitles(null, null, false, null);
+            var subtitles = Subtitles(null, false, null, null, null, mediaSourcesMock);
 
             expect(subtitles.enabled()).toEqual(false);
           });
 
           it('should return true if subtitles are disabled by an api call', function () {
-            var subtitles = Subtitles(null, null, true, null);
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
             subtitles.disable();
 
             expect(subtitles.enabled()).toEqual(false);
@@ -221,13 +225,13 @@ require(
 
         describe('available', function () {
           it('should return true if VOD and url exists', function () {
-            var subtitles = Subtitles(null, null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
 
             expect(subtitles.available()).toEqual(true);
           });
 
           it('should return true if LIVE, url exists and no override', function () {
-            var subtitles = Subtitles(null, segmentLength, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
 
             expect(subtitles.available()).toEqual(true);
           });
@@ -238,32 +242,34 @@ require(
                 legacySubtitles: true
               }
             };
-            var subtitles = Subtitles(null, null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
 
             expect(subtitles.available()).toEqual(true);
           });
 
           it('should return false if LIVE, url exists and legacy override exists', function () {
+            live = true;
             window.bigscreenPlayer = {
               overrides: {
                 legacySubtitles: true
               }
             };
-            var subtitles = Subtitles(null, segmentLength, true, null);
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
 
             expect(subtitles.available()).toEqual(false);
           });
 
           it('should return false if VOD and no url exists', function () {
             subtitlesAvailable = false;
-            var subtitles = Subtitles(null, null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
 
             expect(subtitles.available()).toEqual(false);
           });
 
           it('should return false if LIVE and no url exists', function () {
             subtitlesAvailable = false;
-            var subtitles = Subtitles(null, segmentLength, true, null, null, null, mediaSourcesMock);
+            live = true;
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
 
             expect(subtitles.available()).toEqual(false);
           });
@@ -271,7 +277,7 @@ require(
 
         describe('setPosition', function () {
           it('calls through to subtitlesContainer updatePosition', function () {
-            var subtitles = Subtitles(null, null, true, null);
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
             subtitles.setPosition('pos');
 
             expect(subtitlesContainerSpies.updatePosition).toHaveBeenCalledWith('pos');
@@ -280,7 +286,7 @@ require(
 
         describe('customise', function () {
           it('passes through custom style object and enabled state to subtitlesContainer customise function', function () {
-            var subtitles = Subtitles(null, null, true, null);
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
             var customStyleObj = { size: 0.7 };
             subtitles.customise(customStyleObj);
 
@@ -290,7 +296,7 @@ require(
 
         describe('renderExample', function () {
           it('calls subtitlesContainer renderExample function with correct values', function () {
-            var subtitles = Subtitles(null, null, true, null);
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
             var exampleUrl = '';
             var customStyleObj = { size: 0.7 };
             var safePosition = { left: 30, top: 0 };
@@ -302,7 +308,7 @@ require(
 
         describe('clearExample', function () {
           it('calls subtitlesContainer clearExample function ', function () {
-            var subtitles = Subtitles(null, null, true, null);
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
             subtitles.clearExample();
 
             expect(subtitlesContainerSpies.clearExample).toHaveBeenCalledTimes(1);
@@ -311,7 +317,7 @@ require(
 
         describe('tearDown', function () {
           it('calls through to subtitlesContainer tearDown', function () {
-            var subtitles = Subtitles(null, null, true, null);
+            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
             subtitles.tearDown();
 
             expect(subtitlesContainerSpies.tearDown).toHaveBeenCalledTimes(1);

--- a/script-test/subtitles/subtitles.js
+++ b/script-test/subtitles/subtitles.js
@@ -57,7 +57,7 @@ require(
             var mockMediaPlayer = {};
             var autoStart = true;
             var mockPlaybackElement = document.createElement('div');
-            Subtitles(mockMediaPlayer, autoStart, mockPlaybackElement, null, null, mediaSourcesMock);
+            Subtitles(mockMediaPlayer, autoStart, mockPlaybackElement, null, mediaSourcesMock);
 
             expect(subtitlesMock).toHaveBeenCalledTimes(1);
           });
@@ -82,7 +82,7 @@ require(
             var autoStart = true;
             var mockPlaybackElement = document.createElement('div');
 
-            Subtitles(mockMediaPlayer, autoStart, mockPlaybackElement, null, null, mediaSourcesMock);
+            Subtitles(mockMediaPlayer, autoStart, mockPlaybackElement, null, mediaSourcesMock);
 
             expect(subtitlesMock).toHaveBeenCalledTimes(1);
           });
@@ -123,17 +123,16 @@ require(
             var autoStart = true;
             var mockPlaybackElement = document.createElement('div');
             var customDefaultStyle = {};
-            var windowStartTime = '123456';
 
-            Subtitles(mockMediaPlayer, autoStart, mockPlaybackElement, customDefaultStyle, windowStartTime, mediaSourcesMock);
+            Subtitles(mockMediaPlayer, autoStart, mockPlaybackElement, customDefaultStyle, mediaSourcesMock);
 
-            expect(subtitlesContainer).toHaveBeenCalledWith(mockMediaPlayer, autoStart, mockPlaybackElement, mediaSourcesMock, customDefaultStyle, windowStartTime);
+            expect(subtitlesContainer).toHaveBeenCalledWith(mockMediaPlayer, autoStart, mockPlaybackElement, mediaSourcesMock, customDefaultStyle);
           });
         });
 
         describe('show', function () {
           it('should start subtitles when enabled and available', function () {
-            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, null, null, null, mediaSourcesMock);
             subtitles.enable();
             subtitles.show();
 
@@ -141,7 +140,7 @@ require(
           });
 
           it('should not start subtitles when disabled and available', function () {
-            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, null, null, null, mediaSourcesMock);
             subtitles.disable();
             subtitles.show();
 
@@ -150,7 +149,7 @@ require(
 
           it('should not start subtitles when enabled and unavailable', function () {
             subtitlesAvailable = false;
-            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, null, null, null, mediaSourcesMock);
             subtitles.enable();
             subtitles.show();
 
@@ -159,7 +158,7 @@ require(
 
           it('should not start subtitles when disabled and unavailable', function () {
             subtitlesAvailable = false;
-            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, null, null, null, mediaSourcesMock);
             subtitles.disable();
             subtitles.show();
 
@@ -169,7 +168,7 @@ require(
 
         describe('hide', function () {
           it('should stop subtitles when available', function () {
-            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, null, null, null, mediaSourcesMock);
             subtitles.hide();
 
             expect(subtitlesContainerSpies.stop).toHaveBeenCalledWith();
@@ -178,7 +177,7 @@ require(
 
         describe('enable', function () {
           it('should set enabled state to true', function () {
-            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, null, null, null, mediaSourcesMock);
             subtitles.enable();
 
             expect(subtitles.enabled()).toEqual(true);
@@ -187,7 +186,7 @@ require(
 
         describe('disable', function () {
           it('should set enabled state to false', function () {
-            var subtitles = Subtitles(null, null, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, null, null, null, mediaSourcesMock);
             subtitles.disable();
 
             expect(subtitlesContainerSpies.stop).not.toHaveBeenCalled();
@@ -197,26 +196,26 @@ require(
 
         describe('enabled', function () {
           it('should return true if subtitles are enabled at construction', function () {
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
 
             expect(subtitles.enabled()).toEqual(true);
           });
 
           it('should return true if subtitles are enabled by an api call', function () {
-            var subtitles = Subtitles(null, false, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, false, null, null, mediaSourcesMock);
             subtitles.enable();
 
             expect(subtitles.enabled()).toEqual(true);
           });
 
           it('should return false if subtitles are disabled at construction', function () {
-            var subtitles = Subtitles(null, false, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, false, null, null, mediaSourcesMock);
 
             expect(subtitles.enabled()).toEqual(false);
           });
 
           it('should return true if subtitles are disabled by an api call', function () {
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
             subtitles.disable();
 
             expect(subtitles.enabled()).toEqual(false);
@@ -225,13 +224,13 @@ require(
 
         describe('available', function () {
           it('should return true if VOD and url exists', function () {
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
 
             expect(subtitles.available()).toEqual(true);
           });
 
           it('should return true if LIVE, url exists and no override', function () {
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
 
             expect(subtitles.available()).toEqual(true);
           });
@@ -242,7 +241,7 @@ require(
                 legacySubtitles: true
               }
             };
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
 
             expect(subtitles.available()).toEqual(true);
           });
@@ -254,14 +253,14 @@ require(
                 legacySubtitles: true
               }
             };
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
 
             expect(subtitles.available()).toEqual(false);
           });
 
           it('should return false if VOD and no url exists', function () {
             subtitlesAvailable = false;
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
 
             expect(subtitles.available()).toEqual(false);
           });
@@ -269,7 +268,7 @@ require(
           it('should return false if LIVE and no url exists', function () {
             subtitlesAvailable = false;
             live = true;
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
 
             expect(subtitles.available()).toEqual(false);
           });
@@ -277,7 +276,7 @@ require(
 
         describe('setPosition', function () {
           it('calls through to subtitlesContainer updatePosition', function () {
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
             subtitles.setPosition('pos');
 
             expect(subtitlesContainerSpies.updatePosition).toHaveBeenCalledWith('pos');
@@ -286,7 +285,7 @@ require(
 
         describe('customise', function () {
           it('passes through custom style object and enabled state to subtitlesContainer customise function', function () {
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
             var customStyleObj = { size: 0.7 };
             subtitles.customise(customStyleObj);
 
@@ -296,7 +295,7 @@ require(
 
         describe('renderExample', function () {
           it('calls subtitlesContainer renderExample function with correct values', function () {
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
             var exampleUrl = '';
             var customStyleObj = { size: 0.7 };
             var safePosition = { left: 30, top: 0 };
@@ -308,7 +307,7 @@ require(
 
         describe('clearExample', function () {
           it('calls subtitlesContainer clearExample function ', function () {
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
             subtitles.clearExample();
 
             expect(subtitlesContainerSpies.clearExample).toHaveBeenCalledTimes(1);
@@ -317,7 +316,7 @@ require(
 
         describe('tearDown', function () {
           it('calls through to subtitlesContainer tearDown', function () {
-            var subtitles = Subtitles(null, true, null, null, null, mediaSourcesMock);
+            var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
             subtitles.tearDown();
 
             expect(subtitlesContainerSpies.tearDown).toHaveBeenCalledTimes(1);

--- a/script-test/subtitles/subtitles.js
+++ b/script-test/subtitles/subtitles.js
@@ -11,14 +11,14 @@ require(
 
     describe('Subtitles', function () {
       mediaSourcesMock = {
-        currentCaptionsSource: function () {
+        currentSubtitlesSource: function () {
           if (subtitlesAvailable) {
-            return 'http://captions.example.test';
+            return 'http://subtitles.example.test';
           } else {
             return '';
           }
         },
-        currentCaptionsSegmentLength: function () {
+        currentSubtitlesSegmentLength: function () {
           return live ? 3.84 : undefined;
         }
       };

--- a/script-test/subtitles/subtitles.js
+++ b/script-test/subtitles/subtitles.js
@@ -11,7 +11,7 @@ require(
 
     describe('Subtitles', function () {
       mediaSourcesMock = {
-        getCurrentCaptionsUrl: function () {
+        currentCaptionsSource: function () {
           if (subtitlesAvailable) {
             return 'http://captions.example.test';
           } else {

--- a/script-test/subtitles/subtitles.js
+++ b/script-test/subtitles/subtitles.js
@@ -127,7 +127,7 @@ require(
 
             Subtitles(mockMediaPlayer, autoStart, mockPlaybackElement, customDefaultStyle, windowStartTime, mediaSourcesMock);
 
-            expect(subtitlesContainer).toHaveBeenCalledWith(mockMediaPlayer, autoStart, mockPlaybackElement, customDefaultStyle, windowStartTime, mediaSourcesMock);
+            expect(subtitlesContainer).toHaveBeenCalledWith(mockMediaPlayer, autoStart, mockPlaybackElement, mediaSourcesMock, customDefaultStyle, windowStartTime);
           });
         });
 

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -130,9 +130,10 @@ define('bigscreenplayer/bigscreenplayer',
           mediaStateUpdateCallback
         );
 
+        var segmentLength = bigscreenPlayerData.media.captions ? bigscreenPlayerData.media.captions.segmentLength : undefined;
         subtitles = Subtitles(
           playerComponent,
-          bigscreenPlayerData.media.captions,
+          segmentLength,
           enableSubtitles,
           playbackElement,
           bigscreenPlayerData.media.subtitleCustomisation,
@@ -207,8 +208,9 @@ define('bigscreenplayer/bigscreenplayer',
             }
           };
 
+          var captionUrls = bigscreenPlayerData.media.captions ? bigscreenPlayerData.media.captions.urls : undefined;
           mediaSources = new MediaSources();
-          mediaSources.init(bigscreenPlayerData.media.urls, bigscreenPlayerData.media.captions, serverDate, windowType, getLiveSupport(), mediaSourceCallbacks);
+          mediaSources.init(bigscreenPlayerData.media.urls, captionUrls, serverDate, windowType, getLiveSupport(), mediaSourceCallbacks);
         },
 
         tearDown: function () {

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -208,7 +208,7 @@ define('bigscreenplayer/bigscreenplayer',
           mediaSources = new MediaSources();
 
           // Backwards compatibility with Old API; to be removed on Major Version Update
-          if(bigscreenPlayerData.media && !!bigscreenPlayerData.media.captions && bigscreenPlayerData.media.captionsUrl) { 
+          if(bigscreenPlayerData.media && !bigscreenPlayerData.media.captions && bigscreenPlayerData.media.captionsUrl) { 
             bigscreenPlayerData.media.captions = [{
               url: bigscreenPlayerData.media.captionsUrl
             }]

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -130,10 +130,8 @@ define('bigscreenplayer/bigscreenplayer',
           mediaStateUpdateCallback
         );
 
-        var segmentLength = bigscreenPlayerData.media.captions ? bigscreenPlayerData.media.captions.segmentLength : undefined;
         subtitles = Subtitles(
           playerComponent,
-          segmentLength,
           enableSubtitles,
           playbackElement,
           bigscreenPlayerData.media.subtitleCustomisation,
@@ -208,9 +206,8 @@ define('bigscreenplayer/bigscreenplayer',
             }
           };
 
-          var captionUrls = bigscreenPlayerData.media.captions ? bigscreenPlayerData.media.captions.urls : undefined;
           mediaSources = new MediaSources();
-          mediaSources.init(bigscreenPlayerData.media.urls, captionUrls, serverDate, windowType, getLiveSupport(), mediaSourceCallbacks);
+          mediaSources.init(bigscreenPlayerData.media.urls, bigscreenPlayerData.media.captions, serverDate, windowType, getLiveSupport(), mediaSourceCallbacks);
         },
 
         tearDown: function () {

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -206,6 +206,14 @@ define('bigscreenplayer/bigscreenplayer',
           };
 
           mediaSources = new MediaSources();
+
+          // Backwards compatibility with Old API; to be removed on Major Version Update
+          if(bigscreenPlayerData.media && !!bigscreenPlayerData.media.captions && bigscreenPlayerData.media.captionsUrl) { 
+            bigscreenPlayerData.media.captions = [{
+              url: bigscreenPlayerData.media.captionsUrl
+            }]
+          }
+
           mediaSources.init(bigscreenPlayerData.media.urls, bigscreenPlayerData.media.captions, serverDate, windowType, getLiveSupport(), mediaSourceCallbacks);
         },
 

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -135,7 +135,6 @@ define('bigscreenplayer/bigscreenplayer',
           enableSubtitles,
           playbackElement,
           bigscreenPlayerData.media.subtitleCustomisation,
-          getWindowStartTime() / 1000,
           mediaSources
         );
 

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -208,10 +208,10 @@ define('bigscreenplayer/bigscreenplayer',
           mediaSources = new MediaSources();
 
           // Backwards compatibility with Old API; to be removed on Major Version Update
-          if(bigscreenPlayerData.media && !bigscreenPlayerData.media.captions && bigscreenPlayerData.media.captionsUrl) { 
+          if (bigscreenPlayerData.media && !bigscreenPlayerData.media.captions && bigscreenPlayerData.media.captionsUrl) {
             bigscreenPlayerData.media.captions = [{
               url: bigscreenPlayerData.media.captionsUrl
-            }]
+            }];
           }
 
           mediaSources.init(bigscreenPlayerData.media.urls, bigscreenPlayerData.media.captions, serverDate, windowType, getLiveSupport(), mediaSourceCallbacks);

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -218,14 +218,14 @@ define('bigscreenplayer/bigscreenplayer',
         },
 
         tearDown: function () {
-          if (playerComponent) {
-            playerComponent.tearDown();
-            playerComponent = undefined;
-          }
-
           if (subtitles) {
             subtitles.tearDown();
             subtitles = undefined;
+          }
+
+          if (playerComponent) {
+            playerComponent.tearDown();
+            playerComponent = undefined;
           }
 
           stateChangeCallbacks = [];

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -132,11 +132,12 @@ define('bigscreenplayer/bigscreenplayer',
 
         subtitles = Subtitles(
           playerComponent,
-          bigscreenPlayerData.media.captions || { captionsUrl: bigscreenPlayerData.media.captionsUrl },
+          bigscreenPlayerData.media.captions,
           enableSubtitles,
           playbackElement,
           bigscreenPlayerData.media.subtitleCustomisation,
-          getWindowStartTime() / 1000
+          getWindowStartTime() / 1000,
+          mediaSources
         );
 
         if (enableSubtitles) {
@@ -207,7 +208,7 @@ define('bigscreenplayer/bigscreenplayer',
           };
 
           mediaSources = new MediaSources();
-          mediaSources.init(bigscreenPlayerData.media.urls, serverDate, windowType, getLiveSupport(), mediaSourceCallbacks);
+          mediaSources.init(bigscreenPlayerData.media.urls, bigscreenPlayerData.media.captions, serverDate, windowType, getLiveSupport(), mediaSourceCallbacks);
         },
 
         tearDown: function () {

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -20,9 +20,9 @@ define('bigscreenplayer/mediasources',
       var serverDate;
       var time = {};
       var transferFormat;
-      var captionSources;
+      var subtitlesSources;
 
-      function init (urls, captions, newServerDate, newWindowType, newLiveSupport, callbacks) {
+      function init (urls, subtitles, newServerDate, newWindowType, newLiveSupport, callbacks) {
         if (urls === undefined || urls.length === 0) {
           throw new Error('Media Sources urls are undefined');
         }
@@ -37,7 +37,7 @@ define('bigscreenplayer/mediasources',
         liveSupport = newLiveSupport;
         serverDate = newServerDate;
         mediaSources = PlaybackUtils.cloneArray(urls);
-        captionSources = PlaybackUtils.cloneArray(captions);
+        subtitlesSources = PlaybackUtils.cloneArray(subtitles);
         updateDebugOutput();
 
         if (needToGetManifest(windowType, liveSupport)) {
@@ -63,9 +63,9 @@ define('bigscreenplayer/mediasources',
         }
       }
 
-      function failoverCaptions (postFailoverAction, failoverErrorAction) {
-        if (captionSources.length > 1) {
-          captionSources.shift();
+      function failoverSubtitles (postFailoverAction, failoverErrorAction) {
+        if (subtitlesSources.length > 1) {
+          subtitlesSources.shift();
           updateDebugOutput();
           postFailoverAction();
         } else {
@@ -170,17 +170,17 @@ define('bigscreenplayer/mediasources',
         return '';
       }
 
-      function getCurrentCaptionsUrl () {
-        if (captionSources.length > 0) {
-          return captionSources[0].url.toString();
+      function getCurrentSubtitlesUrl () {
+        if (subtitlesSources.length > 0) {
+          return subtitlesSources[0].url.toString();
         }
 
         return '';
       }
 
-      function getCurrentCaptionSegmentLength () {
-        if (captionSources.length > 0) {
-          return captionSources[0].segmentLength;
+      function getCurrentSubtitlesSegmentLength () {
+        if (subtitlesSources.length > 0) {
+          return subtitlesSources[0].segmentLength;
         }
 
         return undefined;
@@ -225,9 +225,9 @@ define('bigscreenplayer/mediasources',
         return '';
       }
 
-      function getCurrentCaptionsCdn () {
-        if (captionSources.length > 0) {
-          return captionSources[0].cdn.toString();
+      function getCurrentSubtitlesCdn () {
+        if (subtitlesSources.length > 0) {
+          return subtitlesSources[0].cdn.toString();
         }
 
         return '';
@@ -239,9 +239,9 @@ define('bigscreenplayer/mediasources',
         });
       }
 
-      function availableCaptionsCdns () {
-        return captionSources.map(function (mediaSource) {
-          return mediaSource.cdn;
+      function availableSubtitlesCdns () {
+        return subtitlesSources.map(function (mediaSource) {
+          return subtitlesSources.cdn;
         });
       }
 
@@ -250,19 +250,19 @@ define('bigscreenplayer/mediasources',
         DebugTool.keyValue({key: 'current cdn', value: getCurrentCdn()});
         DebugTool.keyValue({key: 'url', value: getCurrentUrl()});
 
-        DebugTool.keyValue({key: 'available subtitle cdns', value: availableCaptionsCdns()});
-        DebugTool.keyValue({key: 'current subtitles cdn', value: getCurrentCaptionsCdn()});
-        DebugTool.keyValue({key: 'subtitles url', value: getCurrentCaptionsUrl()});
+        DebugTool.keyValue({key: 'available subtitle cdns', value: availableSubtitlesCdns()});
+        DebugTool.keyValue({key: 'current subtitles cdn', value: getCurrentSubtitlesCdn()});
+        DebugTool.keyValue({key: 'subtitles url', value: getCurrentSubtitlesUrl()});
       }
 
       return {
         init: init,
         failover: failover,
-        failoverCaptions: failoverCaptions,
+        failoverSubtitles: failoverSubtitles,
         refresh: refresh,
         currentSource: getCurrentUrl,
-        currentCaptionsSource: getCurrentCaptionsUrl,
-        currentCaptionsSegmentLength: getCurrentCaptionSegmentLength,
+        currentSubtitlesSource: getCurrentSubtitlesUrl,
+        currentSubtitlesSegmentLength: getCurrentSubtitlesSegmentLength,
         availableSources: availableUrls,
         time: generateTime
       };

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -251,7 +251,7 @@ define('bigscreenplayer/mediasources',
         DebugTool.keyValue({key: 'url', value: getCurrentUrl()});
 
         DebugTool.keyValue({key: 'available subtitle cdns', value: availableCaptionsCdns()});
-        DebugTool.keyValue({key: 'current subtitles cdns', value: getCurrentCaptionsCdn()});
+        DebugTool.keyValue({key: 'current subtitles cdn', value: getCurrentCaptionsCdn()});
         DebugTool.keyValue({key: 'subtitles url', value: getCurrentCaptionsUrl()});
       }
 

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -240,8 +240,8 @@ define('bigscreenplayer/mediasources',
       }
 
       function availableSubtitlesCdns () {
-        return subtitlesSources.map(function (mediaSource) {
-          return subtitlesSources.cdn;
+        return subtitlesSources.map(function (subtitleSource) {
+          return subtitleSource.cdn;
         });
       }
 

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -66,6 +66,7 @@ define('bigscreenplayer/mediasources',
       function failoverCaptions (postFailoverAction, failoverErrorAction) {
         if (captionSources.length > 1) {
           captionSources.shift();
+          updateDebugOutput();
           postFailoverAction();
         } else {
           failoverErrorAction();
@@ -224,8 +225,22 @@ define('bigscreenplayer/mediasources',
         return '';
       }
 
+      function getCurrentCaptionsCdn () {
+        if (captionSources.length > 0) {
+          return captionSources[0].cdn.toString();
+        }
+
+        return '';
+      }
+
       function availableCdns () {
         return mediaSources.map(function (mediaSource) {
+          return mediaSource.cdn;
+        });
+      }
+
+      function availableCaptionsCdns () {
+        return captionSources.map(function (mediaSource) {
           return mediaSource.cdn;
         });
       }
@@ -234,6 +249,10 @@ define('bigscreenplayer/mediasources',
         DebugTool.keyValue({key: 'available cdns', value: availableCdns()});
         DebugTool.keyValue({key: 'current cdn', value: getCurrentCdn()});
         DebugTool.keyValue({key: 'url', value: getCurrentUrl()});
+
+        DebugTool.keyValue({key: 'available subtitle cdns', value: availableCaptionsCdns()});
+        DebugTool.keyValue({key: 'current subtitles cdns', value: getCurrentCaptionsCdn()});
+        DebugTool.keyValue({key: 'subtitles url', value: getCurrentCaptionsUrl()});
       }
 
       return {

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -20,8 +20,9 @@ define('bigscreenplayer/mediasources',
       var serverDate;
       var time = {};
       var transferFormat;
+      var captionSources;
 
-      function init (urls, newServerDate, newWindowType, newLiveSupport, callbacks) {
+      function init (urls, captionUrls, newServerDate, newWindowType, newLiveSupport, callbacks) {
         if (urls === undefined || urls.length === 0) {
           throw new Error('Media Sources urls are undefined');
         }
@@ -36,6 +37,7 @@ define('bigscreenplayer/mediasources',
         liveSupport = newLiveSupport;
         serverDate = newServerDate;
         mediaSources = PlaybackUtils.cloneArray(urls);
+        // captionSources = PlaybackUtils.cloneArray(captionUrls);
         updateDebugOutput();
 
         if (needToGetManifest(windowType, liveSupport)) {
@@ -158,6 +160,14 @@ define('bigscreenplayer/mediasources',
         return '';
       }
 
+      function getCurrentCaptionsUrl () {
+        if (captionSources.length > 0) {
+          return captionSources[0];
+        }
+
+        return '';
+      }
+
       function availableUrls () {
         return mediaSources.map(function (mediaSource) {
           return mediaSource.url;
@@ -214,6 +224,7 @@ define('bigscreenplayer/mediasources',
         failover: failover,
         refresh: refresh,
         currentSource: getCurrentUrl,
+        getCurrentCaptionsUrl: getCurrentCaptionsUrl,
         availableSources: availableUrls,
         time: generateTime
       };

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -22,7 +22,7 @@ define('bigscreenplayer/mediasources',
       var transferFormat;
       var subtitlesSources;
 
-      function init (urls, subtitles, newServerDate, newWindowType, newLiveSupport, callbacks) {
+      function init (urls, subtitlesUrls, newServerDate, newWindowType, newLiveSupport, callbacks) {
         if (urls === undefined || urls.length === 0) {
           throw new Error('Media Sources urls are undefined');
         }
@@ -36,8 +36,8 @@ define('bigscreenplayer/mediasources',
         windowType = newWindowType;
         liveSupport = newLiveSupport;
         serverDate = newServerDate;
-        mediaSources = PlaybackUtils.cloneArray(urls);
-        subtitlesSources = PlaybackUtils.cloneArray(subtitles);
+        mediaSources = urls ? PlaybackUtils.cloneArray(urls) : [];
+        subtitlesSources = subtitlesUrls ? PlaybackUtils.cloneArray(subtitlesUrls) : [];
         updateDebugOutput();
 
         if (needToGetManifest(windowType, liveSupport)) {

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -67,9 +67,9 @@ define('bigscreenplayer/mediasources',
         if (subtitlesSources.length > 1) {
           subtitlesSources.shift();
           updateDebugOutput();
-          postFailoverAction();
+          if (postFailoverAction) { postFailoverAction(); }
         } else {
-          failoverErrorAction();
+          if (failoverErrorAction) { failoverErrorAction(); }
         }
       }
 

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -217,22 +217,6 @@ define('bigscreenplayer/mediasources',
         Plugins.interface.onErrorHandled(evt);
       }
 
-      function getCurrentCdn () {
-        if (mediaSources.length > 0) {
-          return mediaSources[0].cdn.toString();
-        }
-
-        return '';
-      }
-
-      function getCurrentSubtitlesCdn () {
-        if (subtitlesSources.length > 0) {
-          return subtitlesSources[0].cdn.toString();
-        }
-
-        return '';
-      }
-
       function availableCdns () {
         return mediaSources.map(function (mediaSource) {
           return mediaSource.cdn;
@@ -247,11 +231,9 @@ define('bigscreenplayer/mediasources',
 
       function updateDebugOutput () {
         DebugTool.keyValue({key: 'available cdns', value: availableCdns()});
-        DebugTool.keyValue({key: 'current cdn', value: getCurrentCdn()});
         DebugTool.keyValue({key: 'url', value: getCurrentUrl()});
 
         DebugTool.keyValue({key: 'available subtitle cdns', value: availableSubtitlesCdns()});
-        DebugTool.keyValue({key: 'current subtitles cdn', value: getCurrentSubtitlesCdn()});
         DebugTool.keyValue({key: 'subtitles url', value: getCurrentSubtitlesUrl()});
       }
 

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -224,7 +224,7 @@ define('bigscreenplayer/mediasources',
         failover: failover,
         refresh: refresh,
         currentSource: getCurrentUrl,
-        getCurrentCaptionsUrl: getCurrentCaptionsUrl,
+        currentCaptionsSource: getCurrentCaptionsUrl,
         availableSources: availableUrls,
         time: generateTime
       };

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -63,6 +63,15 @@ define('bigscreenplayer/mediasources',
         }
       }
 
+      function failoverCaptions (postFailoverAction, failoverErrorAction) {
+        if (captionSources.length > 1) {
+          captionSources.shift();
+          postFailoverAction();
+        } else {
+          failoverErrorAction();
+        }
+      }
+
       function shouldFailover (failoverParams) {
         if (isFirstManifest(failoverParams.serviceLocation)) {
           return false;
@@ -230,6 +239,7 @@ define('bigscreenplayer/mediasources',
       return {
         init: init,
         failover: failover,
+        failoverCaptions: failoverCaptions,
         refresh: refresh,
         currentSource: getCurrentUrl,
         currentCaptionsSource: getCurrentCaptionsUrl,

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -22,7 +22,7 @@ define('bigscreenplayer/mediasources',
       var transferFormat;
       var captionSources;
 
-      function init (urls, captionUrls, newServerDate, newWindowType, newLiveSupport, callbacks) {
+      function init (urls, captions, newServerDate, newWindowType, newLiveSupport, callbacks) {
         if (urls === undefined || urls.length === 0) {
           throw new Error('Media Sources urls are undefined');
         }
@@ -37,7 +37,7 @@ define('bigscreenplayer/mediasources',
         liveSupport = newLiveSupport;
         serverDate = newServerDate;
         mediaSources = PlaybackUtils.cloneArray(urls);
-        // captionSources = PlaybackUtils.cloneArray(captionUrls);
+        captionSources = PlaybackUtils.cloneArray(captions);
         updateDebugOutput();
 
         if (needToGetManifest(windowType, liveSupport)) {
@@ -162,7 +162,7 @@ define('bigscreenplayer/mediasources',
 
       function getCurrentCaptionsUrl () {
         if (captionSources.length > 0) {
-          return captionSources[0];
+          return captionSources[0].url.toString();
         }
 
         return '';

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -168,6 +168,14 @@ define('bigscreenplayer/mediasources',
         return '';
       }
 
+      function getCurrentCaptionSegmentLength () {
+        if (captionSources.length > 0) {
+          return captionSources[0].segmentLength;
+        }
+
+        return undefined;
+      }
+
       function availableUrls () {
         return mediaSources.map(function (mediaSource) {
           return mediaSource.url;
@@ -225,6 +233,7 @@ define('bigscreenplayer/mediasources',
         refresh: refresh,
         currentSource: getCurrentUrl,
         currentCaptionsSource: getCurrentCaptionsUrl,
+        currentCaptionsSegmentLength: getCurrentCaptionSegmentLength,
         availableSources: availableUrls,
         time: generateTime
       };

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -83,9 +83,14 @@ define('bigscreenplayer/subtitles/imscsubtitles',
             DebugTool.info('Error loading subtitles data: ' + error);
             Plugins.interface.onSubtitlesLoadError();
             stop();
-            mediaSources.failoverCaptions(start);
+            mediaSources.failoverCaptions(start, failoverError);
           }
         });
+      }
+
+      function failoverError () {
+        // what do we do when we run out of cdns
+        DebugTool.info('Used all subtitles cdns');
       }
 
       function pruneSegments () {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -96,6 +96,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function loadErrorFailover () {
+        var successCase = function () {};
         var errorCase = function () {
           stop();
           Plugins.interface.onSubtitlesLoadError();
@@ -105,10 +106,10 @@ define('bigscreenplayer/subtitles/imscsubtitles',
           loadErrorCount++;
           if (loadErrorCount >= LOAD_ERROR_COUNT_MAX) {
             resetLoadErrorCount();
-            mediaSources.failoverSubtitles(start, errorCase);
+            mediaSources.failoverSubtitles(successCase, errorCase);
           }
         } else {
-          mediaSources.failoverSubtitles(start, errorCase);
+          mediaSources.failoverSubtitles(successCase, errorCase);
         }
       }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -96,20 +96,25 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function loadErrorFailover () {
-        var successCase = function () {};
         var errorCase = function () {
           stop();
           Plugins.interface.onSubtitlesLoadError();
         };
 
         if (liveSubtitles) {
-          loadErrorCount++;
-          if (loadErrorCount >= LOAD_ERROR_COUNT_MAX) {
-            resetLoadErrorCount();
-            mediaSources.failoverSubtitles(successCase, errorCase);
+          if (loadErrorLimit) {
+            mediaSources.failoverSubtitles(undefined, errorCase);
           }
         } else {
-          mediaSources.failoverSubtitles(successCase, errorCase);
+          mediaSources.failoverSubtitles(start, errorCase);
+        }
+      }
+
+      function loadErrorLimit () {
+        loadErrorCount++;
+        if (loadErrorCount >= LOAD_ERROR_COUNT_MAX) {
+          resetLoadErrorCount();
+          return true;
         }
       }
 
@@ -296,6 +301,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         clearExample: removeExampleSubtitlesElement,
         tearDown: function () {
           stop();
+          resetLoadErrorCount();
           segments = undefined;
         }
       };

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -10,7 +10,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
   ],
   function (IMSC, DOMHelpers, DebugTool, Plugins, Utils, LoadURL, TimeUtils) {
     'use strict';
-    return function (mediaPlayer, autoStart, parentElement, mediaSources, defaultStyleOpts, windowStartEpochSeconds) {
+    return function (mediaPlayer, autoStart, parentElement, mediaSources, defaultStyleOpts) {
       var currentSubtitlesElement;
       var exampleSubtitlesElement;
       var imscRenderOpts = transformStyleOptions(defaultStyleOpts);
@@ -21,6 +21,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       var liveSubtitles = !!mediaSources.currentCaptionsSegmentLength();
       var loadErrorCount = 0;
       var LOAD_ERROR_COUNT_MAX = 3;
+      var windowStartEpochSeconds = getWindowStartTime() / 1000;
 
       if (autoStart) {
         start();
@@ -246,6 +247,10 @@ define('bigscreenplayer/subtitles/imscsubtitles',
 
       function getCurrentTime () {
         return liveSubtitles ? windowStartEpochSeconds + mediaPlayer.getCurrentTime() : mediaPlayer.getCurrentTime();
+      }
+
+      function getWindowStartTime () {
+        return mediaSources && mediaSources.time().windowStartTime;
       }
 
       function start () {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -79,7 +79,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
                 pruneSegments();
               }
             } catch (e) {
-              DebugTool.info('Error transforming subtitles : ' + e);
+              DebugTool.info('Error transforming subtitles: ' + e);
               Plugins.interface.onSubtitlesTransformError();
               stop();
             }

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -10,7 +10,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
   ],
   function (IMSC, DOMHelpers, DebugTool, Plugins, Utils, LoadURL, TimeUtils) {
     'use strict';
-    return function (mediaPlayer, autoStart, parentElement, defaultStyleOpts, windowStartEpochSeconds, mediaSources) {
+    return function (mediaPlayer, autoStart, parentElement, mediaSources, defaultStyleOpts, windowStartEpochSeconds) {
       var currentSubtitlesElement;
       var exampleSubtitlesElement;
       var imscRenderOpts = transformStyleOptions(defaultStyleOpts);

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -60,6 +60,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
               DebugTool.info('Error: responseXML is invalid.');
               Plugins.interface.onSubtitlesTransformError();
               stop();
+              mediaSources.failoverCaptions(start);
               return;
             }
 
@@ -99,16 +100,12 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         if (liveSubtitles) {
           loadErrorCount++;
           if (loadErrorCount >= LOAD_ERROR_COUNT_MAX) {
-            mediaSources.failoverCaptions(start, failoverError);
+            resetLoadErrorCount();
+            mediaSources.failoverCaptions(start);
           }
         } else {
-          mediaSources.failoverCaptions(start, failoverError);
+          mediaSources.failoverCaptions(start);
         }
-      }
-
-      function failoverError () {
-        // what do we do when we run out of cdns
-        DebugTool.info('Used all subtitles cdns');
       }
 
       function pruneSegments () {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -18,7 +18,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       var SEGMENTS_TO_KEEP = 3;
       var segments = [];
       var currentSegmentRendered = {};
-      var liveSubtitles = !!mediaSources.currentCaptionsSegmentLength();
+      var liveSubtitles = !!mediaSources.currentSubtitlesSegmentLength();
       var loadErrorCount = 0;
       var LOAD_ERROR_COUNT_MAX = 3;
       var windowStartEpochSeconds = getWindowStartTime() / 1000;
@@ -29,7 +29,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
 
       function loadAllRequiredSegments () {
         var segmentsToLoad = [];
-        var currentSegment = TimeUtils.calculateSegmentNumber(windowStartEpochSeconds + mediaPlayer.getCurrentTime(), mediaSources.currentCaptionsSegmentLength());
+        var currentSegment = TimeUtils.calculateSegmentNumber(windowStartEpochSeconds + mediaPlayer.getCurrentTime(), mediaSources.currentSubtitlesSegmentLength());
         for (var i = 0; i < SEGMENTS_TO_KEEP; i++) {
           var segmentNumber = currentSegment + i;
           var alreadyLoaded = segments.some(function (segment) {
@@ -47,7 +47,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         }
 
         segmentsToLoad.forEach(function (segmentNumber) {
-          var url = mediaSources.currentCaptionsSource();
+          var url = mediaSources.currentSubtitlesSource();
           loadSegment(url, segmentNumber);
         });
       }
@@ -61,7 +61,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
               DebugTool.info('Error: responseXML is invalid.');
               Plugins.interface.onSubtitlesTransformError();
               stop();
-              mediaSources.failoverCaptions(start);
+              mediaSources.failoverSubtitles(start);
               return;
             }
 
@@ -79,7 +79,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
                 pruneSegments();
               }
             } catch (e) {
-              DebugTool.info('Error transforming captions : ' + e);
+              DebugTool.info('Error transforming subtitles : ' + e);
               Plugins.interface.onSubtitlesTransformError();
               stop();
             }
@@ -102,10 +102,10 @@ define('bigscreenplayer/subtitles/imscsubtitles',
           loadErrorCount++;
           if (loadErrorCount >= LOAD_ERROR_COUNT_MAX) {
             resetLoadErrorCount();
-            mediaSources.failoverCaptions(start);
+            mediaSources.failoverSubtitles(start);
           }
         } else {
-          mediaSources.failoverCaptions(start);
+          mediaSources.failoverSubtitles(start);
         }
       }
 
@@ -254,7 +254,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function start () {
-        var url = mediaSources.currentCaptionsSource();
+        var url = mediaSources.currentSubtitlesSource();
         if (url && url !== '') {
           if (!liveSubtitles) {
             loadSegment(url);

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -83,6 +83,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
             DebugTool.info('Error loading subtitles data: ' + error);
             Plugins.interface.onSubtitlesLoadError();
             stop();
+            mediaSources.failoverCaptions(start);
           }
         });
       }

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -95,26 +95,23 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         loadErrorCount = 0;
       }
 
+      function loadErrorLimit () {
+        loadErrorCount++;
+        if (loadErrorCount >= LOAD_ERROR_COUNT_MAX) {
+          resetLoadErrorCount();
+          return true;
+        }
+      }
+
       function loadErrorFailover () {
         var errorCase = function () {
           stop();
           Plugins.interface.onSubtitlesLoadError();
         };
 
-        if (liveSubtitles) {
-          if (loadErrorLimit) {
-            mediaSources.failoverSubtitles(undefined, errorCase);
-          }
-        } else {
+        if ((liveSubtitles && loadErrorLimit()) || !liveSubtitles) {
+          stop();
           mediaSources.failoverSubtitles(start, errorCase);
-        }
-      }
-
-      function loadErrorLimit () {
-        loadErrorCount++;
-        if (loadErrorCount >= LOAD_ERROR_COUNT_MAX) {
-          resetLoadErrorCount();
-          return true;
         }
       }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -87,7 +87,6 @@ define('bigscreenplayer/subtitles/imscsubtitles',
           },
           onError: function (error) {
             DebugTool.info('Error loading subtitles data: ' + error);
-            Plugins.interface.onSubtitlesLoadError();
             stop();
             loadErrorFailover();
           }
@@ -103,10 +102,10 @@ define('bigscreenplayer/subtitles/imscsubtitles',
           loadErrorCount++;
           if (loadErrorCount >= LOAD_ERROR_COUNT_MAX) {
             resetLoadErrorCount();
-            mediaSources.failoverSubtitles(start);
+            mediaSources.failoverSubtitles(start, Plugins.interface.onSubtitlesLoadError);
           }
         } else {
-          mediaSources.failoverSubtitles(start);
+          mediaSources.failoverSubtitles(start, Plugins.interface.onSubtitlesLoadError);
         }
       }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -86,7 +86,6 @@ define('bigscreenplayer/subtitles/imscsubtitles',
           },
           onError: function (error) {
             DebugTool.info('Error loading subtitles data: ' + error);
-            stop();
             loadErrorFailover();
           }
         });
@@ -97,14 +96,19 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function loadErrorFailover () {
+        var errorCase = function () {
+          stop();
+          Plugins.interface.onSubtitlesLoadError();
+        };
+
         if (liveSubtitles) {
           loadErrorCount++;
           if (loadErrorCount >= LOAD_ERROR_COUNT_MAX) {
             resetLoadErrorCount();
-            mediaSources.failoverSubtitles(start, Plugins.interface.onSubtitlesLoadError);
+            mediaSources.failoverSubtitles(start, errorCase);
           }
         } else {
-          mediaSources.failoverSubtitles(start, Plugins.interface.onSubtitlesLoadError);
+          mediaSources.failoverSubtitles(start, errorCase);
         }
       }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -44,7 +44,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         }
 
         segmentsToLoad.forEach(function (segmentNumber) {
-          var url = mediaSources.getCurrentCaptionsUrl();
+          var url = mediaSources.currentCaptionsSource();
           loadSegment(url, segmentNumber);
         });
       }
@@ -228,7 +228,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function start () {
-        var url = mediaSources.getCurrentCaptionsUrl();
+        var url = mediaSources.currentCaptionsSource();
         if (url && url !== '') {
           if (!liveSubtitles) {
             loadSegment(url);

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -10,7 +10,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
   ],
   function (IMSC, DOMHelpers, DebugTool, Plugins, Utils, LoadURL, TimeUtils) {
     'use strict';
-    return function (mediaPlayer, segmentLength, autoStart, parentElement, defaultStyleOpts, windowStartEpochSeconds, mediaSources) {
+    return function (mediaPlayer, autoStart, parentElement, defaultStyleOpts, windowStartEpochSeconds, mediaSources) {
       var currentSubtitlesElement;
       var exampleSubtitlesElement;
       var imscRenderOpts = transformStyleOptions(defaultStyleOpts);
@@ -18,7 +18,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       var SEGMENTS_TO_KEEP = 3;
       var segments = [];
       var currentSegmentRendered = {};
-      var liveSubtitles = !!segmentLength;
+      var liveSubtitles = !!mediaSources.currentCaptionsSegmentLength();
 
       if (autoStart) {
         start();
@@ -26,7 +26,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
 
       function loadAllRequiredSegments () {
         var segmentsToLoad = [];
-        var currentSegment = TimeUtils.calculateSegmentNumber(windowStartEpochSeconds + mediaPlayer.getCurrentTime(), segmentLength);
+        var currentSegment = TimeUtils.calculateSegmentNumber(windowStartEpochSeconds + mediaPlayer.getCurrentTime(), mediaSources.currentCaptionsSegmentLength());
         for (var i = 0; i < SEGMENTS_TO_KEEP; i++) {
           var segmentNumber = currentSegment + i;
           var alreadyLoaded = segments.some(function (segment) {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -62,7 +62,6 @@ define('bigscreenplayer/subtitles/imscsubtitles',
               DebugTool.info('Error: responseXML is invalid.');
               Plugins.interface.onSubtitlesTransformError();
               stop();
-              mediaSources.failoverSubtitles(start);
               return;
             }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -10,7 +10,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
   ],
   function (IMSC, DOMHelpers, DebugTool, Plugins, Utils, LoadURL, TimeUtils) {
     'use strict';
-    return function (mediaPlayer, captions, autoStart, parentElement, defaultStyleOpts, windowStartEpochSeconds) {
+    return function (mediaPlayer, segmentLength, autoStart, parentElement, defaultStyleOpts, windowStartEpochSeconds, mediaSources) {
       var currentSubtitlesElement;
       var exampleSubtitlesElement;
       var imscRenderOpts = transformStyleOptions(defaultStyleOpts);
@@ -18,7 +18,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       var SEGMENTS_TO_KEEP = 3;
       var segments = [];
       var currentSegmentRendered = {};
-      var liveSubtitles = !!captions.segmentLength;
+      var liveSubtitles = !!segmentLength;
 
       if (autoStart) {
         start();
@@ -26,7 +26,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
 
       function loadAllRequiredSegments () {
         var segmentsToLoad = [];
-        var currentSegment = TimeUtils.calculateSegmentNumber(windowStartEpochSeconds + mediaPlayer.getCurrentTime(), captions.segmentLength);
+        var currentSegment = TimeUtils.calculateSegmentNumber(windowStartEpochSeconds + mediaPlayer.getCurrentTime(), segmentLength);
         for (var i = 0; i < SEGMENTS_TO_KEEP; i++) {
           var segmentNumber = currentSegment + i;
           var alreadyLoaded = segments.some(function (segment) {
@@ -44,7 +44,8 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         }
 
         segmentsToLoad.forEach(function (segmentNumber) {
-          loadSegment(captions.captionsUrl, segmentNumber);
+          var url = mediaSources.getCurrentCaptionsUrl();
+          loadSegment(url, segmentNumber);
         });
       }
 
@@ -69,7 +70,6 @@ define('bigscreenplayer/subtitles/imscsubtitles',
                 previousSubtitleIndex: null,
                 number: segmentNumber
               });
-
               if (segments.length > SEGMENTS_TO_KEEP) {
                 pruneSegments();
               }
@@ -228,9 +228,10 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function start () {
-        if (captions.captionsUrl) {
+        var url = mediaSources.getCurrentCaptionsUrl();
+        if (url && url !== '') {
           if (!liveSubtitles) {
-            loadSegment(captions.captionsUrl);
+            loadSegment(url);
           }
 
           updateInterval = setInterval(function () {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -55,6 +55,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       function loadSegment (url, segmentNumber) {
         url = url.replace('$segment$', segmentNumber);
         LoadURL(url, {
+          timeout: 5000,
           onLoad: function (responseXML, responseText, status) {
             resetLoadErrorCount();
             if (!responseXML && !liveSubtitles) {

--- a/script/subtitles/legacysubtitles.js
+++ b/script/subtitles/legacysubtitles.js
@@ -14,22 +14,28 @@ define(
       var container = document.createElement('div');
       var subtitlesRenderer;
 
-      if (mediaSources.currentCaptionsSource()) {
-        LoadURL(mediaSources.currentCaptionsSource(), {
-          onLoad: function (responseXML, responseText, status) {
-            if (!responseXML) {
-              DebugTool.info('Error: responseXML is invalid.');
-              Plugins.interface.onSubtitlesTransformError();
-              return;
-            } else {
-              createContainer(responseXML);
+      loadSubtitles();
+
+      function loadSubtitles () {
+        var url = mediaSources.currentCaptionsSource();
+        if (url && url !== '') {
+          LoadURL(url, {
+            onLoad: function (responseXML, responseText, status) {
+              if (!responseXML) {
+                DebugTool.info('Error: responseXML is invalid.');
+                Plugins.interface.onSubtitlesTransformError();
+                return;
+              } else {
+                createContainer(responseXML);
+              }
+            },
+            onError: function (error) {
+              DebugTool.info('Error loading subtitles data: ' + error);
+              Plugins.interface.onSubtitlesLoadError();
+              mediaSources.failoverCaptions(loadSubtitles);
             }
-          },
-          onError: function (error) {
-            DebugTool.info('Error loading subtitles data: ' + error);
-            Plugins.interface.onSubtitlesLoadError();
-          }
-        });
+          });
+        }
       }
 
       function createContainer (xml) {

--- a/script/subtitles/legacysubtitles.js
+++ b/script/subtitles/legacysubtitles.js
@@ -32,6 +32,7 @@ define(
             },
             onError: function (error) {
               DebugTool.info('Error loading subtitles data: ' + error);
+              tearDown();
               autoStart = true;
               mediaSources.failoverSubtitles(loadSubtitles, Plugins.interface.onSubtitlesLoadError);
             }
@@ -83,6 +84,7 @@ define(
       }
 
       function tearDown () {
+        stop();
         DOMHelpers.safeRemoveElement(container);
       }
 

--- a/script/subtitles/legacysubtitles.js
+++ b/script/subtitles/legacysubtitles.js
@@ -32,16 +32,11 @@ define(
             },
             onError: function (error) {
               DebugTool.info('Error loading subtitles data: ' + error);
-              Plugins.interface.onSubtitlesLoadError();
-              mediaSources.failoverSubtitles(loadSubtitles, failoverError);
+              autoStart = true;
+              mediaSources.failoverSubtitles(loadSubtitles, Plugins.interface.onSubtitlesLoadError);
             }
           });
         }
-      }
-
-      function failoverError () {
-        // what do we do when we run out of cdns
-        DebugTool.info('Used all subtitles cdns');
       }
 
       function createContainer (xml) {

--- a/script/subtitles/legacysubtitles.js
+++ b/script/subtitles/legacysubtitles.js
@@ -32,10 +32,15 @@ define(
             onError: function (error) {
               DebugTool.info('Error loading subtitles data: ' + error);
               Plugins.interface.onSubtitlesLoadError();
-              mediaSources.failoverCaptions(loadSubtitles);
+              mediaSources.failoverCaptions(loadSubtitles, failoverError);
             }
           });
         }
+      }
+
+      function failoverError () {
+        // what do we do when we run out of cdns
+        DebugTool.info('Used all subtitles cdns');
       }
 
       function createContainer (xml) {

--- a/script/subtitles/legacysubtitles.js
+++ b/script/subtitles/legacysubtitles.js
@@ -17,7 +17,7 @@ define(
       loadSubtitles();
 
       function loadSubtitles () {
-        var url = mediaSources.currentCaptionsSource();
+        var url = mediaSources.currentSubtitlesSource();
         if (url && url !== '') {
           LoadURL(url, {
             onLoad: function (responseXML, responseText, status) {
@@ -32,7 +32,7 @@ define(
             onError: function (error) {
               DebugTool.info('Error loading subtitles data: ' + error);
               Plugins.interface.onSubtitlesLoadError();
-              mediaSources.failoverCaptions(loadSubtitles, failoverError);
+              mediaSources.failoverSubtitles(loadSubtitles, failoverError);
             }
           });
         }

--- a/script/subtitles/legacysubtitles.js
+++ b/script/subtitles/legacysubtitles.js
@@ -20,6 +20,7 @@ define(
         var url = mediaSources.currentSubtitlesSource();
         if (url && url !== '') {
           LoadURL(url, {
+            timeout: 5000,
             onLoad: function (responseXML, responseText, status) {
               if (!responseXML) {
                 DebugTool.info('Error: responseXML is invalid.');

--- a/script/subtitles/legacysubtitles.js
+++ b/script/subtitles/legacysubtitles.js
@@ -33,8 +33,6 @@ define(
             onError: function (statusCode) {
               var errorCase = function () { Plugins.interface.onSubtitlesLoadError({status: statusCode}); };
               DebugTool.info('Error loading subtitles data: ' + statusCode);
-              tearDown();
-              autoStart = true;
               mediaSources.failoverSubtitles(loadSubtitles, errorCase);
             },
             onTimeout: function () {

--- a/script/subtitles/legacysubtitles.js
+++ b/script/subtitles/legacysubtitles.js
@@ -10,12 +10,12 @@ define(
   function (Renderer, TransportControlPosition, DOMHelpers, LoadURL, DebugTool, Plugins) {
     'use strict';
 
-    return function (mediaPlayer, captions, autoStart, parentElement) {
+    return function (mediaPlayer, autoStart, parentElement, mediaSources) {
       var container = document.createElement('div');
       var subtitlesRenderer;
 
-      if (captions.captionsUrl) {
-        LoadURL(captions.captionsUrl, {
+      if (mediaSources.currentCaptionsSource()) {
+        LoadURL(mediaSources.currentCaptionsSource(), {
           onLoad: function (responseXML, responseText, status) {
             if (!responseXML) {
               DebugTool.info('Error: responseXML is invalid.');

--- a/script/subtitles/subtitles.js
+++ b/script/subtitles/subtitles.js
@@ -37,7 +37,7 @@ define('bigscreenplayer/subtitles/subtitles',
         if (liveSubtitles && (window.bigscreenPlayer.overrides && window.bigscreenPlayer.overrides.legacySubtitles)) {
           return false;
         } else {
-          return !!mediaSources.getCurrentCaptionsUrl();
+          return !!mediaSources.currentCaptionsSource();
         }
       }
 

--- a/script/subtitles/subtitles.js
+++ b/script/subtitles/subtitles.js
@@ -4,10 +4,10 @@ define('bigscreenplayer/subtitles/subtitles',
   ],
   function (SubtitlesContainer) {
     'use strict';
-    return function (mediaPlayer, captions, autoStart, playbackElement, defaultStyleOpts, windowStartTime) {
+    return function (mediaPlayer, segmentLength, autoStart, playbackElement, defaultStyleOpts, windowStartTime, mediaSources) {
       var subtitlesEnabled = autoStart;
-      var liveSubtitles = captions.segmentLength;
-      var subtitlesContainer = SubtitlesContainer(mediaPlayer, captions, autoStart, playbackElement, defaultStyleOpts, windowStartTime);
+      var liveSubtitles = !!segmentLength;
+      var subtitlesContainer = SubtitlesContainer(mediaPlayer, segmentLength, autoStart, playbackElement, defaultStyleOpts, windowStartTime, mediaSources);
 
       function enable () {
         subtitlesEnabled = true;
@@ -37,7 +37,7 @@ define('bigscreenplayer/subtitles/subtitles',
         if (liveSubtitles && (window.bigscreenPlayer.overrides && window.bigscreenPlayer.overrides.legacySubtitles)) {
           return false;
         } else {
-          return !!captions.captionsUrl;
+          return !!mediaSources.getCurrentCaptionsUrl();
         }
       }
 

--- a/script/subtitles/subtitles.js
+++ b/script/subtitles/subtitles.js
@@ -7,7 +7,7 @@ define('bigscreenplayer/subtitles/subtitles',
     return function (mediaPlayer, autoStart, playbackElement, defaultStyleOpts, windowStartTime, mediaSources) {
       var subtitlesEnabled = autoStart;
       var liveSubtitles = !!mediaSources.currentCaptionsSegmentLength();
-      var subtitlesContainer = SubtitlesContainer(mediaPlayer, autoStart, playbackElement, defaultStyleOpts, windowStartTime, mediaSources);
+      var subtitlesContainer = SubtitlesContainer(mediaPlayer, autoStart, playbackElement, mediaSources, defaultStyleOpts, windowStartTime);
 
       function enable () {
         subtitlesEnabled = true;

--- a/script/subtitles/subtitles.js
+++ b/script/subtitles/subtitles.js
@@ -4,10 +4,10 @@ define('bigscreenplayer/subtitles/subtitles',
   ],
   function (SubtitlesContainer) {
     'use strict';
-    return function (mediaPlayer, autoStart, playbackElement, defaultStyleOpts, windowStartTime, mediaSources) {
+    return function (mediaPlayer, autoStart, playbackElement, defaultStyleOpts, mediaSources) {
       var subtitlesEnabled = autoStart;
       var liveSubtitles = !!mediaSources.currentCaptionsSegmentLength();
-      var subtitlesContainer = SubtitlesContainer(mediaPlayer, autoStart, playbackElement, mediaSources, defaultStyleOpts, windowStartTime);
+      var subtitlesContainer = SubtitlesContainer(mediaPlayer, autoStart, playbackElement, mediaSources, defaultStyleOpts);
 
       function enable () {
         subtitlesEnabled = true;

--- a/script/subtitles/subtitles.js
+++ b/script/subtitles/subtitles.js
@@ -6,7 +6,7 @@ define('bigscreenplayer/subtitles/subtitles',
     'use strict';
     return function (mediaPlayer, autoStart, playbackElement, defaultStyleOpts, mediaSources) {
       var subtitlesEnabled = autoStart;
-      var liveSubtitles = !!mediaSources.currentCaptionsSegmentLength();
+      var liveSubtitles = !!mediaSources.currentSubtitlesSegmentLength();
       var subtitlesContainer = SubtitlesContainer(mediaPlayer, autoStart, playbackElement, mediaSources, defaultStyleOpts);
 
       function enable () {
@@ -37,7 +37,7 @@ define('bigscreenplayer/subtitles/subtitles',
         if (liveSubtitles && (window.bigscreenPlayer.overrides && window.bigscreenPlayer.overrides.legacySubtitles)) {
           return false;
         } else {
-          return !!mediaSources.currentCaptionsSource();
+          return !!mediaSources.currentSubtitlesSource();
         }
       }
 

--- a/script/subtitles/subtitles.js
+++ b/script/subtitles/subtitles.js
@@ -4,10 +4,10 @@ define('bigscreenplayer/subtitles/subtitles',
   ],
   function (SubtitlesContainer) {
     'use strict';
-    return function (mediaPlayer, segmentLength, autoStart, playbackElement, defaultStyleOpts, windowStartTime, mediaSources) {
+    return function (mediaPlayer, autoStart, playbackElement, defaultStyleOpts, windowStartTime, mediaSources) {
       var subtitlesEnabled = autoStart;
-      var liveSubtitles = !!segmentLength;
-      var subtitlesContainer = SubtitlesContainer(mediaPlayer, segmentLength, autoStart, playbackElement, defaultStyleOpts, windowStartTime, mediaSources);
+      var liveSubtitles = !!mediaSources.currentCaptionsSegmentLength();
+      var subtitlesContainer = SubtitlesContainer(mediaPlayer, autoStart, playbackElement, defaultStyleOpts, windowStartTime, mediaSources);
 
       function enable () {
         subtitlesEnabled = true;

--- a/script/utils/playbackutils.js
+++ b/script/utils/playbackutils.js
@@ -38,8 +38,10 @@ define(
       cloneArray: function (arr) {
         var clone = [];
 
-        for (var i = 0, n = arr.length; i < n; i++) {
-          clone.push(this.clone(arr[i]));
+        if (arr) {
+          for (var i = 0, n = arr.length; i < n; i++) {
+            clone.push(this.clone(arr[i]));
+          }
         }
 
         return clone;

--- a/script/utils/playbackutils.js
+++ b/script/utils/playbackutils.js
@@ -38,10 +38,8 @@ define(
       cloneArray: function (arr) {
         var clone = [];
 
-        if (arr) {
-          for (var i = 0, n = arr.length; i < n; i++) {
-            clone.push(this.clone(arr[i]));
-          }
+        for (var i = 0, n = arr.length; i < n; i++) {
+          clone.push(this.clone(arr[i]));
         }
 
         return clone;


### PR DESCRIPTION
📺 What

Introduce CDN failover capability for subtitles.

> Tickets: [IPLAYERTVV1-11794](https://jira.dev.bbc.co.uk/browse/IPLAYERTVV1-11794)


🛠 How

- initialise BigscreenPlayer with a captions array.
- failover to subsequent sources if loading the subtitles xml is unsuccessful.


✅ Testing 

| Test engineer sign off | :x: |
| ---- | ---- |


 ✅ Acceptance criteria [Optional]

- [x] Subtitles continue to display if a cdn fails
- [x] Subtitles failover for VOD
- [x] Subtitles failover for Simulcast
- [x] Video failover not affected
- [x] Subtitles remain in sync after failover
- [x] Legacy and IMSC subtitles to have failover functionality