### PR TITLE
Subtitle Customisation: Also support `top`, `bottom` and `right` percentage on`SafePosition`

### DIFF
--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -194,7 +194,7 @@ require(
         });
 
         it('should call renderHTML with a preview element with the correct structure when no position info', function () {
-          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {});
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, undefined);
 
           var exampleHtml = null;
           var height = null;

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -9,7 +9,7 @@ require(
       var imscMock;
       var pluginInterfaceMock;
       var pluginsMock;
-      var mockParentElement = document.createElement('div');
+      var mockParentElement;
       var fromXmlReturn;
       var mediaPlayer;
       var subtitles;
@@ -79,6 +79,11 @@ require(
           callbackObject.onLoad(loadUrlStubResponseXml, loadUrlStubResponseText, 200);
         });
 
+        mockParentElement = document.createElement('div');
+        mockParentElement.style.height = '100px';
+        mockParentElement.style.width = '200px';
+        document.body.appendChild(mockParentElement);
+
         injector.mock({
           'bigscreenplayer/external/smp-imsc': imscMock,
           'bigscreenplayer/plugins': pluginsMock,
@@ -95,6 +100,7 @@ require(
         jasmine.clock().uninstall();
         imscMock.generateISD.calls.reset();
         imscMock.renderHTML.calls.reset();
+        document.body.removeChild(mockParentElement);
       });
 
       function progressTime (mediaPlayerTime) {
@@ -132,7 +138,7 @@ require(
           subtitles.start();
           progressTime(9);
 
-          expect(imscMock.renderHTML).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, expectedOpts);
+          expect(imscMock.renderHTML).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(HTMLDivElement), null, 100, 200, false, null, null, false, expectedOpts);
         });
 
         it('overrides the subtitles styling metadata with supplied custom styles when rendering', function () {
@@ -146,7 +152,7 @@ require(
           subtitles.start();
           subtitles.customise(styleOpts, true);
 
-          expect(imscMock.renderHTML).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, expectedOpts);
+          expect(imscMock.renderHTML).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(HTMLDivElement), null, 100, 200, false, null, null, false, expectedOpts);
         });
 
         it('merges the current subtitles styling metadata with new supplied custom styles when rendering', function () {
@@ -161,7 +167,7 @@ require(
           subtitles.start();
           subtitles.customise(customStyleOpts, true);
 
-          expect(imscMock.renderHTML).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, expectedOpts);
+          expect(imscMock.renderHTML).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(HTMLDivElement), null, 100, 200, false, null, null, false, expectedOpts);
         });
 
         it('does not render custom styles when subtitles are not enabled', function () {
@@ -191,22 +197,32 @@ require(
           subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {});
 
           var exampleHtml = null;
-          imscMock.renderHTML.and.callFake(function (isd, subsElement) {
+          var height = null;
+          var width = null;
+          imscMock.renderHTML.and.callFake(function (isd, subsElement, _, renderHeight, renderWidth) {
             exampleHtml = subsElement.outerHTML;
+            height = renderHeight;
+            width = renderWidth;
           });
 
           subtitles.renderExample('', {}, {});
 
           expect(imscMock.renderHTML).toHaveBeenCalledTimes(1);
-          expect(exampleHtml).toBe('<div id="subtitlesPreview" style="position: absolute; top: 0%; right: 0%; bottom: 0%; left: 0%;"></div>');
+          expect(exampleHtml).toBe('<div id="subtitlesPreview" style="position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px;"></div>');
+          expect(height).toBe(100);
+          expect(width).toBe(200);
         });
 
         it('should call renderHTML with a preview element with the correct structure when there is position info', function () {
           subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {});
 
           var exampleHtml = null;
-          imscMock.renderHTML.and.callFake(function (isd, subsElement) {
+          var height = null;
+          var width = null;
+          imscMock.renderHTML.and.callFake(function (isd, subsElement, _, renderHeight, renderWidth) {
             exampleHtml = subsElement.outerHTML;
+            height = renderHeight;
+            width = renderWidth;
           });
 
           subtitles.renderExample('', {}, {
@@ -217,7 +233,9 @@ require(
           });
 
           expect(imscMock.renderHTML).toHaveBeenCalledTimes(1);
-          expect(exampleHtml).toBe('<div id="subtitlesPreview" style="position: absolute; top: 1%; right: 2%; bottom: 3%; left: 4%;"></div>');
+          expect(exampleHtml).toBe('<div id="subtitlesPreview" style="position: absolute; top: 1px; right: 4px; bottom: 3px; left: 8px;"></div>');
+          expect(height).toBe(96);
+          expect(width).toBe(188);
         });
       });
 
@@ -750,7 +768,7 @@ require(
             jasmine.clock().tick(750);
 
             expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 0}), msToS(epochStartTimeMilliseconds) + 2.750);
-            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, {});
+            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 100, 200, false, null, null, false, {});
 
             imscMock.generateISD.calls.reset();
             imscMock.renderHTML.calls.reset();
@@ -766,7 +784,7 @@ require(
             jasmine.clock().tick(750);
 
             expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 1}), msToS(epochStartTimeMilliseconds) + 4.25);
-            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, {});
+            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 100, 200, false, null, null, false, {});
 
             imscMock.generateISD.calls.reset();
             imscMock.renderHTML.calls.reset();
@@ -806,7 +824,7 @@ require(
             jasmine.clock().tick(750);
 
             expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 2}), msToS(epochStartTimeMilliseconds) + 8);
-            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, {});
+            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 100, 200, false, null, null, false, {});
 
             imscMock.generateISD.calls.reset();
             imscMock.renderHTML.calls.reset();
@@ -822,7 +840,7 @@ require(
             jasmine.clock().tick(750);
 
             expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 2}), msToS(epochStartTimeMilliseconds) + 9.5);
-            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, {});
+            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 100, 200, false, null, null, false, {});
 
             imscMock.generateISD.calls.reset();
             imscMock.renderHTML.calls.reset();
@@ -830,7 +848,7 @@ require(
             jasmine.clock().tick(750);
 
             expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 2}), msToS(epochStartTimeMilliseconds) + 10.25);
-            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, {});
+            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 100, 200, false, null, null, false, {});
 
             imscMock.generateISD.calls.reset();
             imscMock.renderHTML.calls.reset();
@@ -846,7 +864,7 @@ require(
             jasmine.clock().tick(750);
 
             expect(imscMock.generateISD).toHaveBeenCalledOnceWith(jasmine.objectContaining({mockCallId: 2}), msToS(epochStartTimeMilliseconds) + 11.75);
-            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 0, 0, false, null, null, false, {});
+            expect(imscMock.renderHTML).toHaveBeenCalledOnceWith(jasmine.objectContaining({ contents: ['mockContents'] }), jasmine.any(HTMLDivElement), null, 100, 200, false, null, null, false, {});
 
             imscMock.generateISD.calls.reset();
             imscMock.renderHTML.calls.reset();

--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -186,6 +186,39 @@ require(
           expect(imscMock.generateISD).toHaveBeenCalledTimes(1);
           expect(imscMock.renderHTML).toHaveBeenCalledTimes(1);
         });
+
+        it('should call renderHTML with a preview element with the correct structure when no position info', function () {
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {});
+
+          var exampleHtml = null;
+          imscMock.renderHTML.and.callFake(function (isd, subsElement) {
+            exampleHtml = subsElement.outerHTML;
+          });
+
+          subtitles.renderExample('', {}, {});
+
+          expect(imscMock.renderHTML).toHaveBeenCalledTimes(1);
+          expect(exampleHtml).toBe('<div id="subtitlesPreview" style="position: absolute; top: 0%; right: 0%; bottom: 0%; left: 0%;"></div>');
+        });
+
+        it('should call renderHTML with a preview element with the correct structure when there is position info', function () {
+          subtitles = ImscSubtitles(mediaPlayer, false, mockParentElement, mockMediaSources, {});
+
+          var exampleHtml = null;
+          imscMock.renderHTML.and.callFake(function (isd, subsElement) {
+            exampleHtml = subsElement.outerHTML;
+          });
+
+          subtitles.renderExample('', {}, {
+            top: 1,
+            right: 2,
+            bottom: 3,
+            left: 4
+          });
+
+          expect(imscMock.renderHTML).toHaveBeenCalledTimes(1);
+          expect(exampleHtml).toBe('<div id="subtitlesPreview" style="position: absolute; top: 1%; right: 2%; bottom: 3%; left: 4%;"></div>');
+        });
       });
 
       describe('Vod subtitles', function () {

--- a/script-test/subtitles/subtitles.js
+++ b/script-test/subtitles/subtitles.js
@@ -298,7 +298,7 @@ require(
             var subtitles = Subtitles(null, true, null, null, mediaSourcesMock);
             var exampleUrl = '';
             var customStyleObj = { size: 0.7 };
-            var safePosition = { left: 30, top: 0 };
+            var safePosition = { top: 0, right: 0, bottom: 0, left: 30 };
             subtitles.renderExample(exampleUrl, customStyleObj, safePosition);
 
             expect(subtitlesContainerSpies.renderExample).toHaveBeenCalledWith(exampleUrl, customStyleObj, safePosition);

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -221,17 +221,15 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         exampleSubtitlesElement.id = 'subtitlesPreview';
         exampleSubtitlesElement.style.position = 'absolute';
 
-        var renderWidth = parentElement.clientWidth;
-        if (safePosition) {
-          exampleSubtitlesElement.style.left = safePosition.left + '%';
-
-          var leftPixels = parentElement.clientWidth * (safePosition.left / 100);
-          renderWidth = parentElement.clientWidth - leftPixels;
-        }
+        safePosition = safePosition || {};
+        exampleSubtitlesElement.style.top = (safePosition.top || 0) + '%';
+        exampleSubtitlesElement.style.right = (safePosition.right || 0) + '%';
+        exampleSubtitlesElement.style.bottom = (safePosition.bottom || 0) + '%';
+        exampleSubtitlesElement.style.left = (safePosition.left || 0) + '%';
 
         parentElement.appendChild(exampleSubtitlesElement);
 
-        renderHTML(exampleXml, 1, exampleSubtitlesElement, exampleStyle, parentElement.clientHeight, renderWidth);
+        renderHTML(exampleXml, 1, exampleSubtitlesElement, exampleStyle, parentElement.clientHeight, parentElement.clientWidth);
       }
 
       function renderHTML (xml, currentTime, subsElement, styleOpts, renderHeight, renderWidth) {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -221,15 +221,24 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         exampleSubtitlesElement.id = 'subtitlesPreview';
         exampleSubtitlesElement.style.position = 'absolute';
 
-        safePosition = safePosition || {};
-        exampleSubtitlesElement.style.top = (safePosition.top || 0) + '%';
-        exampleSubtitlesElement.style.right = (safePosition.right || 0) + '%';
-        exampleSubtitlesElement.style.bottom = (safePosition.bottom || 0) + '%';
-        exampleSubtitlesElement.style.left = (safePosition.left || 0) + '%';
+        var elementWidth = parentElement.clientWidth;
+        var elementHeight = parentElement.clientHeight;
+        var topPixels = ((safePosition.top || 0) / 100) * elementHeight;
+        var rightPixels = ((safePosition.right || 0) / 100) * elementWidth;
+        var bottomPixels = ((safePosition.bottom || 0) / 100) * elementHeight;
+        var leftPixels = ((safePosition.left || 0) / 100) * elementWidth;
 
+        var renderWidth = elementWidth - leftPixels - rightPixels;
+        var renderHeight = elementHeight - topPixels - bottomPixels;
+
+        safePosition = safePosition || {};
+        exampleSubtitlesElement.style.top = (topPixels) + 'px';
+        exampleSubtitlesElement.style.right = (rightPixels) + 'px';
+        exampleSubtitlesElement.style.bottom = (bottomPixels) + 'px';
+        exampleSubtitlesElement.style.left = (leftPixels) + 'px';
         parentElement.appendChild(exampleSubtitlesElement);
 
-        renderHTML(exampleXml, 1, exampleSubtitlesElement, exampleStyle, parentElement.clientHeight, parentElement.clientWidth);
+        renderHTML(exampleXml, 1, exampleSubtitlesElement, exampleStyle, renderHeight, renderWidth);
       }
 
       function renderHTML (xml, currentTime, subsElement, styleOpts, renderHeight, renderWidth) {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -211,6 +211,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
       }
 
       function renderExample (exampleXmlString, styleOpts, safePosition) {
+        safePosition = safePosition || {};
         var exampleXml = IMSC.fromXML(exampleXmlString);
         removeExampleSubtitlesElement();
 
@@ -231,7 +232,6 @@ define('bigscreenplayer/subtitles/imscsubtitles',
         var renderWidth = elementWidth - leftPixels - rightPixels;
         var renderHeight = elementHeight - topPixels - bottomPixels;
 
-        safePosition = safePosition || {};
         exampleSubtitlesElement.style.top = (topPixels) + 'px';
         exampleSubtitlesElement.style.right = (rightPixels) + 'px';
         exampleSubtitlesElement.style.bottom = (bottomPixels) + 'px';


### PR DESCRIPTION
📺 What
Also support `top`, `bottom` and `right` percentage on `SafePosition` for the subtitle preview.

This will give the UI team more flexibility on the position of the menu. I.e. it doesn't need to be fixed to the left of the screen.

Follow up to https://github.com/bbc/bigscreen-player/pull/193
Fixes https://github.com/bbc/bigscreen-player/issues/195

> Tickets: IPLAYERTVV1-12243


🛠 How
- Also handle `top`, `right` and `bottom` (defaulting them to 0 to preserve backwards compatibilty)
- Add some tests that the preview dom element is correct.


✅ Testing [Semi-optional]
Probably good enough to get this version in an app branch and check that the dom element looks correct?

[Test Guidelines](https://github.com/bbc/bigscreen-player/wiki/Areas-Impacted)

| Test engineer sign off | ✅  |
| ---- | ---- |


 ✅ Acceptance criteria [Optional]
The dom element looks like 
![image](https://user-images.githubusercontent.com/3259993/115588348-901d5d80-a2c6-11eb-8747-8801c9f3844b.png) (but with `px` values not `%`)  in the app and takes up the correct space in the UI.
