### PR TITLE
Catch async error thrown outside of test scope

### DIFF
--- a/script-test/utils/callcallbackstest.js
+++ b/script-test/utils/callcallbackstest.js
@@ -18,15 +18,23 @@ require(
         });
       });
 
+      // Note: Forgive the time hack, async deferred errors can be flakey in other tests if not caught!
       it('calls later callbacks if an earlier one errors', function () {
+        jasmine.clock().install();
         var callback = jasmine.createSpy('callback');
 
-        callCallbacks([
-          function () { throw new Error('oops'); },
-          callback
-        ]);
+        var failingCallCallbacks = function () {
+          callCallbacks([
+            function () { throw new Error('oops'); },
+            callback
+          ]);
+          jasmine.clock().tick(1);
+        };
+
+        expect(failingCallCallbacks).toThrowError();
 
         expect(callback).toHaveBeenCalledTimes(1);
+        jasmine.clock().uninstall();
       });
     });
   }


### PR DESCRIPTION
📺 What

The defer exceptions PR recently added this test, which causes other tests to fail occasionally on the CI.

> Tickets: N/A


🛠 How

Mock out time with the jasmine clock, then progress time inside the expectation that catches the error.

