### PR TITLE
legacyplayeradapter: do not call `playFrom` if not implemented

### DIFF
--- a/script-test/playbackstrategies/legacyplayeradaptortest.js
+++ b/script-test/playbackstrategies/legacyplayeradaptortest.js
@@ -183,14 +183,68 @@ require(
       });
 
       describe('play', function () {
-        it('should play from 0 if the stream has ended', function () {
-          setUpLegacyAdaptor();
+        describe('if the player supports playFrom()', function () {
+          it('should play from 0 if the stream has ended', function () {
+            setUpLegacyAdaptor();
 
-          eventCallbacks({type: MediaPlayerEvent.COMPLETE});
+            eventCallbacks({type: MediaPlayerEvent.COMPLETE});
 
-          legacyAdaptor.play();
+            legacyAdaptor.play();
 
-          expect(mediaPlayer.playFrom).toHaveBeenCalledWith(0);
+            expect(mediaPlayer.playFrom).toHaveBeenCalledWith(0);
+          });
+
+          it('should play from the current time if we are not ended, paused or buffering', function () {
+            setUpLegacyAdaptor();
+
+            eventCallbacks({type: MediaPlayerEvent.STATUS, currentTime: 10});
+
+            legacyAdaptor.play();
+
+            expect(mediaPlayer.playFrom).toHaveBeenCalledWith(10);
+          });
+
+          it('should play from the current time on live if we are not ended, paused or buffering', function () {
+            testTimeCorrection = 10;
+            setUpLegacyAdaptor({windowType: WindowTypes.SLIDING});
+
+            eventCallbacks({type: MediaPlayerEvent.STATUS, currentTime: 10});
+
+            legacyAdaptor.play();
+
+            expect(mediaPlayer.playFrom).toHaveBeenCalledWith(10);
+          });
+        });
+
+        describe('if the player does not support playFrom()', function () {
+          beforeEach(function () { delete mediaPlayer.playFrom; });
+
+          it('should do nothing and remain paused', function () {
+            setUpLegacyAdaptor();
+
+            eventCallbacks({type: MediaPlayerEvent.COMPLETE});
+
+            legacyAdaptor.play();
+
+            expect(legacyAdaptor.isPaused()).toEqual(true);
+          });
+
+          it('should do nothing if we are not ended, paused or buffering', function () {
+            setUpLegacyAdaptor();
+
+            eventCallbacks({type: MediaPlayerEvent.STATUS, currentTime: 10});
+
+            legacyAdaptor.play();
+          });
+
+          it('should do nothing on live if we are not ended, paused or buffering', function () {
+            testTimeCorrection = 10;
+            setUpLegacyAdaptor({windowType: WindowTypes.SLIDING});
+
+            eventCallbacks({type: MediaPlayerEvent.STATUS, currentTime: 10});
+
+            legacyAdaptor.play();
+          });
         });
 
         it('should resume if the player is in a paused or buffering state', function () {
@@ -201,27 +255,6 @@ require(
           legacyAdaptor.play();
 
           expect(mediaPlayer.resume).toHaveBeenCalledWith();
-        });
-
-        it('should play from the current time if we are not ended, paused or buffering', function () {
-          setUpLegacyAdaptor();
-
-          eventCallbacks({type: MediaPlayerEvent.STATUS, currentTime: 10});
-
-          legacyAdaptor.play();
-
-          expect(mediaPlayer.playFrom).toHaveBeenCalledWith(10);
-        });
-
-        it('should play from the current time on live if we are not ended, paused or buffering', function () {
-          testTimeCorrection = 10;
-          setUpLegacyAdaptor({windowType: WindowTypes.SLIDING});
-
-          eventCallbacks({type: MediaPlayerEvent.STATUS, currentTime: 10});
-
-          legacyAdaptor.play();
-
-          expect(mediaPlayer.playFrom).toHaveBeenCalledWith(10);
         });
       });
 
@@ -464,47 +497,90 @@ require(
           expect(legacyAdaptor.getCurrentTime()).toEqual(10);
         });
 
-        it('should seek to the time value passed in', function () {
-          setUpLegacyAdaptor();
+        // eslint-disable-next-line jasmine/no-suite-dupes
+        describe('if the player supports playFrom()', function () {
+          it('should seek to the time value passed in', function () {
+            setUpLegacyAdaptor();
 
-          legacyAdaptor.setCurrentTime(10);
+            legacyAdaptor.setCurrentTime(10);
 
-          expect(mediaPlayer.playFrom).toHaveBeenCalledWith(10);
+            expect(mediaPlayer.playFrom).toHaveBeenCalledWith(10);
+          });
+
+          it('should seek to the time value passed in + time correction', function () {
+            testTimeCorrection = 10;
+            setUpLegacyAdaptor({windowType: WindowTypes.SLIDING});
+
+            legacyAdaptor.setCurrentTime(10);
+
+            expect(mediaPlayer.playFrom).toHaveBeenCalledWith(20);
+          });
+
+          it('should pause after a seek if we were in a paused state, not watching dash and on a capable device', function () {
+            setUpLegacyAdaptor();
+
+            eventCallbacks({type: MediaPlayerEvent.PAUSED});
+
+            legacyAdaptor.setCurrentTime(10);
+
+            expect(mediaPlayer.playFrom).toHaveBeenCalledWith(10);
+
+            expect(mediaPlayer.pause).toHaveBeenCalledWith();
+          });
+
+          it('should not pause after a seek if we are not on capable device and watching a dash stream', function () {
+            setUpLegacyAdaptor({windowType: WindowTypes.SLIDING});
+
+            legacyAdaptor.load('application/dash+xml', undefined);
+
+            eventCallbacks({type: MediaPlayerEvent.PAUSED});
+
+            legacyAdaptor.setCurrentTime(10);
+
+            expect(mediaPlayer.playFrom).toHaveBeenCalledWith(10);
+
+            expect(mediaPlayer.pause).not.toHaveBeenCalledWith();
+          });
         });
 
-        it('should seek to the time value passed in + time correction', function () {
-          testTimeCorrection = 10;
-          setUpLegacyAdaptor({windowType: WindowTypes.SLIDING});
+        // eslint-disable-next-line jasmine/no-suite-dupes
+        describe('if the player does not support playFrom()', function () {
+          beforeEach(function () { delete mediaPlayer.playFrom; });
 
-          legacyAdaptor.setCurrentTime(10);
+          it('should do nothing', function () {
+            setUpLegacyAdaptor();
 
-          expect(mediaPlayer.playFrom).toHaveBeenCalledWith(20);
-        });
+            legacyAdaptor.setCurrentTime(10);
+          });
 
-        it('should pause after a seek if we were in a paused state, not watching dash and on a capable device', function () {
-          setUpLegacyAdaptor();
+          it('should do nothing for live', function () {
+            testTimeCorrection = 10;
+            setUpLegacyAdaptor({windowType: WindowTypes.SLIDING});
 
-          eventCallbacks({type: MediaPlayerEvent.PAUSED});
+            legacyAdaptor.setCurrentTime(10);
+          });
 
-          legacyAdaptor.setCurrentTime(10);
+          it('should remain paused if we were in a paused state, not watching dash and on a capable device', function () {
+            setUpLegacyAdaptor();
 
-          expect(mediaPlayer.playFrom).toHaveBeenCalledWith(10);
+            eventCallbacks({type: MediaPlayerEvent.PAUSED});
 
-          expect(mediaPlayer.pause).toHaveBeenCalledWith();
-        });
+            legacyAdaptor.setCurrentTime(10);
 
-        it('should not pause after a seek if we are not on capable device and watching a dash stream', function () {
-          setUpLegacyAdaptor({windowType: WindowTypes.SLIDING});
+            expect(legacyAdaptor.isPaused()).toEqual(true);
+          });
 
-          legacyAdaptor.load('application/dash+xml', undefined);
+          it('should not pause after a no-op seek if we are not on capable device and watching a dash stream', function () {
+            setUpLegacyAdaptor({windowType: WindowTypes.SLIDING});
 
-          eventCallbacks({type: MediaPlayerEvent.PAUSED});
+            legacyAdaptor.load('application/dash+xml', undefined);
 
-          legacyAdaptor.setCurrentTime(10);
+            eventCallbacks({type: MediaPlayerEvent.PAUSED});
 
-          expect(mediaPlayer.playFrom).toHaveBeenCalledWith(10);
+            legacyAdaptor.setCurrentTime(10);
 
-          expect(mediaPlayer.pause).not.toHaveBeenCalledWith();
+            expect(mediaPlayer.pause).not.toHaveBeenCalledWith();
+          });
         });
       });
 

--- a/script-test/playbackstrategies/legacyplayeradaptortest.js
+++ b/script-test/playbackstrategies/legacyplayeradaptortest.js
@@ -219,14 +219,12 @@ require(
         describe('if the player does not support playFrom()', function () {
           beforeEach(function () { delete mediaPlayer.playFrom; });
 
-          it('should do nothing and remain paused', function () {
+          it('should not throw an error', function () {
             setUpLegacyAdaptor();
 
             eventCallbacks({type: MediaPlayerEvent.COMPLETE});
 
             legacyAdaptor.play();
-
-            expect(legacyAdaptor.isPaused()).toEqual(true);
           });
 
           it('should do nothing if we are not ended, paused or buffering', function () {

--- a/script-test/playbackstrategies/legacyplayeradaptortest.js
+++ b/script-test/playbackstrategies/legacyplayeradaptortest.js
@@ -545,13 +545,14 @@ require(
         describe('if the player does not support playFrom()', function () {
           beforeEach(function () { delete mediaPlayer.playFrom; });
 
-          it('should do nothing', function () {
+          // eslint-disable-next-line jasmine/no-spec-dupes
+          it('should not throw an error', function () {
             setUpLegacyAdaptor();
 
             legacyAdaptor.setCurrentTime(10);
           });
 
-          it('should do nothing for live', function () {
+          it('should not throw an error for live', function () {
             testTimeCorrection = 10;
             setUpLegacyAdaptor({windowType: WindowTypes.SLIDING});
 

--- a/script/playbackstrategy/legacyplayeradapter.js
+++ b/script/playbackstrategy/legacyplayeradapter.js
@@ -253,6 +253,8 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
           DebugTool.keyValue({key: 'strategy', value: getStrategy()});
         },
         play: function () {
+          if (isEnded && !mediaPlayer.playFrom) return;
+
           isPaused = false;
           if (delayPauseOnExitSeek && exitingSeek) {
             pauseOnExitSeek = false;
@@ -262,7 +264,7 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
             } else if (transitions.canResume()) {
               mediaPlayer.resume();
             } else {
-              mediaPlayer.playFrom(currentTime + timeCorrection);
+              mediaPlayer.playFrom && mediaPlayer.playFrom(currentTime + timeCorrection);
             }
           }
         },
@@ -318,6 +320,8 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
           return currentTime;
         },
         setCurrentTime: function (seekToTime) {
+          if (!mediaPlayer.playFrom) return;
+
           isEnded = false;
           currentTime = seekToTime;
           seekToTime += timeCorrection;

--- a/script/playbackstrategy/legacyplayeradapter.js
+++ b/script/playbackstrategy/legacyplayeradapter.js
@@ -318,8 +318,6 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
           return currentTime;
         },
         setCurrentTime: function (seekToTime) {
-          if (!mediaPlayer.playFrom) return;
-
           isEnded = false;
           currentTime = seekToTime;
           seekToTime += timeCorrection;
@@ -330,7 +328,7 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
             pauseOnExitSeek = isPaused;
           }
 
-          mediaPlayer.playFrom(seekToTime);
+          mediaPlayer.playFrom && mediaPlayer.playFrom(seekToTime);
           if (isPaused && !delayPauseOnExitSeek) {
             mediaPlayer.pause();
           }

--- a/script/playbackstrategy/legacyplayeradapter.js
+++ b/script/playbackstrategy/legacyplayeradapter.js
@@ -253,14 +253,12 @@ define('bigscreenplayer/playbackstrategy/legacyplayeradapter',
           DebugTool.keyValue({key: 'strategy', value: getStrategy()});
         },
         play: function () {
-          if (isEnded && !mediaPlayer.playFrom) return;
-
           isPaused = false;
           if (delayPauseOnExitSeek && exitingSeek) {
             pauseOnExitSeek = false;
           } else {
             if (isEnded) {
-              mediaPlayer.playFrom(0);
+              mediaPlayer.playFrom && mediaPlayer.playFrom(0);
             } else if (transitions.canResume()) {
               mediaPlayer.resume();
             } else {


### PR DESCRIPTION
📺 What

_I recommend disabling white space changes to review_

'restartable' devices to not have a `playFrom` method, but we were still trying to call it sometimes, causing errors.

We now check if it's there before calling it, the same way we do for other optional methods.

Interestingly there was a test that made sure this was broken 😆 : "restartable HMTL5 Live Player should not have methods for playFrom"


> Tickets: IPLAYERTVV1-12491


🛠 How
Check the function exists before calling it.
- `setCurrentTime` may result in the wrong current time for a bit, but won't throw an error anymore. This is safer than making `setCurrentTime` a no-op, leaving the known wrong current time bug.
- `play()` will flip `isPaused()` to `false`, but will not start playback if the content has ended. This is a safer fix, with this known `isPaused()` bug
- `play()` is a no-op if `!transitions.canResume()`. Not sure if there's a better thing to do here?

✅ Testing [Semi-optional]
So far just unit tests.

[Test Guidelines](https://github.com/bbc/bigscreen-player/wiki/Areas-Impacted)

| Test engineer sign off | :x: |
| ---- | ---- |

[How will this change be tested?]