### PR TITLE
Emit manifest and render changed events

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -166,7 +166,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
   }
 
   function emitManifestInfo (manifest) {
-    Plugins.interface.onManifestLoaded({ manifest })
+    Plugins.interface.onManifestLoaded(manifest)
   }
 
   function onManifestValidityChange (event) {

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -232,6 +232,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
     }
 
     emitPlayerInfo()
+    Plugins.interface.onQualityChangedRendered(event)
   }
 
   /**

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -160,7 +160,13 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
 
       ManifestModifier.filter(manifest, representationOptions)
       ManifestModifier.generateBaseUrls(manifest, mediaSources.availableSources())
+
+      emitManifestInfo(manifest)
     }
+  }
+
+  function emitManifestInfo (manifest) {
+    Plugins.interface.onManifestLoaded({ manifest })
   }
 
   function onManifestValidityChange (event) {

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -899,6 +899,16 @@ describe('Media Source Extensions Playback Strategy', () => {
     })
   })
 
+  describe('onManifestLoaded', () => {
+    it('calls onManifestLoaded plugin with the manifest when dashjs loads it', () => {
+      const onManifestLoadedSpy = jest.spyOn(Plugins.interface, 'onManifestLoaded')
+
+      dashEventCallback(dashjsMediaPlayerEvents.MANIFEST_LOADED, testManifestObject)
+
+      expect(onManifestLoadedSpy).toHaveBeenCalledWith(expect.any(Object))
+    })
+  })
+
   describe('onMetricAdded and onQualityChangeRendered', () => {
     const mockEvent = {
       mediaType: 'video',

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -39,6 +39,7 @@ export default {
     onScreenCapabilityDetermined: (tvInfo) => callOnAllPlugins('onScreenCapabilityDetermined', tvInfo),
     onPlayerInfoUpdated: (evt) => callOnAllPlugins('onPlayerInfoUpdated', evt),
     onManifestLoaded: (manifest) => callOnAllPlugins('onManifestLoaded', manifest),
+    onQualityChangedRendered: (evt) => callOnAllPlugins('onQualityChangedRendered', evt),
     onSubtitlesLoadError: (evt) => callOnAllPlugins('onSubtitlesLoadError', evt),
     onSubtitlesTimeout: (evt) => callOnAllPlugins('onSubtitlesTimeout', evt),
     onSubtitlesXMLError: (evt) => callOnAllPlugins('onSubtitlesXMLError', evt),

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -38,6 +38,7 @@ export default {
     onBufferingCleared: (evt) => callOnAllPlugins('onBufferingCleared', evt),
     onScreenCapabilityDetermined: (tvInfo) => callOnAllPlugins('onScreenCapabilityDetermined', tvInfo),
     onPlayerInfoUpdated: (evt) => callOnAllPlugins('onPlayerInfoUpdated', evt),
+    onManifestLoaded: (manifest) => callOnAllPlugins('onManifestLoaded', manifest),
     onSubtitlesLoadError: (evt) => callOnAllPlugins('onSubtitlesLoadError', evt),
     onSubtitlesTimeout: (evt) => callOnAllPlugins('onSubtitlesTimeout', evt),
     onSubtitlesXMLError: (evt) => callOnAllPlugins('onSubtitlesXMLError', evt),


### PR DESCRIPTION
📺 What

Allow consumers access to the parsed manifest info and also know about any changes in rendered represenation.

> Tickets: IPLAYERTVV1-12875

🛠 How

Add two plugins `onManifestLoaded` and `onQualityChangedRendered`. 

✅ Testing [Semi-optional]

| Test engineer sign off | :x: |
| ---- | ---- |

Manual testing that plugins are correctly emitted.