### PR TITLE
Seekable range end takes live delay into account

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -12,8 +12,6 @@ import Utils from '../utils/playbackutils'
 import { MediaPlayer } from 'dashjs/index_mediaplayerOnly'
 
 function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUHD, customPlayerSettings) {
-  const LIVE_DELAY_SECONDS = 1.1
-
   let mediaPlayer
   let mediaElement
 
@@ -40,6 +38,18 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
       numDownloaded: undefined
     }
   }
+
+  let playerSettings = Utils.merge({
+    debug: {
+      logLevel: 2
+    },
+    streaming: {
+      liveDelay: 1.1,
+      bufferToKeep: 4,
+      bufferTimeAtTopQuality: 12,
+      bufferTimeAtTopQualityLongForm: 15
+    }
+  }, customPlayerSettings)
 
   const DashJSEvents = {
     LOG: 'log',
@@ -316,7 +326,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
   }
 
   function getClampedTime (time, range) {
-    return Math.min(Math.max(time, range.start), range.end - LIVE_DELAY_SECONDS)
+    return Math.min(Math.max(time, range.start), range.end - playerSettings.streaming.liveDelay)
   }
 
   function load (mimeType, playbackTime) {
@@ -346,17 +356,6 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
 
   function setUpMediaPlayer (playbackTime) {
     mediaPlayer = MediaPlayer().create()
-    const playerSettings = Utils.merge({
-      debug: {
-        logLevel: 2
-      },
-      streaming: {
-        liveDelay: LIVE_DELAY_SECONDS,
-        bufferToKeep: 4,
-        bufferTimeAtTopQuality: 12,
-        bufferTimeAtTopQualityLongForm: 15
-      }
-    }, customPlayerSettings)
     mediaPlayer.updateSettings(playerSettings)
     mediaPlayer.initialize(mediaElement, null, true)
     modifySource(playbackTime)
@@ -419,7 +418,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
       if (dvrInfo) {
         return {
           start: dvrInfo.range.start - timeCorrection,
-          end: dvrInfo.range.end - timeCorrection
+          end: dvrInfo.range.end - timeCorrection - playerSettings.streaming.liveDelay
         }
       }
     }
@@ -454,7 +453,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
 
   function calculateSeekOffset (time) {
     function getClampedTimeForLive (time) {
-      return Math.min(Math.max(time, 0), mediaPlayer.getDVRWindowSize() - LIVE_DELAY_SECONDS)
+      return Math.min(Math.max(time, 0), mediaPlayer.getDVRWindowSize() - playerSettings.streaming.liveDelay)
     }
 
     if (windowType === WindowTypes.SLIDING) {

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -142,7 +142,7 @@ describe('Media Source Extensions Playback Strategy', () => {
     mockAudioElement = undefined
   })
 
-  function setUpMSE (timeCorrection, windowType, mediaKind, windowStartTimeMS, windowEndTimeMS) {
+  function setUpMSE (timeCorrection, windowType, mediaKind, windowStartTimeMS, windowEndTimeMS, customPlayerSettings) {
     const defaultWindowType = windowType || WindowTypes.STATIC
     const defaultMediaKind = mediaKind || MediaKinds.VIDEO
 
@@ -152,7 +152,7 @@ describe('Media Source Extensions Playback Strategy', () => {
       windowEndTime: windowEndTimeMS || 0
     }
 
-    mseStrategy = MSEStrategy(mediaSources, defaultWindowType, defaultMediaKind, playbackElement, {}, false)
+    mseStrategy = MSEStrategy(mediaSources, defaultWindowType, defaultMediaKind, playbackElement, false, customPlayerSettings || {})
   }
 
   describe('Transitions', () => {
@@ -462,6 +462,30 @@ describe('Media Source Extensions Playback Strategy', () => {
   describe('getSeekableRange()', () => {
     it('returns the correct start and end time', () => {
       setUpMSE()
+      mseStrategy.load(null, 45)
+
+      expect(mseStrategy.getSeekableRange()).toEqual({ start: 0, end: 101 })
+    })
+
+    it('returns the end time taking the live delay into account for a live stream', () => {
+      let customPlayerSettings = {
+        streaming: {
+          liveDelay: 20
+        }
+      }
+      setUpMSE(0, WindowTypes.SLIDING, MediaKinds.VIDEO, 100, 1000, customPlayerSettings)
+      mseStrategy.load(null, 45)
+
+      expect(mseStrategy.getSeekableRange()).toEqual({ start: 0, end: 81 })
+    })
+
+    it('returns the end time ignoring the live delay for an on demand stream', () => {
+      let customPlayerSettings = {
+        streaming: {
+          liveDelay: 20
+        }
+      }
+      setUpMSE(0, WindowTypes.STATIC, MediaKinds.VIDEO, 100, 1000, customPlayerSettings)
       mseStrategy.load(null, 45)
 
       expect(mseStrategy.getSeekableRange()).toEqual({ start: 0, end: 101 })


### PR DESCRIPTION
📺 What

Given the live delay for MSE strategy means you shouldn't be playing closer than that value to the end of the stream, update the seekable range end, so that clients aren't informed that they can seek further forward than they can.

> Tickets: IPLAYERTVV1-13509

🛠 How

For dynamic streams, using the MSE strategy, subtract the value of `liveDelay` from the DVR Info end before returning.

✅ Testing

[Test Guidelines](https://github.com/bbc/bigscreen-player/wiki/Areas-Impacted)

| Test engineer sign off | ✅ |
| ---- | ---- |