### PR TITLE
Debug tool readability improvements

### DIFF
--- a/script/debugger/debugview.js
+++ b/script/debugger/debugview.js
@@ -28,8 +28,8 @@ define('bigscreenplayer/debugger/debugview',
 
       staticBox.id = 'staticBox';
       staticBox.style.position = 'absolute';
-      staticBox.style.width = '26%';
-      staticBox.style.right = '5%';
+      staticBox.style.width = '30%';
+      staticBox.style.right = '1%';
       staticBox.style.top = '15%';
       staticBox.style.bottom = '25%';
       staticBox.style.backgroundColor = '#1D1D1D';
@@ -68,24 +68,39 @@ define('bigscreenplayer/debugger/debugview',
       var dynamicLogs = logData.dynamic;
       var LINES_TO_DISPLAY = 29;
       if (dynamicLogs.length === 0) {
-        logContainer.innerHTML = '';
+        logContainer.textContent = '';
       }
 
       dynamicLogs = dynamicLogs.slice(-LINES_TO_DISPLAY);
-      logContainer.innerHTML = dynamicLogs.join('\n');
+      logContainer.textContent = dynamicLogs.join('\n');
 
-      var staticLogString = '';
-      logData.static.forEach(function (log) {
-        staticLogString = staticLogString + log.key + ': ' + log.value + '\n';
-      });
+      logData.static.forEach(updateStaticElements);
+    }
 
-      staticContainer.innerHTML = staticLogString;
+    function updateStaticElements (log) {
+      var existingElement = document.getElementById(log.key);
+      var text = log.key + ': ' + log.value;
+      if (existingElement) {
+        if (text !== existingElement.textContent) {
+          existingElement.textContent = text;
+        }
+      } else {
+        createNewStaticElement(log.key, log.value);
+      }
+    }
+
+    function createNewStaticElement (key, value) {
+      var staticLog = document.createElement('div');
+
+      staticLog.id = key;
+      staticLog.style.paddingBottom = '1%';
+      staticLog.style.borderBottom = '1px solid white';
+      staticLog.textContent = key + ': ' + value;
+
+      staticContainer.appendChild(staticLog);
     }
 
     function tearDown () {
-      var logBox = document.getElementById('logBox');
-      var staticBox = document.getElementById('staticBox');
-
       DOMHelpers.safeRemoveElement(logBox);
       DOMHelpers.safeRemoveElement(staticBox);
 

--- a/script/debugger/debugview.js
+++ b/script/debugger/debugview.js
@@ -76,7 +76,7 @@ define('bigscreenplayer/debugger/debugview',
 
       var staticLogString = '';
       logData.static.forEach(function (log) {
-        staticLogString = staticLogString + log.key + ': ' + log.value + '\n\n';
+        staticLogString = staticLogString + log.key + ': ' + log.value + '\n';
       });
 
       staticContainer.innerHTML = staticLogString;

--- a/script/mediasources.js
+++ b/script/mediasources.js
@@ -252,10 +252,10 @@ define('bigscreenplayer/mediasources',
 
       function updateDebugOutput () {
         DebugTool.keyValue({key: 'available cdns', value: availableCdns()});
-        DebugTool.keyValue({key: 'url', value: getCurrentUrl()});
+        DebugTool.keyValue({key: 'url', value: stripQueryParamsAndHash(getCurrentUrl())});
 
         DebugTool.keyValue({key: 'available subtitle cdns', value: availableSubtitlesCdns()});
-        DebugTool.keyValue({key: 'subtitles url', value: getCurrentSubtitlesUrl()});
+        DebugTool.keyValue({key: 'subtitles url', value: stripQueryParamsAndHash(getCurrentSubtitlesUrl())});
       }
 
       return {


### PR DESCRIPTION
📺 What

* Strip down URLs on the debug tool.

🛠 How

* Use stripQueryParamAndHash on the displayed URLs

👀 See
Before:
<img width="1280" alt="Screenshot 2021-07-14 at 11 58 46" src="https://user-images.githubusercontent.com/25988323/125625632-3f0d80e7-1589-4f8f-b926-9d3b7bf62310.png">

After: 
<img width="1279" alt="Screenshot 2021-07-19 at 08 50 48" src="https://user-images.githubusercontent.com/25988323/126122970-0b0ba590-4de0-4cbd-98ff-d80e25c9fc3c.png">


