### PR TITLE
Ability to set/get playback rate

### DIFF
--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -126,7 +126,7 @@ require(
         var mockDebugTool = jasmine.createSpyObj('mockDebugTool', ['apicall', 'time', 'event', 'keyValue', 'tearDown', 'setRootElement']);
         mockPlayerComponentInstance = jasmine.createSpyObj('playerComponentMock', [
           'play', 'pause', 'isEnded', 'isPaused', 'setCurrentTime', 'getCurrentTime', 'getDuration', 'getSeekableRange',
-          'getPlayerElement', 'tearDown', 'getWindowStartTime', 'getWindowEndTime']);
+          'getPlayerElement', 'tearDown', 'getWindowStartTime', 'getWindowEndTime', 'setPlaybackRate']);
         mockSubtitlesInstance = jasmine.createSpyObj('mockSubtitlesInstance', ['enable', 'disable', 'show', 'hide', 'enabled', 'available', 'setPosition', 'customise', 'renderExample', 'clearExample', 'tearDown']);
         mockResizer = jasmine.createSpyObj('mockResizer', ['resize', 'clear', 'isResized']);
         successCallback = jasmine.createSpy('successCallback');
@@ -705,6 +705,22 @@ require(
           mockEventHook({data: {currentTime: middleOfStreamWindow}, timeUpdate: true});
 
           expect(callback).toHaveBeenCalledWith({currentTime: middleOfStreamWindow, endOfStream: false});
+        });
+      });
+
+      describe('setPlaybackRate', function () {
+        it('should setPlaybackRate on the strategy/playerComponent', function () {
+          initialiseBigscreenPlayer();
+
+          bigscreenPlayer.setPlaybackRate(2);
+
+          expect(mockPlayerComponentInstance.setPlaybackRate).toHaveBeenCalledWith(2);
+        });
+
+        it('should not set playback rate on the strategy/playerComponent if bigscreen player is not initialised', function () {
+          bigscreenPlayer.setCurrentTime(2);
+
+          expect(mockPlayerComponentInstance.setPlaybackRate).not.toHaveBeenCalled();
         });
       });
 

--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -725,10 +725,12 @@ require(
 
         it('should call through to get the playback rate when requested', function () {
           initialiseBigscreenPlayer();
+          mockPlayerComponentInstance.getPlaybackRate.and.returnValue(1.5);
 
-          bigscreenPlayer.getPlaybackRate();
+          var rate = bigscreenPlayer.getPlaybackRate();
 
           expect(mockPlayerComponentInstance.getPlaybackRate).toHaveBeenCalled();
+          expect(rate).toEqual(1.5);
         });
 
         it('should not get playback rate if playerComponent is not initialised', function () {

--- a/script-test/bigscreenplayertest.js
+++ b/script-test/bigscreenplayertest.js
@@ -126,7 +126,7 @@ require(
         var mockDebugTool = jasmine.createSpyObj('mockDebugTool', ['apicall', 'time', 'event', 'keyValue', 'tearDown', 'setRootElement']);
         mockPlayerComponentInstance = jasmine.createSpyObj('playerComponentMock', [
           'play', 'pause', 'isEnded', 'isPaused', 'setCurrentTime', 'getCurrentTime', 'getDuration', 'getSeekableRange',
-          'getPlayerElement', 'tearDown', 'getWindowStartTime', 'getWindowEndTime', 'setPlaybackRate']);
+          'getPlayerElement', 'tearDown', 'getWindowStartTime', 'getWindowEndTime', 'setPlaybackRate', 'getPlaybackRate']);
         mockSubtitlesInstance = jasmine.createSpyObj('mockSubtitlesInstance', ['enable', 'disable', 'show', 'hide', 'enabled', 'available', 'setPosition', 'customise', 'renderExample', 'clearExample', 'tearDown']);
         mockResizer = jasmine.createSpyObj('mockResizer', ['resize', 'clear', 'isResized']);
         successCallback = jasmine.createSpy('successCallback');
@@ -708,7 +708,7 @@ require(
         });
       });
 
-      describe('setPlaybackRate', function () {
+      describe('Playback Rate', function () {
         it('should setPlaybackRate on the strategy/playerComponent', function () {
           initialiseBigscreenPlayer();
 
@@ -717,10 +717,24 @@ require(
           expect(mockPlayerComponentInstance.setPlaybackRate).toHaveBeenCalledWith(2);
         });
 
-        it('should not set playback rate on the strategy/playerComponent if bigscreen player is not initialised', function () {
-          bigscreenPlayer.setCurrentTime(2);
+        it('should not set playback rate if playerComponent is not initialised', function () {
+          bigscreenPlayer.setPlaybackRate(2);
 
           expect(mockPlayerComponentInstance.setPlaybackRate).not.toHaveBeenCalled();
+        });
+
+        it('should call through to get the playback rate when requested', function () {
+          initialiseBigscreenPlayer();
+
+          bigscreenPlayer.getPlaybackRate();
+
+          expect(mockPlayerComponentInstance.getPlaybackRate).toHaveBeenCalled();
+        });
+
+        it('should not get playback rate if playerComponent is not initialised', function () {
+          bigscreenPlayer.getPlaybackRate();
+
+          expect(mockPlayerComponentInstance.getPlaybackRate).not.toHaveBeenCalled();
         });
       });
 

--- a/script-test/playbackstrategies/basicstrategytest.js
+++ b/script-test/playbackstrategies/basicstrategytest.js
@@ -476,13 +476,24 @@ require(
         });
       });
 
-      describe('setPlaybackRate', function () {
+      describe('Playback Rate', function () {
         it('sets the playback rate on the media element', function () {
           setUpStrategy();
           basicStrategy.load(null, 0);
           basicStrategy.setPlaybackRate(2);
 
           expect(mockVideoElement.playbackRate).toEqual(2);
+        });
+
+        it('gets the playback rate on the media element', function () {
+          setUpStrategy();
+          basicStrategy.load(null, 0);
+          var testRate = 1.5;
+          basicStrategy.setPlaybackRate(testRate);
+
+          var rate = basicStrategy.getPlaybackRate();
+
+          expect(rate).toEqual(testRate);
         });
       });
 

--- a/script-test/playbackstrategies/basicstrategytest.js
+++ b/script-test/playbackstrategies/basicstrategytest.js
@@ -476,6 +476,16 @@ require(
         });
       });
 
+      describe('setPlaybackRate', function () {
+        it('sets the playback rate on the media element', function () {
+          setUpStrategy();
+          basicStrategy.load(null, 0);
+          basicStrategy.setPlaybackRate(2);
+
+          expect(mockVideoElement.playbackRate).toEqual(2);
+        });
+      });
+
       describe('isPaused', function () {
         it('should return false when the media element is not paused', function () {
           setUpStrategy();

--- a/script-test/playbackstrategies/legacyplayeradaptortest.js
+++ b/script-test/playbackstrategies/legacyplayeradaptortest.js
@@ -51,7 +51,7 @@ require(
         mediaPlayer = jasmine.createSpyObj('mediaPlayer', ['addEventCallback', 'initialiseMedia', 'beginPlayback',
           'getState', 'resume', 'getPlayerElement', 'getSeekableRange',
           'reset', 'stop', 'removeAllEventCallbacks', 'getSource',
-          'getMimeType', 'beginPlaybackFrom', 'playFrom', 'pause']);
+          'getMimeType', 'beginPlaybackFrom', 'playFrom', 'pause', 'setPlaybackRate']);
 
         injector.mock({
           'bigscreenplayer/playbackstrategy/liveglitchcurtain': mockGlitchCurtainConstructorInstance
@@ -505,6 +505,16 @@ require(
           expect(mediaPlayer.playFrom).toHaveBeenCalledWith(10);
 
           expect(mediaPlayer.pause).not.toHaveBeenCalledWith();
+        });
+      });
+
+      describe('setPlaybackRate', function () {
+        it('calls through to the mediaPlayers setPlaybackRate function', function () {
+          setUpLegacyAdaptor();
+
+          legacyAdaptor.setPlaybackRate(2);
+
+          expect(mediaPlayer.setPlaybackRate).toHaveBeenCalledWith(2);
         });
       });
 

--- a/script-test/playbackstrategies/legacyplayeradaptortest.js
+++ b/script-test/playbackstrategies/legacyplayeradaptortest.js
@@ -517,12 +517,14 @@ require(
           expect(mediaPlayer.setPlaybackRate).toHaveBeenCalledWith(2);
         });
 
-        it('calls through to the mediaPlayers getPlaybackRate function', function () {
+        it('calls through to the mediaPlayers getPlaybackRate function and returns correct value', function () {
           setUpLegacyAdaptor();
+          mediaPlayer.getPlaybackRate.and.returnValue(1.5);
 
-          legacyAdaptor.getPlaybackRate();
+          var rate = legacyAdaptor.getPlaybackRate();
 
           expect(mediaPlayer.getPlaybackRate).toHaveBeenCalled();
+          expect(rate).toEqual(1.5);
         });
 
         it('getPlaybackRate returns 1.0 if mediaPlayer does not have getPlaybackRate function', function () {

--- a/script-test/playbackstrategies/legacyplayeradaptortest.js
+++ b/script-test/playbackstrategies/legacyplayeradaptortest.js
@@ -51,7 +51,7 @@ require(
         mediaPlayer = jasmine.createSpyObj('mediaPlayer', ['addEventCallback', 'initialiseMedia', 'beginPlayback',
           'getState', 'resume', 'getPlayerElement', 'getSeekableRange',
           'reset', 'stop', 'removeAllEventCallbacks', 'getSource',
-          'getMimeType', 'beginPlaybackFrom', 'playFrom', 'pause', 'setPlaybackRate']);
+          'getMimeType', 'beginPlaybackFrom', 'playFrom', 'pause', 'setPlaybackRate', 'getPlaybackRate']);
 
         injector.mock({
           'bigscreenplayer/playbackstrategy/liveglitchcurtain': mockGlitchCurtainConstructorInstance
@@ -508,13 +508,28 @@ require(
         });
       });
 
-      describe('setPlaybackRate', function () {
+      describe('Playback Rate', function () {
         it('calls through to the mediaPlayers setPlaybackRate function', function () {
           setUpLegacyAdaptor();
 
           legacyAdaptor.setPlaybackRate(2);
 
           expect(mediaPlayer.setPlaybackRate).toHaveBeenCalledWith(2);
+        });
+
+        it('calls through to the mediaPlayers getPlaybackRate function', function () {
+          setUpLegacyAdaptor();
+
+          legacyAdaptor.getPlaybackRate();
+
+          expect(mediaPlayer.getPlaybackRate).toHaveBeenCalled();
+        });
+
+        it('getPlaybackRate returns 1.0 if mediaPlayer does not have getPlaybackRate function', function () {
+          mediaPlayer = jasmine.createSpyObj('mediaPlayer', ['addEventCallback']);
+          setUpLegacyAdaptor();
+
+          expect(legacyAdaptor.getPlaybackRate()).toEqual(1.0);
         });
       });
 

--- a/script-test/playbackstrategies/modifiers/html5tests.js
+++ b/script-test/playbackstrategies/modifiers/html5tests.js
@@ -1808,12 +1808,23 @@ require(
         });
       });
 
-      describe('setPlaybackRate', function () {
+      describe('Playback Rate', function () {
         it('sets the playback rate on the media element', function () {
           player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
           player.setPlaybackRate(2);
 
           expect(mockVideoMediaElement.playbackRate).toEqual(2);
+        });
+
+        it('gets the playback rate on the media element', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+
+          var testRate = 1.5;
+          player.setPlaybackRate(testRate);
+
+          var rate = player.getPlaybackRate();
+
+          expect(rate).toEqual(testRate);
         });
       });
 

--- a/script-test/playbackstrategies/modifiers/html5tests.js
+++ b/script-test/playbackstrategies/modifiers/html5tests.js
@@ -1808,6 +1808,15 @@ require(
         });
       });
 
+      describe('setPlaybackRate', function () {
+        it('sets the playback rate on the media element', function () {
+          player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});
+          player.setPlaybackRate(2);
+
+          expect(mockVideoMediaElement.playbackRate).toEqual(2);
+        });
+      });
+
       describe('Media Element Stop', function () {
         it(' Stop When In Buffering State', function () {
           player.initialiseMedia(MediaPlayerBase.TYPE.VIDEO, 'http://url/', 'video/mp4', sourceContainer, {});

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -49,7 +49,7 @@ require(
         mockDashInstance = jasmine.createSpyObj('mockDashInstance',
           ['initialize', 'retrieveManifest', 'getDebug', 'getSource', 'on', 'off', 'time', 'duration', 'attachSource',
             'reset', 'isPaused', 'pause', 'play', 'seek', 'isReady', 'refreshManifest', 'getDashMetrics', 'getDashAdapter',
-            'getBitrateInfoListFor', 'getAverageThroughput', 'getDVRWindowSize', 'updateSettings', 'setDuration', 'setPlaybackRate']);
+            'getBitrateInfoListFor', 'getAverageThroughput', 'getDVRWindowSize', 'updateSettings', 'setDuration', 'setPlaybackRate', 'getPlaybackRate']);
         mockPluginsInterface = jasmine.createSpyObj('interface', ['onErrorCleared', 'onBuffering', 'onBufferingCleared', 'onError', 'onFatalError', 'onErrorHandled', 'onPlayerInfoUpdated']);
         mockPlugins = {
           interface: mockPluginsInterface
@@ -815,7 +815,7 @@ require(
         });
       });
 
-      describe('setPlaybackRate()', function () {
+      describe('Playback Rate', function () {
         it('should call through to MediaPlayer\'s setPlaybackRate function', function () {
           setUpMSE();
           mseStrategy.load(null, 0);
@@ -823,6 +823,15 @@ require(
           mseStrategy.setPlaybackRate(2);
 
           expect(mockDashInstance.setPlaybackRate).toHaveBeenCalledWith(2);
+        });
+
+        it('should call through to MediaPlayer\'s getPlaybackRate function', function () {
+          setUpMSE();
+          mseStrategy.load(null, 0);
+
+          mseStrategy.getPlaybackRate();
+
+          expect(mockDashInstance.getPlaybackRate).toHaveBeenCalled();
         });
       });
 

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -49,7 +49,7 @@ require(
         mockDashInstance = jasmine.createSpyObj('mockDashInstance',
           ['initialize', 'retrieveManifest', 'getDebug', 'getSource', 'on', 'off', 'time', 'duration', 'attachSource',
             'reset', 'isPaused', 'pause', 'play', 'seek', 'isReady', 'refreshManifest', 'getDashMetrics', 'getDashAdapter',
-            'getBitrateInfoListFor', 'getAverageThroughput', 'getDVRWindowSize', 'updateSettings', 'setDuration']);
+            'getBitrateInfoListFor', 'getAverageThroughput', 'getDVRWindowSize', 'updateSettings', 'setDuration', 'setPlaybackRate']);
         mockPluginsInterface = jasmine.createSpyObj('interface', ['onErrorCleared', 'onBuffering', 'onBufferingCleared', 'onError', 'onFatalError', 'onErrorHandled', 'onPlayerInfoUpdated']);
         mockPlugins = {
           interface: mockPluginsInterface
@@ -812,6 +812,17 @@ require(
 
             expect(mockDashInstance.seek).toHaveBeenCalledWith(78.9);
           });
+        });
+      });
+
+      describe('setPlaybackRate()', function () {
+        it('should call through to MediaPlayer\'s setPlaybackRate function', function () {
+          setUpMSE();
+          mseStrategy.load(null, 0);
+
+          mseStrategy.setPlaybackRate(2);
+
+          expect(mockDashInstance.setPlaybackRate).toHaveBeenCalledWith(2);
         });
       });
 

--- a/script-test/playbackstrategies/msestrategytest.js
+++ b/script-test/playbackstrategies/msestrategytest.js
@@ -825,13 +825,15 @@ require(
           expect(mockDashInstance.setPlaybackRate).toHaveBeenCalledWith(2);
         });
 
-        it('should call through to MediaPlayer\'s getPlaybackRate function', function () {
+        it('should call through to MediaPlayer\'s getPlaybackRate function and returns correct value', function () {
           setUpMSE();
           mseStrategy.load(null, 0);
+          mockDashInstance.getPlaybackRate.and.returnValue(1.5);
 
-          mseStrategy.getPlaybackRate();
+          var rate = mseStrategy.getPlaybackRate();
 
           expect(mockDashInstance.getPlaybackRate).toHaveBeenCalled();
+          expect(rate).toEqual(1.5);
         });
       });
 

--- a/script-test/playercomponenttest.js
+++ b/script-test/playercomponenttest.js
@@ -281,6 +281,17 @@ require(
         });
       });
 
+      describe('setPlaybackRate', function () {
+        it('calls into the strategy to set the playback rate', function () {
+          spyOn(mockStrategy, 'setPlaybackRate');
+          setUpPlayerComponent();
+
+          playerComponent.setPlaybackRate(2);
+
+          expect(mockStrategy.setPlaybackRate).toHaveBeenCalledWith(2);
+        });
+      });
+
       describe('events', function () {
         describe('on playing', function () {
           it('should fire error cleared on the plugins', function () {

--- a/script-test/playercomponenttest.js
+++ b/script-test/playercomponenttest.js
@@ -281,7 +281,7 @@ require(
         });
       });
 
-      describe('setPlaybackRate', function () {
+      describe('Playback Rate', function () {
         it('calls into the strategy to set the playback rate', function () {
           spyOn(mockStrategy, 'setPlaybackRate');
           setUpPlayerComponent();
@@ -289,6 +289,15 @@ require(
           playerComponent.setPlaybackRate(2);
 
           expect(mockStrategy.setPlaybackRate).toHaveBeenCalledWith(2);
+        });
+
+        it('calls into the strategy to get the playback rate', function () {
+          spyOn(mockStrategy, 'getPlaybackRate');
+          setUpPlayerComponent();
+
+          playerComponent.getPlaybackRate();
+
+          expect(mockStrategy.getPlaybackRate).toHaveBeenCalled();
         });
       });
 

--- a/script-test/playercomponenttest.js
+++ b/script-test/playercomponenttest.js
@@ -294,10 +294,12 @@ require(
         it('calls into the strategy to get the playback rate', function () {
           spyOn(mockStrategy, 'getPlaybackRate');
           setUpPlayerComponent();
+          mockStrategy.getPlaybackRate.and.returnValue(1.5);
 
-          playerComponent.getPlaybackRate();
+          var rate = playerComponent.getPlaybackRate();
 
           expect(mockStrategy.getPlaybackRate).toHaveBeenCalled();
+          expect(rate).toEqual(1.5);
         });
       });
 

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -273,11 +273,6 @@ define('bigscreenplayer/bigscreenplayer',
             subtitleCallbacks.splice(indexOf, 1);
           }
         },
-        setPlaybackRate: function (rate) {
-          if (playerComponent) {
-            playerComponent.setPlaybackRate(rate);
-          }
-        },
         setCurrentTime: function (time) {
           DebugTool.apicall('setCurrentTime');
           if (playerComponent) {
@@ -285,6 +280,14 @@ define('bigscreenplayer/bigscreenplayer',
             playerComponent.setCurrentTime(time);
             endOfStream = windowType !== WindowTypes.STATIC && Math.abs(this.getSeekableRange().end - time) < END_OF_STREAM_TOLERANCE;
           }
+        },
+        setPlaybackRate: function (rate) {
+          if (playerComponent) {
+            playerComponent.setPlaybackRate(rate);
+          }
+        },
+        getPlaybackRate: function () {
+          return playerComponent && playerComponent.getPlaybackRate();
         },
         getCurrentTime: function () {
           return playerComponent && playerComponent.getCurrentTime() || 0;

--- a/script/bigscreenplayer.js
+++ b/script/bigscreenplayer.js
@@ -273,6 +273,11 @@ define('bigscreenplayer/bigscreenplayer',
             subtitleCallbacks.splice(indexOf, 1);
           }
         },
+        setPlaybackRate: function (rate) {
+          if (playerComponent) {
+            playerComponent.setPlaybackRate(rate);
+          }
+        },
         setCurrentTime: function (time) {
           DebugTool.apicall('setCurrentTime');
           if (playerComponent) {

--- a/script/mockbigscreenplayer.js
+++ b/script/mockbigscreenplayer.js
@@ -50,7 +50,7 @@ define('bigscreenplayer/mockbigscreenplayer',
     var liveWindowData;
     var manifestError;
 
-    var excludedFuncs = ['mock', 'mockJasmine', 'unmock', 'toggleDebug', 'getLogLevels', 'setLogLevel', 'convertEpochMsToVideoTimeSeconds', 'clearSubtitleExample', 'areSubtitlesCustomisable'];
+    var excludedFuncs = ['mock', 'mockJasmine', 'unmock', 'toggleDebug', 'getLogLevels', 'setLogLevel', 'convertEpochMsToVideoTimeSeconds', 'clearSubtitleExample', 'areSubtitlesCustomisable', 'setPlaybackRate'];
 
     function startProgress (progressCause) {
       setTimeout(function () {

--- a/script/mockbigscreenplayer.js
+++ b/script/mockbigscreenplayer.js
@@ -50,7 +50,7 @@ define('bigscreenplayer/mockbigscreenplayer',
     var liveWindowData;
     var manifestError;
 
-    var excludedFuncs = ['mock', 'mockJasmine', 'unmock', 'toggleDebug', 'getLogLevels', 'setLogLevel', 'convertEpochMsToVideoTimeSeconds', 'clearSubtitleExample', 'areSubtitlesCustomisable', 'setPlaybackRate'];
+    var excludedFuncs = ['mock', 'mockJasmine', 'unmock', 'toggleDebug', 'getLogLevels', 'setLogLevel', 'convertEpochMsToVideoTimeSeconds', 'clearSubtitleExample', 'areSubtitlesCustomisable', 'setPlaybackRate', 'getPlaybackRate'];
 
     function startProgress (progressCause) {
       setTimeout(function () {

--- a/script/playbackstrategy/basicstrategy.js
+++ b/script/playbackstrategy/basicstrategy.js
@@ -195,6 +195,10 @@ define('bigscreenplayer/playbackstrategy/basicstrategy',
         }
       }
 
+      function setPlaybackRate (rate) {
+        mediaElement.playbackRate = rate;
+      }
+
       function getClampedTime (time, range) {
         return Math.min(Math.max(time, range.start), range.end - CLAMP_OFFSET_SECONDS);
       }
@@ -276,6 +280,7 @@ define('bigscreenplayer/playbackstrategy/basicstrategy',
         pause: pause,
         play: play,
         setCurrentTime: setCurrentTime,
+        setPlaybackRate: setPlaybackRate,
         getPlayerElement: getPlayerElement
       };
     };

--- a/script/playbackstrategy/basicstrategy.js
+++ b/script/playbackstrategy/basicstrategy.js
@@ -199,6 +199,10 @@ define('bigscreenplayer/playbackstrategy/basicstrategy',
         mediaElement.playbackRate = rate;
       }
 
+      function getPlaybackRate () {
+        return mediaElement.playbackRate;
+      }
+
       function getClampedTime (time, range) {
         return Math.min(Math.max(time, range.start), range.end - CLAMP_OFFSET_SECONDS);
       }
@@ -281,6 +285,7 @@ define('bigscreenplayer/playbackstrategy/basicstrategy',
         play: play,
         setCurrentTime: setCurrentTime,
         setPlaybackRate: setPlaybackRate,
+        getPlaybackRate: getPlaybackRate,
         getPlayerElement: getPlayerElement
       };
     };

--- a/script/playbackstrategy/legacyplayeradapter.js
+++ b/script/playbackstrategy/legacyplayeradapter.js
@@ -304,7 +304,9 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
           }
         },
         setPlaybackRate: function (rate) {
-          mediaPlayer.setPlaybackRate(rate);
+          if (typeof mediaPlayer.setPlaybackRate === 'function') {
+            mediaPlayer.setPlaybackRate(rate);
+          }
         },
         getCurrentTime: function () {
           return currentTime;

--- a/script/playbackstrategy/legacyplayeradapter.js
+++ b/script/playbackstrategy/legacyplayeradapter.js
@@ -308,6 +308,12 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
             mediaPlayer.setPlaybackRate(rate);
           }
         },
+        getPlaybackRate: function () {
+          if (typeof mediaPlayer.getPlaybackRate === 'function') {
+            return mediaPlayer.getPlaybackRate();
+          }
+          return 1.0;
+        },
         getCurrentTime: function () {
           return currentTime;
         },

--- a/script/playbackstrategy/legacyplayeradapter.js
+++ b/script/playbackstrategy/legacyplayeradapter.js
@@ -303,6 +303,9 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
             return seekableRange;
           }
         },
+        setPlaybackRate: function (rate) {
+          mediaPlayer.setPlaybackRate(rate);
+        },
         getCurrentTime: function () {
           return currentTime;
         },

--- a/script/playbackstrategy/mockstrategy.js
+++ b/script/playbackstrategy/mockstrategy.js
@@ -59,6 +59,9 @@ define('bigscreenplayer/playbackstrategy/mockstrategy',
       setCurrentTime: function () {
         return;
       },
+      setPlaybackRate: function () {
+        return;
+      },
       isPaused: function () {
         return;
       },

--- a/script/playbackstrategy/mockstrategy.js
+++ b/script/playbackstrategy/mockstrategy.js
@@ -62,6 +62,9 @@ define('bigscreenplayer/playbackstrategy/mockstrategy',
       setPlaybackRate: function () {
         return;
       },
+      getPlaybackRate: function () {
+        return;
+      },
       isPaused: function () {
         return;
       },

--- a/script/playbackstrategy/modifiers/html5.js
+++ b/script/playbackstrategy/modifiers/html5.js
@@ -670,6 +670,10 @@ define(
           mediaElement.playbackRate = rate;
         },
 
+        getPlaybackRate: function () {
+          return mediaElement.playbackRate;
+        },
+
         playFrom: function (seconds) {
           postBufferingState = MediaPlayerBase.STATE.PLAYING;
           targetSeekTime = seconds;

--- a/script/playbackstrategy/modifiers/html5.js
+++ b/script/playbackstrategy/modifiers/html5.js
@@ -666,6 +666,10 @@ define(
           }
         },
 
+        setPlaybackRate: function (rate) {
+          mediaElement.playbackRate = rate;
+        },
+
         playFrom: function (seconds) {
           postBufferingState = MediaPlayerBase.STATE.PLAYING;
           targetSeekTime = seconds;

--- a/script/playbackstrategy/modifiers/samsungmaple.js
+++ b/script/playbackstrategy/modifiers/samsungmaple.js
@@ -598,37 +598,21 @@ define(
         },
 
         initialiseMedia: initialiseMedia,
-
         playFrom: playFrom,
-
         beginPlayback: beginPlayback,
-
         beginPlaybackFrom: beginPlaybackFrom,
-
         resume: resume,
-
         pause: pause,
-
         stop: stop,
-
         reset: reset,
-
         getSeekableRange: getSeekableRange,
-
         getState: getState,
-
         getPlayerElement: getPlayerElement,
-
         getSource: getSource,
-
         getMimeType: getMimeType,
-
         getCurrentTime: getCurrentTime,
-
         getDuration: getDuration,
-
         toPaused: toPaused,
-
         toPlaying: toPlaying
       };
     }

--- a/script/playbackstrategy/modifiers/samsungstreaming.js
+++ b/script/playbackstrategy/modifiers/samsungstreaming.js
@@ -767,37 +767,21 @@ define(
         },
 
         initialiseMedia: initialiseMedia,
-
         playFrom: playFrom,
-
         beginPlayback: beginPlayback,
-
         beginPlaybackFrom: beginPlaybackFrom,
-
         resume: resume,
-
         pause: pause,
-
         stop: stop,
-
         reset: reset,
-
         getSeekableRange: getSeekableRange,
-
         getState: getState,
-
         getPlayerElement: getPlayerElement,
-
         getSource: getSource,
-
         getMimeType: getMimeType,
-
         getCurrentTime: getCurrentTime,
-
         getDuration: getDuration,
-
         toPaused: toPaused,
-
         toPlaying: toPlaying
       };
     }

--- a/script/playbackstrategy/modifiers/samsungstreaming2015.js
+++ b/script/playbackstrategy/modifiers/samsungstreaming2015.js
@@ -753,37 +753,21 @@ define(
         },
 
         initialiseMedia: initialiseMedia,
-
         playFrom: playFrom,
-
         beginPlayback: beginPlayback,
-
         beginPlaybackFrom: beginPlaybackFrom,
-
         resume: resume,
-
         pause: pause,
-
         stop: stop,
-
         reset: reset,
-
         getSeekableRange: getSeekableRange,
-
         getState: getState,
-
         getPlayerElement: getPlayerElement,
-
         getSource: getSource,
-
         getMimeType: getMimeType,
-
         getCurrentTime: getCurrentTime,
-
         getDuration: getDuration,
-
         toPaused: toPaused,
-
         toPlaying: toPlaying
       };
     }

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -566,6 +566,9 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         play: function () {
           mediaPlayer.play();
         },
+        setPlaybackRate: function (rate) {
+          mediaPlayer.setPlaybackRate(rate);
+        },
         setCurrentTime: function (time) {
           publishedSeekEvent = false;
           isSeeking = true;

--- a/script/playbackstrategy/msestrategy.js
+++ b/script/playbackstrategy/msestrategy.js
@@ -566,9 +566,6 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
         play: function () {
           mediaPlayer.play();
         },
-        setPlaybackRate: function (rate) {
-          mediaPlayer.setPlaybackRate(rate);
-        },
         setCurrentTime: function (time) {
           publishedSeekEvent = false;
           isSeeking = true;
@@ -579,6 +576,12 @@ define('bigscreenplayer/playbackstrategy/msestrategy',
             var seekTime = calculateSeekOffset(time);
             mediaPlayer.seek(seekTime);
           }
+        },
+        setPlaybackRate: function (rate) {
+          mediaPlayer.setPlaybackRate(rate);
+        },
+        getPlaybackRate: function () {
+          return mediaPlayer.getPlaybackRate();
         }
       };
     };

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -98,6 +98,10 @@ define(
         playbackStrategy.setPlaybackRate(rate);
       }
 
+      function getPlaybackRate () {
+        return playbackStrategy.getPlaybackRate();
+      }
+
       function isNativeHLSRestartable () {
         return window.bigscreenPlayer.playbackStrategy === PlaybackStrategyModel.NATIVE &&
                transferFormat === TransferFormats.HLS &&
@@ -331,6 +335,7 @@ define(
         transitions: transitions,
         isEnded: isEnded,
         setPlaybackRate: setPlaybackRate,
+        getPlaybackRate: getPlaybackRate,
         setCurrentTime: setCurrentTime,
         getCurrentTime: getCurrentTime,
         getDuration: getDuration,

--- a/script/playercomponent.js
+++ b/script/playercomponent.js
@@ -94,6 +94,10 @@ define(
         }
       }
 
+      function setPlaybackRate (rate) {
+        playbackStrategy.setPlaybackRate(rate);
+      }
+
       function isNativeHLSRestartable () {
         return window.bigscreenPlayer.playbackStrategy === PlaybackStrategyModel.NATIVE &&
                transferFormat === TransferFormats.HLS &&
@@ -326,6 +330,7 @@ define(
         pause: pause,
         transitions: transitions,
         isEnded: isEnded,
+        setPlaybackRate: setPlaybackRate,
         setCurrentTime: setCurrentTime,
         getCurrentTime: getCurrentTime,
         getDuration: getDuration,


### PR DESCRIPTION
📺 What

Add ability to set the playback rate

> Tickets: IPLAYERTVV1-12315

🛠 How

Add api methods for get and set.

When setting:
- MSE strategy - will call method on dash.js
- Native strategy - will set the playback rate directly on the mediaElement (only for the html5 media player - so will **not** currently work for live or other players such as cehtml using native strategy)
- Basic strategy - will set playback rate directly

When getting - for native strategy, attempting to getPlaybackRate on anything other than the standard html5 mediaPlayer will result in a return value of 1.0. This is because you cannot _**set**_ the rate for these non-standard players.