### PR TITLE
Handle async uncaught error in the test suite

### DIFF
--- a/script-test/utils/deferexceptiontest.js
+++ b/script-test/utils/deferexceptiontest.js
@@ -11,11 +11,21 @@ require(
       });
 
       it('does not let an exception through', function () {
-        expect(function () {
-          deferExceptions(function () {
-            throw new Error('oops');
-          });
-        }).not.toThrow();
+        jasmine.clock().install();
+        var error = new Error('oops');
+
+        try {
+          expect(function () {
+            deferExceptions(function () {
+              throw error;
+            });
+          }).not.toThrow();
+          jasmine.clock().tick();
+        } catch (e) {
+          expect(e).toBe(error);
+        }
+
+        jasmine.clock().uninstall();
       });
     });
   }


### PR DESCRIPTION
📺 What

This test occasionally causes other tests to fail because the error is deferred by a setTimeout.

> Tickets: N/A

🛠 How

Similar to #228 this mocks out time to force the error to be thrown and caught by the test.