### PR TITLE
Treat XHR status code 0 as error in loadUrl

### DIFF
--- a/src/utils/loadurl.js
+++ b/src/utils/loadurl.js
@@ -1,4 +1,4 @@
-function LoadUrl(url, opts) {
+function LoadUrl (url, opts) {
   const xhr = new XMLHttpRequest()
 
   if (opts.timeout) {
@@ -12,7 +12,7 @@ function LoadUrl(url, opts) {
   xhr.onreadystatechange = () => {
     if (xhr.readyState === 4) {
       xhr.onreadystatechange = null
-      if (xhr.status === 0 || (xhr.status >= 200 && xhr.status < 300)) {
+      if (xhr.status >= 200 && xhr.status < 300) {
         if (opts.onLoad) {
           opts.onLoad(xhr.responseXML, xhr.responseText, xhr.status)
         }


### PR DESCRIPTION
📺 What

In #271 we allowed a status code of `0` to be treated as a success response in `loadUrl` which is used when fetching manifests and subtitle files. 


🛠 How

Update `loadUrl.js` to not explicitly allow status code `0` as a successful response.