### PR TITLE
Make the subtitles request timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ require(
             cdn: 'cdn1' 
           },
         ],
-        captionsUrl: 'https://www.somelovelycaptionsurl.com/captions/', // NB This paramater is being depreciated in favour of the captions array shown above. 
+        captionsUrl: 'https://www.somelovelycaptionsurl.com/captions/', // NB This parameter is being deprecated in favour of the captions array shown above. 
         subtitlesRequestTimeout: 5000, // Optional override for the XHR timeout on sidecar loaded subtitles
         subtitleCustomisation: {
           size: 0.75,

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ require(
             cdn: 'cdn1' 
           },
         ],
-        captionsUrl: 'https://www.somelovelycaptionsurl.com/captions/' // NB This paramater is being depreciated in favour of the captions array shown above. 
+        captionsUrl: 'https://www.somelovelycaptionsurl.com/captions/', // NB This paramater is being depreciated in favour of the captions array shown above. 
+        subtitlesRequestTimeout: 5000, // Optional override for the XHR timeout on sidecar loaded subtitles
         subtitleCustomisation: {
           size: 0.75,
           lineHeight: 1.10,

--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -107,7 +107,7 @@ require(
       beforeEach(function (done) {
         mediaSourcesMock = function () {
           return {
-            init: function (urls, captionUrls, serverDate, windowType, liveSupport, callbacks) {
+            init: function (media, serverDate, windowType, liveSupport, callbacks) {
               mediaSourcesCallbackSuccessSpy = spyOn(callbacks, 'onSuccess').and.callThrough();
               mediaSourcesCallbackErrorSpy = spyOn(callbacks, 'onError').and.callThrough();
               if (forceMediaSourcesConstructionFailure) {

--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -18,6 +18,7 @@ require(
 
       var testSources;
       var testSubtitlesSources;
+      var testMedia;
       var SEGMENT_LENGTH = 3.84;
       var testCallbacks;
       var triggerManifestLoadError = false;
@@ -73,6 +74,10 @@ require(
             {url: 'http://subtitlessource1.com/', cdn: 'http://supplier1.com/', segmentLength: SEGMENT_LENGTH},
             {url: 'http://subtitlessource2.com/', cdn: 'http://supplier2.com/', segmentLength: SEGMENT_LENGTH}
           ];
+          testMedia = {
+            urls: testSources,
+            captions: testSubtitlesSources
+          };
           done();
         });
       });
@@ -92,14 +97,15 @@ require(
         it('throws an error when initialised with no sources', function () {
           expect(function () {
             var mediaSources = new MediaSources();
-            mediaSources.init([], testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+            testMedia.urls = [];
+            mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
             mediaSources.currentSource();
           }).toThrow(new Error('Media Sources urls are undefined'));
         });
 
         it('clones the urls', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           testSources[0].url = 'clonetest';
 
           expect(mediaSources.currentSource()).toEqual('http://source1.com/');
@@ -108,37 +114,37 @@ require(
         it('throws an error when callbacks are undefined', function () {
           expect(function () {
             var mediaSources = new MediaSources();
-            mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {});
+            mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {});
           }).toThrow(new Error('Media Sources callbacks are undefined'));
 
           expect(function () {
             var mediaSources = new MediaSources();
-            mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {onSuccess: function () {}});
+            mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {onSuccess: function () {}});
           }).toThrow(new Error('Media Sources callbacks are undefined'));
 
           expect(function () {
             var mediaSources = new MediaSources();
-            mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {onError: function () {}});
+            mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, {onError: function () {}});
           }).toThrow(new Error('Media Sources callbacks are undefined'));
         });
 
         it('calls onSuccess callback immediately for STATIC window content', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(testCallbacks.onSuccess).toHaveBeenCalledWith();
         });
 
         it('calls onSuccess callback immediately for LIVE content on a PLAYABLE device', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.SLIDING, LiveSupport.PLAYABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.SLIDING, LiveSupport.PLAYABLE, testCallbacks);
 
           expect(testCallbacks.onSuccess).toHaveBeenCalledWith();
         });
 
         it('calls onSuccess callback when manifest loader returns on success for SLIDING window content', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(testCallbacks.onSuccess).toHaveBeenCalledWith();
         });
@@ -148,7 +154,7 @@ require(
           triggerFailOnce = true;
           var mediaSources = new MediaSources();
 
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(testCallbacks.onSuccess).toHaveBeenCalledTimes(1);
         });
@@ -156,14 +162,14 @@ require(
         it('calls onError callback when manifest loader fails and there are insufficent sources to failover to', function () {
           triggerManifestLoadError = true;
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(testCallbacks.onError).toHaveBeenCalledWith({error: 'manifest'});
         });
 
         it('sets time data correcly when manifest loader successfully returns', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(mediaSources.time()).toEqual(mockTimeObject);
         });
@@ -185,7 +191,7 @@ require(
 
           var serverDate = new Date();
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, serverDate, WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, serverDate, WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
 
           mockManifestLoader.load.calls.reset();
 
@@ -198,7 +204,7 @@ require(
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(postFailoverAction).toHaveBeenCalledWith();
@@ -207,9 +213,10 @@ require(
 
         it('When there are no more sources to failover to, it calls failure action callback', function () {
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
+          testMedia.urls.pop();
 
           var mediaSources = new MediaSources();
-          mediaSources.init([{url: 'http://source1.com/', cdn: 'http://supplier1.com/'}], testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(onFailureAction).toHaveBeenCalledWith();
@@ -220,7 +227,7 @@ require(
           var failoverInfo = {errorMessage: 'test error', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           var pluginData = {
@@ -238,9 +245,11 @@ require(
 
         it('Plugin event not emitted when there are no sources to failover to', function () {
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
+          testMedia.urls.pop();
 
           var mediaSources = new MediaSources();
-          mediaSources.init([{url: 'http://source1.com/', cdn: 'http://supplier1.com/'}], testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(mockPluginsInterface.onErrorHandled).not.toHaveBeenCalled();
@@ -250,11 +259,13 @@ require(
       describe('isFirstManifest', function () {
         it('does not failover if service location is identical to current source cdn besides path', function () {
           var mediaSources = new MediaSources();
+
+          testMedia.urls = [
+            { url: 'http://source1.com/path/to/thing.extension', cdn: 'http://cdn1.com' },
+            { url: 'http://source2.com', cdn: 'http://cdn2.com' }];
+
           mediaSources.init(
-            [
-              { url: 'http://source1.com/path/to/thing.extension', cdn: 'http://cdn1.com' },
-              { url: 'http://source2.com', cdn: 'http://cdn2.com' }],
-            testSubtitlesSources,
+            testMedia,
             new Date(),
             WindowTypes.STATIC,
             LiveSupport.SEEKABLE,
@@ -277,11 +288,13 @@ require(
 
         it('does not failover if service location is identical to current source cdn besides hash and query', function () {
           var mediaSources = new MediaSources();
+
+          testMedia.urls = [
+            {url: 'http://source1.com', cdn: 'http://cdn1.com'},
+            {url: 'http://source2.com', cdn: 'http://cdn2.com'}],
+
           mediaSources.init(
-            [
-              {url: 'http://source1.com', cdn: 'http://cdn1.com'},
-              {url: 'http://source2.com', cdn: 'http://cdn2.com'}],
-            testSubtitlesSources,
+            testMedia,
             new Date(),
             WindowTypes.STATIC,
             LiveSupport.SEEKABLE,
@@ -312,7 +325,7 @@ require(
 
         it('returns the first media source url', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(mediaSources.currentSource()).toBe(testSources[0].url);
         });
@@ -323,7 +336,7 @@ require(
           var failoverInfo = {errorMessage: 'failover', isBufferingTimeoutError: true};
 
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failover(postFailoverAction, onFailureAction, failoverInfo);
 
           expect(mediaSources.currentSource()).toBe(testSources[1].url);
@@ -333,14 +346,14 @@ require(
       describe('currentSubtitlesSource', function () {
         it('returns the first subtitles source url', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(mediaSources.currentSubtitlesSource()).toBe(testSubtitlesSources[0].url);
         });
 
         it('returns the second subtitle source following a failover', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failoverSubtitles();
 
           expect(mediaSources.currentSubtitlesSource()).toBe(testSubtitlesSources[1].url);
@@ -350,7 +363,7 @@ require(
       describe('currentSubtitlesSegmentLength', function () {
         it('returns the first subtitles segment length', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(mediaSources.currentSubtitlesSegmentLength()).toBe(SEGMENT_LENGTH);
         });
@@ -367,7 +380,7 @@ require(
 
         it('When there are subtitles sources to failover to, it calls the post failover callback', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failoverSubtitles(postFailoverAction, onFailureAction);
 
           expect(postFailoverAction).toHaveBeenCalledTimes(1);
@@ -375,8 +388,10 @@ require(
         });
 
         it('When there are no more subtitles sources to failover to, it calls failure action callback', function () {
+          testMedia.captions.pop();
+
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, [{url: 'http://subtitlessource1.com/', cdn: 'http://supplier1.com/'}], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           mediaSources.failoverSubtitles(postFailoverAction, onFailureAction);
 
           expect(onFailureAction).toHaveBeenCalledTimes(1);
@@ -387,7 +402,7 @@ require(
       describe('availableSources', function () {
         it('returns an array of media source urls', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(mediaSources.availableSources()).toEqual(['http://source1.com/', 'http://source2.com/']);
         });
@@ -398,7 +413,7 @@ require(
         describe('when window type is STATIC', function () {
           beforeEach(function () {
             mediaSources = new MediaSources();
-            mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+            mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
           });
 
           it('should failover if current time is greater than 5 seconds from duration', function () {
@@ -452,7 +467,7 @@ require(
             it('should not reload the manifest', function () {
               mediaSources = new MediaSources();
               mockTransferFormat = TransferFormats.DASH;
-              mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.GROWING, LiveSupport.SEEKABLE, testCallbacks);
+              mediaSources.init(testMedia, new Date(), WindowTypes.GROWING, LiveSupport.SEEKABLE, testCallbacks);
 
               var mediaSourceCallbacks = jasmine.createSpyObj('mediaSourceCallbacks', ['onSuccess', 'onError']);
 
@@ -473,7 +488,7 @@ require(
             it('should reload the manifest', function () {
               mediaSources = new MediaSources();
               mockTransferFormat = TransferFormats.HLS;
-              mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.GROWING, LiveSupport.SEEKABLE, testCallbacks);
+              mediaSources.init(testMedia, new Date(), WindowTypes.GROWING, LiveSupport.SEEKABLE, testCallbacks);
 
               var mediaSourceCallbacks = jasmine.createSpyObj('mediaSourceCallbacks', ['onSuccess', 'onError']);
 
@@ -496,7 +511,7 @@ require(
         var mediaSources;
         beforeEach(function () {
           mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
         });
 
         it('updates the mediasources time data', function () {

--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -173,6 +173,16 @@ require(
 
           expect(mediaSources.time()).toEqual(mockTimeObject);
         });
+
+        it('overrides the subtitlesRequestTimeout when set in media object', function () {
+          var mediaSources = new MediaSources();
+          var overriddenTimeout = 60000;
+
+          testMedia.subtitlesRequestTimeout = overriddenTimeout;
+          mediaSources.init(testMedia, new Date(), WindowTypes.SLIDING, LiveSupport.SEEKABLE, testCallbacks);
+
+          expect(mediaSources.subtitlesRequestTimeout()).toEqual(overriddenTimeout);
+        });
       });
 
       describe('failover', function () {
@@ -291,7 +301,7 @@ require(
 
           testMedia.urls = [
             {url: 'http://source1.com', cdn: 'http://cdn1.com'},
-            {url: 'http://source2.com', cdn: 'http://cdn2.com'}],
+            {url: 'http://source2.com', cdn: 'http://cdn2.com'}];
 
           mediaSources.init(
             testMedia,

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -132,7 +132,7 @@ require(
         mediaSourcesTimeSpy = spyOn(mediaSources, 'time');
         mediaSourcesTimeSpy.and.callThrough();
         spyOn(mediaSources, 'failover').and.callThrough();
-        mediaSources.init(cdnArray, [], new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, mediaSourceCallbacks);
+        mediaSources.init({urls: cdnArray, captions: []}, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, mediaSourceCallbacks);
 
         testManifestObject = {
           type: 'manifestLoaded',

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -36,7 +36,7 @@ require(
         epochStartTimeMilliseconds = undefined;
 
         mediaPlayer = jasmine.createSpyObj('mediaPlayer', ['getCurrentTime']);
-        mockMediaSources = jasmine.createSpyObj('mockMediaSources', ['currentSubtitlesSource', 'failoverSubtitles', 'currentSubtitlesSegmentLength', 'time']);
+        mockMediaSources = jasmine.createSpyObj('mockMediaSources', ['currentSubtitlesSource', 'failoverSubtitles', 'currentSubtitlesSegmentLength', 'subtitlesRequestTimeout', 'time']);
         mockMediaSources.currentSubtitlesSource.and.callFake(function () { return subtitlesUrl; });
         mockMediaSources.failoverSubtitles.and.callFake(function (postFailoverAction, failoverErrorAction) {
           if (avalailableSourceCount > 1) {

--- a/script-test/subtitles/legacysubtitles.js
+++ b/script-test/subtitles/legacysubtitles.js
@@ -35,7 +35,7 @@ require(
         });
 
         subtitlesUrl = 'http://stub-captions.test';
-        mockMediaSources = jasmine.createSpyObj('mockMediaSources', ['currentSubtitlesSource', 'failoverSubtitles']);
+        mockMediaSources = jasmine.createSpyObj('mockMediaSources', ['currentSubtitlesSource', 'failoverSubtitles', 'subtitlesRequestTimeout']);
         mockMediaSources.currentSubtitlesSource.and.returnValue(subtitlesUrl);
         mockMediaSources.failoverSubtitles.and.callFake(function (postFailoverAction, failoverErrorAction) {
           if (avalailableSourceCount > 1) {

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -214,7 +214,7 @@ define('bigscreenplayer/bigscreenplayer',
             }];
           }
 
-          mediaSources.init(bigscreenPlayerData.media.urls, bigscreenPlayerData.media.captions, serverDate, windowType, getLiveSupport(), mediaSourceCallbacks);
+          mediaSources.init(bigscreenPlayerData.media, serverDate, windowType, getLiveSupport(), mediaSourceCallbacks);
         },
 
         tearDown: function () {

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -21,6 +21,8 @@ define('bigscreenplayer/mediasources',
       var time = {};
       var transferFormat;
       var subtitlesSources;
+      // Default 5000 can be overridden with media.subtitlesRequestTimeout
+      var subtitlesRequestTimeout = 5000;
 
       function init (media, newServerDate, newWindowType, newLiveSupport, callbacks) {
         if (media.urls === undefined || media.urls.length === 0) {
@@ -28,9 +30,13 @@ define('bigscreenplayer/mediasources',
         }
 
         if (callbacks === undefined ||
-      callbacks.onSuccess === undefined ||
-      callbacks.onError === undefined) {
+          callbacks.onSuccess === undefined ||
+          callbacks.onError === undefined) {
           throw new Error('Media Sources callbacks are undefined');
+        }
+
+        if (media.subtitlesRequestTimeout) {
+          subtitlesRequestTimeout = media.subtitlesRequestTimeout;
         }
 
         windowType = newWindowType;
@@ -38,6 +44,7 @@ define('bigscreenplayer/mediasources',
         serverDate = newServerDate;
         mediaSources = media.urls ? PlaybackUtils.cloneArray(media.urls) : [];
         subtitlesSources = media.captions ? PlaybackUtils.cloneArray(media.captions) : [];
+
         updateDebugOutput();
 
         if (needToGetManifest(windowType, liveSupport)) {
@@ -186,6 +193,10 @@ define('bigscreenplayer/mediasources',
         return undefined;
       }
 
+      function getSubtitlesRequestTimeout () {
+        return subtitlesRequestTimeout;
+      }
+
       function availableUrls () {
         return mediaSources.map(function (mediaSource) {
           return mediaSource.url;
@@ -245,6 +256,7 @@ define('bigscreenplayer/mediasources',
         currentSource: getCurrentUrl,
         currentSubtitlesSource: getCurrentSubtitlesUrl,
         currentSubtitlesSegmentLength: getCurrentSubtitlesSegmentLength,
+        subtitlesRequestTimeout: getSubtitlesRequestTimeout,
         availableSources: availableUrls,
         time: generateTime
       };

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -22,8 +22,8 @@ define('bigscreenplayer/mediasources',
       var transferFormat;
       var subtitlesSources;
 
-      function init (urls, subtitlesUrls, newServerDate, newWindowType, newLiveSupport, callbacks) {
-        if (urls === undefined || urls.length === 0) {
+      function init (media, newServerDate, newWindowType, newLiveSupport, callbacks) {
+        if (media.urls === undefined || media.urls.length === 0) {
           throw new Error('Media Sources urls are undefined');
         }
 
@@ -36,8 +36,8 @@ define('bigscreenplayer/mediasources',
         windowType = newWindowType;
         liveSupport = newLiveSupport;
         serverDate = newServerDate;
-        mediaSources = urls ? PlaybackUtils.cloneArray(urls) : [];
-        subtitlesSources = subtitlesUrls ? PlaybackUtils.cloneArray(subtitlesUrls) : [];
+        mediaSources = media.urls ? PlaybackUtils.cloneArray(media.urls) : [];
+        subtitlesSources = media.captions ? PlaybackUtils.cloneArray(media.captions) : [];
         updateDebugOutput();
 
         if (needToGetManifest(windowType, liveSupport)) {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -55,7 +55,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       function loadSegment (url, segmentNumber) {
         url = url.replace('$segment$', segmentNumber);
         LoadURL(url, {
-          timeout: 5000,
+          timeout: mediaSources.subtitlesRequestTimeout(),
           onLoad: function (responseXML, responseText, status) {
             resetLoadErrorCount();
             if (!responseXML && !liveSubtitles) {
@@ -89,6 +89,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
             loadErrorFailover(statusCode);
           },
           onTimeout: function () {
+            DebugTool.info('Request timeout loading subtitles');
             Plugins.interface.onSubtitlesTimeout();
           }
         });

--- a/script/subtitles/legacysubtitles.js
+++ b/script/subtitles/legacysubtitles.js
@@ -20,7 +20,7 @@ define(
         var url = mediaSources.currentSubtitlesSource();
         if (url && url !== '') {
           LoadURL(url, {
-            timeout: 5000,
+            timeout: mediaSources.subtitlesRequestTimeout(),
             onLoad: function (responseXML, responseText, status) {
               if (!responseXML) {
                 DebugTool.info('Error: responseXML is invalid.');
@@ -36,6 +36,7 @@ define(
               mediaSources.failoverSubtitles(loadSubtitles, errorCase);
             },
             onTimeout: function () {
+              DebugTool.info('Request timeout loading subtitles');
               Plugins.interface.onSubtitlesTimeout();
             }
           });


### PR DESCRIPTION
📺 What

The XHR timeout for sidecar loaded subtitles was set to a static 5000ms in a previous PR. This makes the value configurable per initialisation of the player.

> Tickets: IPLAYERTVV1-11795 

🛠 How

-Add an optional `media.subtitlesRequestTimeout` to the media object used to initialise `bigscreenplayer`.
- Initialise `mediasources` with the media block instead of adding an additional parameter deriving from that object to the init interface.
- Refactor some `mediasources` tests while in the area.

✅ Testing 
| Test engineer sign off | :x: |
| ---- | ---- |