### PR TITLE
Protect all interactions with Seekable property when using the caching override.

### DIFF
--- a/src/playbackstrategy/modifiers/html5.js
+++ b/src/playbackstrategy/modifiers/html5.js
@@ -267,7 +267,6 @@ function Html5 () {
   }
 
   function setSentinels (sentinels) {
-    disableSeekSentinel = true
     if (disableSentinels) { return }
 
     clearSentinels()
@@ -351,27 +350,36 @@ function Html5 () {
       readyToCache = true
     }, 250)
 
-    cachedSeekableRange = {
-      start: mediaElement.seekable.start(0),
-      end: mediaElement.seekable.end(0)
+    if (mediaElement.seekable && mediaElement.seekable.length > 0) {
+      cachedSeekableRange = {
+        start: mediaElement.seekable.start(0),
+        end: mediaElement.seekable.end(0)
+      }
+    } else if (mediaElement.duration !== undefined) {
+      cachedSeekableRange = {
+        start: 0,
+        end: mediaElement.duration
+      }
     }
   }
 
   function getSeekableRange () {
     if (mediaElement) {
-      if (isReadyToPlayFrom() && mediaElement.seekable && mediaElement.seekable.length > 0) {
+      if (isReadyToPlayFrom()) {
         if (window.bigscreenPlayer.overrides && window.bigscreenPlayer.overrides.cacheSeekableRange) {
           return getCachedSeekableRange()
         } else {
-          return {
-            start: mediaElement.seekable.start(0),
-            end: mediaElement.seekable.end(0)
+          if (mediaElement.seekable && mediaElement.seekable.length > 0) {
+            return {
+              start: mediaElement.seekable.start(0),
+              end: mediaElement.seekable.end(0)
+            }
+          } else if (mediaElement.duration !== undefined) {
+            return {
+              start: 0,
+              end: mediaElement.duration
+            }
           }
-        }
-      } else if (mediaElement.duration !== undefined) {
-        return {
-          start: 0,
-          end: mediaElement.duration
         }
       }
     }

--- a/src/playbackstrategy/modifiers/html5.js
+++ b/src/playbackstrategy/modifiers/html5.js
@@ -349,7 +349,7 @@ function Html5 () {
     readyToCache = false
     setTimeout(function () {
       readyToCache = true
-    }, 500)
+    }, 1100)
 
     cachedSeekableRange = {
       start: mediaElement.seekable.start(0),

--- a/src/playbackstrategy/modifiers/html5.js
+++ b/src/playbackstrategy/modifiers/html5.js
@@ -1,7 +1,6 @@
 import MediaPlayerBase from '../modifiers/mediaplayerbase'
 import DOMHelpers from '../../domhelpers'
 import handlePlayPromise from '../../utils/handleplaypromise'
-import DebugTool from '../../debugger/debugtool'
 
 function Html5 () {
   const sentinelLimits = {
@@ -350,40 +349,31 @@ function Html5 () {
       readyToCache = true
     }, 250)
 
-    if (mediaElement.seekable && mediaElement.seekable.length > 0) {
-      cachedSeekableRange = {
-        start: mediaElement.seekable.start(0),
-        end: mediaElement.seekable.end(0)
-      }
-    } else if (mediaElement.duration !== undefined) {
-      cachedSeekableRange = {
-        start: 0,
-        end: mediaElement.duration
+    cachedSeekableRange = getElementSeekableRange()
+  }
+
+  function getElementSeekableRange () {
+    if (mediaElement) {
+      if (isReadyToPlayFrom() && mediaElement.seekable && mediaElement.seekable.length > 0) {
+        return {
+          start: mediaElement.seekable.start(0),
+          end: mediaElement.seekable.end(0)
+        }
+      } else if (mediaElement.duration !== undefined) {
+        return {
+          start: 0,
+          end: mediaElement.duration
+        }
       }
     }
   }
 
   function getSeekableRange () {
-    if (mediaElement) {
-      if (isReadyToPlayFrom()) {
-        if (window.bigscreenPlayer.overrides && window.bigscreenPlayer.overrides.cacheSeekableRange) {
-          return getCachedSeekableRange()
-        } else {
-          if (mediaElement.seekable && mediaElement.seekable.length > 0) {
-            return {
-              start: mediaElement.seekable.start(0),
-              end: mediaElement.seekable.end(0)
-            }
-          } else if (mediaElement.duration !== undefined) {
-            return {
-              start: 0,
-              end: mediaElement.duration
-            }
-          }
-        }
-      }
+    if (window.bigscreenPlayer.overrides && window.bigscreenPlayer.overrides.cacheSeekableRange) {
+      return getCachedSeekableRange()
+    } else {
+      return getElementSeekableRange()
     }
-    return undefined
   }
 
   function onFinishedBuffering () {

--- a/src/playbackstrategy/modifiers/html5.js
+++ b/src/playbackstrategy/modifiers/html5.js
@@ -1,6 +1,7 @@
 import MediaPlayerBase from '../modifiers/mediaplayerbase'
 import DOMHelpers from '../../domhelpers'
 import handlePlayPromise from '../../utils/handleplaypromise'
+import DebugTool from '../../debugger/debugtool'
 
 function Html5 () {
   const sentinelLimits = {
@@ -344,10 +345,11 @@ function Html5 () {
   }
 
   function cacheSeekableRange () {
+    DebugTool.info('cacheSeekableRange')
     readyToCache = false
     setTimeout(function () {
       readyToCache = true
-    }, 250)
+    }, 1100)
 
     cachedSeekableRange = {
       start: mediaElement.seekable.start(0),

--- a/src/playbackstrategy/modifiers/html5.js
+++ b/src/playbackstrategy/modifiers/html5.js
@@ -349,7 +349,7 @@ function Html5 () {
     readyToCache = false
     setTimeout(function () {
       readyToCache = true
-    }, 250)
+    }, 500)
 
     cachedSeekableRange = {
       start: mediaElement.seekable.start(0),

--- a/src/playbackstrategy/modifiers/html5.js
+++ b/src/playbackstrategy/modifiers/html5.js
@@ -267,6 +267,7 @@ function Html5 () {
   }
 
   function setSentinels (sentinels) {
+    disableSeekSentinel = true
     if (disableSentinels) { return }
 
     clearSentinels()
@@ -345,11 +346,10 @@ function Html5 () {
   }
 
   function cacheSeekableRange () {
-    DebugTool.info('cacheSeekableRange')
     readyToCache = false
     setTimeout(function () {
       readyToCache = true
-    }, 1100)
+    }, 250)
 
     cachedSeekableRange = {
       start: mediaElement.seekable.start(0),

--- a/src/playbackstrategy/modifiers/html5.js
+++ b/src/playbackstrategy/modifiers/html5.js
@@ -349,7 +349,7 @@ function Html5 () {
     readyToCache = false
     setTimeout(function () {
       readyToCache = true
-    }, 1100)
+    }, 250)
 
     cachedSeekableRange = {
       start: mediaElement.seekable.start(0),


### PR DESCRIPTION
📺 What

Adds additional caching protection to the seekable range properties.

> Tickets: IPLAYERTVV1-12900


🛠 How

* Encapsulates the calls to all the seekable range properties inside a `getElementSeekableRange` so `getCachedSeekableRange` can now use this and won't interact with the `mediaElement.seekable` more than every 250ms.