### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ require(
             cdn: 'cdn1' // Displayed by Debug Tool
           }, {
             url: 'https://www.somelovelycaptionsurl2.com/captions/$segment$',
-            segmentLength: 3.84 
-            cdn: 'cdn1' 
+            segmentLength: 3.84
+            cdn: 'cdn1'
           },
         ],
-        captionsUrl: 'https://www.somelovelycaptionsurl.com/captions/', // NB This parameter is being deprecated in favour of the captions array shown above. 
+        captionsUrl: 'https://www.somelovelycaptionsurl.com/captions/', // NB This parameter is being deprecated in favour of the captions array shown above.
         subtitlesRequestTimeout: 5000, // Optional override for the XHR timeout on sidecar loaded subtitles
         subtitleCustomisation: {
           size: 0.75,
@@ -120,12 +120,12 @@ See the [configuration](https://github.com/bbc/bigscreen-player/wiki/Playback-St
 ### Reacting to state changes
 
 State changes which are emitted from the player can be acted upon to by registering a callback. The callback will receive all of the following state changes as the `state` property of the event:
-- MediaState.STOPPED
-- MediaState.PAUSED
-- MediaState.PLAYING
-- MediaState.WAITING
-- MediaState.ENDED
-- MediaState.FATAL_ERROR
+- `MediaState.STOPPED`
+- `MediaState.PAUSED`
+- `MediaState.PLAYING`
+- `MediaState.WAITING`
+- `MediaState.ENDED`
+- `MediaState.FATAL_ERROR`
 
 State changes may be registered for before initialisation and will automatically be cleared upon `tearDown()` of the player.
 
@@ -245,12 +245,12 @@ See [here](https://github.com/bbc/bigscreen-player/wiki/Mocking-Bigscreen-Player
 ## Releasing
 
 1. Create a PR.
-2. Label the PR with one of these labels: 
-    - `semver prerelease` 
+2. Label the PR with one of these labels:
+    - `semver prerelease`
     - `semver patch`
     - `semver minor`
-    - `semver major` 
-  
+    - `semver major`
+
     along with one of the following:
     - `has a user facing change`
     - `has no user facing changes`

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ require(
         captions: [{
             url: 'https://www.somelovelycaptionsurl.com/captions/$segment$', // $segment$ required for replacement for live
             segmentLength: 3.84, // Required to calculate live subtitle segment to fetch & live subtitle URL.
-            cdn: 'cdn1', // Displayed by Debug Tool
+            cdn: 'cdn1' // Displayed by Debug Tool
           }, {
             url: 'https://www.somelovelycaptionsurl2.com/captions/$segment$',
             segmentLength: 3.84,
-            cdn: 'cdn1',
+            cdn: 'cdn1'
           },
         ],
         captionsUrl: 'https://www.somelovelycaptionsurl.com/captions/', // NB This parameter is being deprecated in favour of the captions array shown above.
@@ -182,13 +182,13 @@ bigscreenPlayer.unregisterForSubtitleChanges(subtitleChangeToken);
 Plugins can be created to extend the functionality of the Bigscreen Player by adhering to an interface which propagates non state change events from the player. For example, when an error is raised or cleared.
 
 The full interface is as follows:
-- onError
-- onFatalError
-- onErrorCleared
-- onErrorHandled
-- onBuffering
-- onBufferingCleared
-- onScreenCapabilityDetermined
+- `onError`
+- `onFatalError`
+- `onErrorCleared`
+- `onErrorHandled`
+- `onBuffering`
+- `onBufferingCleared`
+- `onScreenCapabilityDetermined`
 
 An example plugin may look like:
 

--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ require(
         ],
         captions: [{
             url: 'https://www.somelovelycaptionsurl.com/captions/$segment$', // $segment$ required for replacement for live
-            segmentLength: 3.84 // Required to calculate live subtitle segment to fetch & live subtitle URL.
-            cdn: 'cdn1' // Displayed by Debug Tool
+            segmentLength: 3.84, // Required to calculate live subtitle segment to fetch & live subtitle URL.
+            cdn: 'cdn1', // Displayed by Debug Tool
           }, {
             url: 'https://www.somelovelycaptionsurl2.com/captions/$segment$',
-            segmentLength: 3.84
-            cdn: 'cdn1'
+            segmentLength: 3.84,
+            cdn: 'cdn1',
           },
         ],
         captionsUrl: 'https://www.somelovelycaptionsurl.com/captions/', // NB This parameter is being deprecated in favour of the captions array shown above.


### PR DESCRIPTION
📺 What

Updated README, improved code correctness.

🛠 How

First of all, I wrapped the `MediaStates` in `README.md` with backticks for good measure because the media states are code, thus they should be formatted properly as code as well, adding backticks makes it look more accurate, meaningful, and purposeful. Also added commas in objects as this is a syntax requirement.
