### PR TITLE
Allow HTTP status code 0 as successful response when loading manifest and subtitles files

### DIFF
--- a/src/utils/loadurl.js
+++ b/src/utils/loadurl.js
@@ -1,4 +1,4 @@
-function LoadUrl (url, opts) {
+function LoadUrl(url, opts) {
   const xhr = new XMLHttpRequest()
 
   if (opts.timeout) {
@@ -12,13 +12,13 @@ function LoadUrl (url, opts) {
   xhr.onreadystatechange = () => {
     if (xhr.readyState === 4) {
       xhr.onreadystatechange = null
-      if (xhr.status >= 200 && xhr.status < 300) {
+      if (xhr.status === 0 || (xhr.status >= 200 && xhr.status < 300)) {
         if (opts.onLoad) {
           opts.onLoad(xhr.responseXML, xhr.responseText, xhr.status)
         }
       } else {
         if (opts.onError) {
-          opts.onError({errorType: 'NON_200_ERROR', statusCode: xhr.status})
+          opts.onError({ errorType: 'NON_200_ERROR', statusCode: xhr.status })
         }
       }
     }
@@ -37,7 +37,7 @@ function LoadUrl (url, opts) {
     xhr.send(opts.data || null)
   } catch ({ name }) {
     if (opts.onError) {
-      opts.onError({errorType: name, statusCode: xhr.status})
+      opts.onError({ errorType: name, statusCode: xhr.status })
     }
   }
 }


### PR DESCRIPTION
📺 What

Allow XHR requests for the manifest and subtitles to return a HTTP status of 0.

As per the [XHR MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readystatechange_event), it shows that a status code of 0 can be acceptable as a success response. 

This PR allows that scenario in case we have been rejecting responses that actually have valid data. 


🛠 How

Update the `loadUrl` script to allow status code of 0 to be classes as successful and continue with the request parsing. 