### PR TITLE
Report CDN as an event through subtitle error plugins

### DIFF
--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -379,6 +379,15 @@ require(
         });
       });
 
+      describe('currentSubtitlesCdn', function () {
+        it('returns the first subtitles cdn', function () {
+          var mediaSources = new MediaSources();
+          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+
+          expect(mediaSources.currentSubtitlesCdn()).toBe(testSources[0].cdn);
+        });
+      });
+
       describe('failoverSubtitles', function () {
         var postFailoverAction;
         var onFailureAction;

--- a/script-test/mediasourcestest.js
+++ b/script-test/mediasourcestest.js
@@ -32,7 +32,7 @@ require(
       beforeEach(function (done) {
         injector = new Squire();
         testCallbacks = jasmine.createSpyObj('mediaSourceCallbacks', ['onSuccess', 'onError']);
-        mockPluginsInterface = jasmine.createSpyObj('interface', ['onErrorCleared', 'onBuffering', 'onBufferingCleared', 'onError', 'onFatalError', 'onErrorHandled']);
+        mockPluginsInterface = jasmine.createSpyObj('interface', ['onErrorCleared', 'onBuffering', 'onBufferingCleared', 'onError', 'onFatalError', 'onErrorHandled', 'onSubtitlesLoadError']);
 
         mockPlugins = {
           interface: mockPluginsInterface
@@ -382,7 +382,7 @@ require(
       describe('currentSubtitlesCdn', function () {
         it('returns the first subtitles cdn', function () {
           var mediaSources = new MediaSources();
-          mediaSources.init(testSources, testSubtitlesSources, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
 
           expect(mediaSources.currentSubtitlesCdn()).toBe(testSources[0].cdn);
         });
@@ -415,6 +415,24 @@ require(
 
           expect(onFailureAction).toHaveBeenCalledTimes(1);
           expect(postFailoverAction).not.toHaveBeenCalled();
+        });
+
+        it('fires onSubtitlesLoadError plugin with a correct parameters when there are sources available to failover to', function () {
+          var mediaSources = new MediaSources();
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.failoverSubtitles(postFailoverAction, onFailureAction, 404);
+
+          expect(mockPluginsInterface.onSubtitlesLoadError).toHaveBeenCalledWith({status: 404, severity: PluginEnums.STATUS.FAILOVER, cdn: 'http://supplier1.com/'});
+        });
+
+        it('fires onSubtitlesLoadError plugin with a correct parameters when there are no sources available to failover to', function () {
+          testMedia.captions.pop();
+
+          var mediaSources = new MediaSources();
+          mediaSources.init(testMedia, new Date(), WindowTypes.STATIC, LiveSupport.SEEKABLE, testCallbacks);
+          mediaSources.failoverSubtitles(postFailoverAction, onFailureAction, 404);
+
+          expect(mockPluginsInterface.onSubtitlesLoadError).toHaveBeenCalledWith({status: 404, severity: PluginEnums.STATUS.FATAL, cdn: 'http://supplier1.com/'});
         });
       });
 

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -15,6 +15,7 @@ require(
       var subtitles;
       var mockMediaSources;
       var subtitlesUrl;
+      var subtitlesCdn;
       var segmentLength;
       var epochStartTimeMilliseconds;
       var avalailableSourceCount;
@@ -31,6 +32,7 @@ require(
         injector = new Squire();
 
         subtitlesUrl = 'http://stub-subtitles.test';
+        subtitlesCdn = 'supplier1';
         loadUrlStubResponseText = '<?xml version="1.0" encoding="utf-8"?><tt xmlns="http://www.w3.org/ns/ttml"></tt>';
         segmentLength = undefined;
         epochStartTimeMilliseconds = undefined;
@@ -47,6 +49,7 @@ require(
           }
         });
         mockMediaSources.currentSubtitlesSegmentLength.and.callFake(function () { return segmentLength; });
+        mockMediaSources.currentSubtitlesCdn.and.callFake(function () { return subtitlesCdn; });
         mockMediaSources.time.and.callFake(function () {
           return {
             windowStartTime: epochStartTimeMilliseconds
@@ -235,6 +238,7 @@ require(
           });
           subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
+          expect(pluginsMock.interface.onSubtitlesXMLError).toHaveBeenCalledWith({cdn: subtitlesCdn});
           expect(pluginsMock.interface.onSubtitlesXMLError).toHaveBeenCalledTimes(1);
         });
 
@@ -244,6 +248,7 @@ require(
           });
           subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
+          expect(pluginsMock.interface.onSubtitlesTimeout).toHaveBeenCalledWith({cdn: subtitlesCdn});
           expect(pluginsMock.interface.onSubtitlesTimeout).toHaveBeenCalledTimes(1);
         });
 

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -36,7 +36,7 @@ require(
         epochStartTimeMilliseconds = undefined;
 
         mediaPlayer = jasmine.createSpyObj('mediaPlayer', ['getCurrentTime']);
-        mockMediaSources = jasmine.createSpyObj('mockMediaSources', ['currentSubtitlesSource', 'failoverSubtitles', 'currentSubtitlesSegmentLength', 'subtitlesRequestTimeout', 'time']);
+        mockMediaSources = jasmine.createSpyObj('mockMediaSources', ['currentSubtitlesSource', 'failoverSubtitles', 'currentSubtitlesSegmentLength', 'currentSubtitlesCdn', 'subtitlesRequestTimeout', 'time']);
         mockMediaSources.currentSubtitlesSource.and.callFake(function () { return subtitlesUrl; });
         mockMediaSources.failoverSubtitles.and.callFake(function (postFailoverAction, failoverErrorAction) {
           if (avalailableSourceCount > 1) {
@@ -207,16 +207,6 @@ require(
           subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
           expect(loadUrlMock).toHaveBeenCalledTimes(2);
-        });
-
-        it('fires onSubtitlesLoadError plugin if loading of subtitles fails on last available source', function () {
-          avalailableSourceCount = 1;
-          loadUrlMock.and.callFake(function (url, callbackObject) {
-            callbackObject.onError(404);
-          });
-          subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
-
-          expect(pluginsMock.interface.onSubtitlesLoadError).toHaveBeenCalledWith({status: 404});
         });
 
         it('Calls fromXML on creation with the extracted XML from the text property of the response argument', function () {
@@ -665,20 +655,6 @@ require(
             jasmine.clock().tick(750);
 
             expect(loadUrlMock).toHaveBeenCalledTimes(3);
-          });
-
-          it('Should fire onSubtitlesLoadError plugin if loading of segments fails on last available source', function () {
-            avalailableSourceCount = 1;
-            loadUrlMock.and.callFake(function (url, callbackObject) {
-              callbackObject.onError(404);
-            });
-
-            subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
-
-            mediaPlayer.getCurrentTime.and.returnValue(10);
-            jasmine.clock().tick(750);
-
-            expect(pluginsMock.interface.onSubtitlesLoadError).toHaveBeenCalledWith({status: 404});
           });
         });
 

--- a/script-test/subtitles/legacysubtitles.js
+++ b/script-test/subtitles/legacysubtitles.js
@@ -103,16 +103,6 @@ require(
         expect(mockMediaSources.failoverSubtitles).toHaveBeenCalledTimes(1);
       });
 
-      it('Should fire onSubtitlesLoadError plugin if loading of XML fails on last available source', function () {
-        avalailableSourceCount = 1;
-        loadUrlMock.and.callFake(function (url, callbackObject) {
-          callbackObject.onError();
-        });
-        legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
-
-        expect(pluginsMock.interface.onSubtitlesLoadError).toHaveBeenCalledTimes(1);
-      });
-
       it('Should fire onSubtitlesTimeout if the XHR times out', function () {
         loadUrlMock.and.callFake(function (url, callbackObject) {
           callbackObject.onTimeout();

--- a/script-test/subtitles/legacysubtitles.js
+++ b/script-test/subtitles/legacysubtitles.js
@@ -17,6 +17,7 @@ require(
     var pluginInterfaceMock;
     var pluginsMock;
     var subtitlesUrl;
+    var subtitlesCdn;
     var mockMediaSources;
     var avalailableSourceCount;
 
@@ -35,8 +36,10 @@ require(
         });
 
         subtitlesUrl = 'http://stub-captions.test';
-        mockMediaSources = jasmine.createSpyObj('mockMediaSources', ['currentSubtitlesSource', 'failoverSubtitles', 'subtitlesRequestTimeout']);
+        subtitlesCdn = 'supplier1';
+        mockMediaSources = jasmine.createSpyObj('mockMediaSources', ['currentSubtitlesSource', 'failoverSubtitles', 'subtitlesRequestTimeout', 'currentSubtitlesCdn']);
         mockMediaSources.currentSubtitlesSource.and.returnValue(subtitlesUrl);
+        mockMediaSources.currentSubtitlesCdn.and.returnValue(subtitlesCdn);
         mockMediaSources.failoverSubtitles.and.callFake(function (postFailoverAction, failoverErrorAction) {
           if (avalailableSourceCount > 1) {
             avalailableSourceCount--;
@@ -85,6 +88,7 @@ require(
         });
         legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
 
+        expect(pluginsMock.interface.onSubtitlesXMLError).toHaveBeenCalledWith({cdn: subtitlesCdn});
         expect(pluginsMock.interface.onSubtitlesXMLError).toHaveBeenCalledTimes(1);
       });
 
@@ -95,6 +99,7 @@ require(
         });
         legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
 
+        expect(mockMediaSources.failoverSubtitles).toHaveBeenCalledWith(jasmine.any(Function), jasmine.any(Function), 404);
         expect(mockMediaSources.failoverSubtitles).toHaveBeenCalledTimes(1);
       });
 
@@ -114,6 +119,7 @@ require(
         });
         legacySubtitles = LegacySubtitlesWithMocks(null, false, parentElement, mockMediaSources);
 
+        expect(pluginsMock.interface.onSubtitlesTimeout).toHaveBeenCalledWith({cdn: subtitlesCdn});
         expect(pluginsMock.interface.onSubtitlesTimeout).toHaveBeenCalledTimes(1);
       });
 

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -197,6 +197,14 @@ define('bigscreenplayer/mediasources',
         return subtitlesRequestTimeout;
       }
 
+      function getCurrentSubtitlesCdn () {
+        if (subtitlesSources.length > 0) {
+          return subtitlesSources[0].cdn;
+        }
+
+        return undefined;
+      }
+
       function availableUrls () {
         return mediaSources.map(function (mediaSource) {
           return mediaSource.url;
@@ -256,6 +264,7 @@ define('bigscreenplayer/mediasources',
         currentSource: getCurrentUrl,
         currentSubtitlesSource: getCurrentSubtitlesUrl,
         currentSubtitlesSegmentLength: getCurrentSubtitlesSegmentLength,
+        currentSubtitlesCdn: getCurrentSubtitlesCdn,
         subtitlesRequestTimeout: getSubtitlesRequestTimeout,
         availableSources: availableUrls,
         time: generateTime

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -70,12 +70,14 @@ define('bigscreenplayer/mediasources',
         }
       }
 
-      function failoverSubtitles (postFailoverAction, failoverErrorAction) {
+      function failoverSubtitles (postFailoverAction, failoverErrorAction, statusCode) {
         if (subtitlesSources.length > 1) {
+          Plugins.interface.onSubtitlesLoadError({status: statusCode, severity: PluginEnums.STATUS.FAILOVER, cdn: getCurrentSubtitlesCdn()});
           subtitlesSources.shift();
           updateDebugOutput();
           if (postFailoverAction) { postFailoverAction(); }
         } else {
+          Plugins.interface.onSubtitlesLoadError({status: statusCode, severity: PluginEnums.STATUS.FATAL, cdn: getCurrentSubtitlesCdn()});
           if (failoverErrorAction) { failoverErrorAction(); }
         }
       }

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -60,7 +60,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
             resetLoadErrorCount();
             if (!responseXML && !liveSubtitles) {
               DebugTool.info('Error: responseXML is invalid.');
-              Plugins.interface.onSubtitlesXMLError();
+              Plugins.interface.onSubtitlesXMLError({cdn: mediaSources.currentSubtitlesCdn()});
               stop();
               return;
             }
@@ -90,7 +90,8 @@ define('bigscreenplayer/subtitles/imscsubtitles',
           },
           onTimeout: function () {
             DebugTool.info('Request timeout loading subtitles');
-            Plugins.interface.onSubtitlesTimeout();
+            Plugins.interface.onSubtitlesTimeout({cdn: mediaSources.currentSubtitlesCdn()});
+            stop();
           }
         });
       }
@@ -110,12 +111,11 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       function loadErrorFailover (statusCode) {
         var errorCase = function () {
           stop();
-          Plugins.interface.onSubtitlesLoadError({status: statusCode});
         };
 
         if ((liveSubtitles && loadErrorLimit()) || !liveSubtitles) {
           stop();
-          mediaSources.failoverSubtitles(start, errorCase);
+          mediaSources.failoverSubtitles(start, errorCase, statusCode);
         }
       }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -109,13 +109,9 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function loadErrorFailover (statusCode) {
-        var errorCase = function () {
-          stop();
-        };
-
         if ((liveSubtitles && loadErrorLimit()) || !liveSubtitles) {
           stop();
-          mediaSources.failoverSubtitles(start, errorCase, statusCode);
+          mediaSources.failoverSubtitles(start, stop, statusCode);
         }
       }
 

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -109,9 +109,11 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function loadErrorFailover (statusCode) {
+        var errorCase = function () { DebugTool.info('No more CDNs available for subtitle failover'); };
+
         if ((liveSubtitles && loadErrorLimit()) || !liveSubtitles) {
           stop();
-          mediaSources.failoverSubtitles(start, stop, statusCode);
+          mediaSources.failoverSubtitles(start, errorCase, statusCode);
         }
       }
 

--- a/script/subtitles/legacysubtitles.js
+++ b/script/subtitles/legacysubtitles.js
@@ -31,7 +31,7 @@ define(
               }
             },
             onError: function (statusCode) {
-              var errorCase = function () { Plugins.interface.onSubtitlesLoadError({status: statusCode}); };
+              var errorCase = function () { DebugTool.info('Failed to load from subtitles file from all available CDNs'); };
               DebugTool.info('Error loading subtitles data: ' + statusCode);
               mediaSources.failoverSubtitles(loadSubtitles, errorCase, statusCode);
             },

--- a/script/subtitles/legacysubtitles.js
+++ b/script/subtitles/legacysubtitles.js
@@ -24,7 +24,7 @@ define(
             onLoad: function (responseXML, responseText, status) {
               if (!responseXML) {
                 DebugTool.info('Error: responseXML is invalid.');
-                Plugins.interface.onSubtitlesXMLError();
+                Plugins.interface.onSubtitlesXMLError({cdn: mediaSources.currentSubtitlesCdn()});
                 return;
               } else {
                 createContainer(responseXML);
@@ -33,11 +33,11 @@ define(
             onError: function (statusCode) {
               var errorCase = function () { Plugins.interface.onSubtitlesLoadError({status: statusCode}); };
               DebugTool.info('Error loading subtitles data: ' + statusCode);
-              mediaSources.failoverSubtitles(loadSubtitles, errorCase);
+              mediaSources.failoverSubtitles(loadSubtitles, errorCase, statusCode);
             },
             onTimeout: function () {
               DebugTool.info('Request timeout loading subtitles');
-              Plugins.interface.onSubtitlesTimeout();
+              Plugins.interface.onSubtitlesTimeout({cdn: mediaSources.currentSubtitlesCdn()});
             }
           });
         }


### PR DESCRIPTION
📺 What

Report current CDN through subtitle error plugins where appropriate (load, timeout, xml errors)

> Tickets: IPLAYERTVV1-11795

🛠 How

Expose current subtitle cdn on `mediasources`. Move subtitle error plugin into media sources and fire whenever failover is attempted, with a severity level of FAILOVER or FATAL, depending on whether there are further cdns to attempt. 

✅ Testing [Semi-optional]

[Test Guidelines](https://github.com/bbc/bigscreen-player/wiki/Areas-Impacted)

| Test engineer sign off | ✅ |
| ---- | ---- |

[How will this change be tested?]