### PR TITLE
Remove line space on right hand side of debug tool

### DIFF
--- a/script/debugger/debugview.js
+++ b/script/debugger/debugview.js
@@ -76,7 +76,7 @@ define('bigscreenplayer/debugger/debugview',
 
       var staticLogString = '';
       logData.static.forEach(function (log) {
-        staticLogString = staticLogString + log.key + ': ' + log.value + '\n\n';
+        staticLogString = staticLogString + log.key + ': ' + log.value + '\n';
       });
 
       staticContainer.innerHTML = staticLogString;


### PR DESCRIPTION
📺 What

Remove line space on right hand side of debug tool.

> Tickets: N/A

🛠 How

Remove one of the `\n`'s

👀 See

Original line spacing - some fields can easily be pushed off the bottom - this is exacerbated when using long url:

<img width="1280" alt="original_spacing" src="https://user-images.githubusercontent.com/35135054/123609189-5c474280-d7f7-11eb-9d00-be53d52bc46e.png">

New spacing:

<img width="1278" alt="new_spacing" src="https://user-images.githubusercontent.com/35135054/123609252-69fcc800-d7f7-11eb-9f1b-7bec69fe9514.png">




