### PR TITLE
Make subtitle header XML split more general

### DIFF
--- a/script-test/subtitles/imscsubtitles.js
+++ b/script-test/subtitles/imscsubtitles.js
@@ -283,7 +283,7 @@ require(
           loadUrlStubResponseText = '<?xml version="1.0" encoding="utf-8" extra property="something"?><tt xmlns="http://www.w3.org/ns/ttml"></tt>';
           subtitles = ImscSubtitles(mediaPlayer, true, mockParentElement, mockMediaSources, {});
 
-          expect(imscMock.fromXML).toHaveBeenCalledWith(loadUrlStubResponseText);
+          expect(imscMock.fromXML).toHaveBeenCalledWith('<tt xmlns="http://www.w3.org/ns/ttml"></tt>');
         });
 
         it('fires tranformError plugin if IMSC throws an exception when parsing', function () {

--- a/script/subtitles/imscsubtitles.js
+++ b/script/subtitles/imscsubtitles.js
@@ -66,7 +66,7 @@ define('bigscreenplayer/subtitles/imscsubtitles',
             }
 
             try {
-              var xml = IMSC.fromXML(responseText.split(/<\?xml version=\"1.0\" encoding=\"UTF-8\"\?>/i)[1] || responseText);
+              var xml = IMSC.fromXML(responseText.split(/<\?xml[^\?]+\?>/i)[1] || responseText);
               var times = xml.getMediaTimeEvents();
 
               segments.push({


### PR DESCRIPTION
📺 What

Allows the XML declaration to contain more generic content including the usage of both single and double quotation marks 

> Tickets: IPLAYERTVV1-12583


🛠 How

Update the regex used to match the declaration in the `.split` function when preparing the document for IMSC.

 ✅ Acceptance criteria 

* [ ] XML documents with varying XML declarations can be used to provide subtitles