### PR TITLE
Handle and report manifest errors and provide a fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prepare": "[ ! -d dist/ ] && npm run build || exit 0",
     "docs": "npx jsdoc -c jsdoc.conf.json",
     "build": "rollup -c rollup.config.js",
+    "watch": "rollup -c rollup.config.js -w",
     "start": "rollup -c rollup.dev.config.js -w",
     "test": "jest",
     "coverage": "jest --coverage",

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -99,7 +99,7 @@ function BigscreenPlayer () {
       return new Date(time * 1000)
     }
   }
-
+  
   function convertVideoTimeSecondsToEpochMs (seconds) {
     return getWindowStartTime() ? getWindowStartTime() + (seconds * 1000) : null
   }

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -101,7 +101,7 @@ function BigscreenPlayer () {
   }
 
   function convertVideoTimeSecondsToEpochMs (seconds) {
-    return getWindowStartTime() ? getWindowStartTime() + (seconds * 1000) : undefined
+    return getWindowStartTime() ? getWindowStartTime() + (seconds * 1000) : null
   }
 
   function bigscreenPlayerDataLoaded (bigscreenPlayerData, enableSubtitles) {
@@ -574,7 +574,7 @@ function BigscreenPlayer () {
      * @return the time in seconds within the current sliding window.
      */
     convertEpochMsToVideoTimeSeconds: (epochTime) => {
-      return getWindowStartTime() ? Math.floor((epochTime - getWindowStartTime()) / 1000) : undefined
+      return getWindowStartTime() ? Math.floor((epochTime - getWindowStartTime()) / 1000) : null
     },
 
     /**

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -99,7 +99,7 @@ function BigscreenPlayer () {
       return new Date(time * 1000)
     }
   }
-  
+
   function convertVideoTimeSecondsToEpochMs (seconds) {
     return getWindowStartTime() ? getWindowStartTime() + (seconds * 1000) : null
   }

--- a/src/bigscreenplayer.test.js
+++ b/src/bigscreenplayer.test.js
@@ -1253,7 +1253,7 @@ describe('Bigscreen Player', () => {
 
       initialiseBigscreenPlayer()
 
-      expect(bigscreenPlayer.convertVideoTimeSecondsToEpochMs(1000)).toBeUndefined()
+      expect(bigscreenPlayer.convertVideoTimeSecondsToEpochMs(1000)).toBe(null)
     })
   })
 
@@ -1286,7 +1286,7 @@ describe('Bigscreen Player', () => {
 
       initialiseBigscreenPlayer()
 
-      expect(bigscreenPlayer.convertEpochMsToVideoTimeSeconds(1547643600000)).toBeUndefined()
+      expect(bigscreenPlayer.convertEpochMsToVideoTimeSeconds(1547643600000)).toBe(null)
     })
   })
 

--- a/src/manifest/manifestparser.js
+++ b/src/manifest/manifestparser.js
@@ -1,6 +1,7 @@
 import TimeUtils from './../utils/timeutils'
 import DebugTool from '../debugger/debugtool'
 import Plugins from '../plugins'
+import pluginenums from '../pluginenums'
 
 function parseMPD (manifest, dateWithOffset) {
   try {
@@ -28,13 +29,11 @@ function parseMPD (manifest, dateWithOffset) {
         correction: timeCorrection
       }
     } else {
-      const error = new Error('Error parsing DASH manifest attributes')
-      error.type = 'manifest-dash-attribute-parse'
-      throw error
+      throw new Error('manifest-dash-attributes-parse-error')
     }
   } catch (e) {
-    const error = new Error('Error parsing DASH manifest')
-    error.type = 'manifest-dash-generic-parse'
+    const error = new Error(e.message || 'manifest-dash-parse-error')
+    error.code = pluginenums.ERROR_CODES.MANIFEST_PARSE
     throw error
   }
 }
@@ -52,13 +51,11 @@ function parseM3U8 (manifest) {
         windowEndTime: windowEndTime
       }
     } else {
-      const error = new Error('Error parsing HLS manifest attributes')
-      error.type = 'manifest-hls-attribute-parse'
-      throw error
+      throw new Error('manifest-hls-attributes-parse-error')
     }
   } catch (e) {
-    const error = new Error('Error parsing HLS manifest')
-    error.type = 'manifest-hls-generic-parse'
+    const error = new Error(e.message || 'manifest-hls-parse-error')
+    error.code = pluginenums.ERROR_CODES.MANIFEST_PARSE
     throw error
   }
 }
@@ -102,8 +99,8 @@ function parse (manifest, type, dateWithOffset) {
       return parseM3U8(manifest)
     }
   } catch (e) {
-    DebugTool.error('Manifest Parse Error: ' + e.type)
-    Plugins.interface.onManifestParseError(e.type)
+    DebugTool.error('Manifest Parse Error: ' + e.code + ' ' + e.message)
+    Plugins.interface.onManifestParseError({code: e.code, message: e.message})
     return fallback
   }
 }

--- a/src/manifest/manifestparser.js
+++ b/src/manifest/manifestparser.js
@@ -1,4 +1,5 @@
 import TimeUtils from './../utils/timeutils'
+import DebugTool from '../debugger/debugtool'
 
 function parseMPD (manifest, dateWithOffset) {
   try {
@@ -81,10 +82,23 @@ function getM3U8WindowSizeInSeconds (data) {
 }
 
 function parse (manifest, type, dateWithOffset) {
-  if (type === 'mpd') {
-    return parseMPD(manifest, dateWithOffset)
-  } else if (type === 'm3u8') {
-    return parseM3U8(manifest)
+  const fallback = {
+    windowStartTime: null,
+    windowEndTime: null,
+    correction: 0 
+  }
+
+  try {
+    if (type === 'mpd') {
+      return parseMPD(manifest, dateWithOffset)
+    } else if (type === 'm3u8') {
+      return parseM3U8(manifest)
+    }
+  } catch (e) {
+    // Debug Logging
+    DebugTool.info('Manifest Parse Error: ' + e.type)
+    // Add a plugin to report the failure - Plugins.onManifestParseError, defaults will allow content to play
+    return fallback
   }
 }
 

--- a/src/manifest/manifestparser.js
+++ b/src/manifest/manifestparser.js
@@ -99,7 +99,7 @@ function parse (manifest, type, dateWithOffset) {
       return parseM3U8(manifest)
     }
   } catch (e) {
-    DebugTool.error('Manifest Parse Error: ' + e.code + ' ' + e.message)
+    DebugTool.info('Manifest Parse Error: ' + e.code + ' ' + e.message)
     Plugins.interface.onManifestParseError({code: e.code, message: e.message})
     return fallback
   }

--- a/src/manifest/manifestparser.js
+++ b/src/manifest/manifestparser.js
@@ -26,10 +26,14 @@ function parseMPD (manifest, dateWithOffset) {
         correction: timeCorrection
       }
     } else {
-      return { error: 'Error parsing DASH manifest attributes' }
+      const error = new Error('Error parsing DASH manifest attributes')
+      error.type = 'manifest-dash-attribute-parse'
+      throw error
     }
   } catch (e) {
-    return { error: 'Error parsing DASH manifest' }
+    const error = new Error('Error parsing DASH manifest')
+    error.type = 'manifest-dash-generic-parse'
+    throw error
   }
 }
 
@@ -45,7 +49,9 @@ function parseM3U8 (manifest) {
       windowEndTime: windowEndTime
     }
   } else {
-    return { error: 'Error parsing HLS manifest' }
+    const error = new Error('Error parsing HLS manifest')
+    error.type = 'manifest-hls-generic-parse'
+    throw error
   }
 }
 

--- a/src/manifest/manifestparser.js
+++ b/src/manifest/manifestparser.js
@@ -42,10 +42,10 @@ function parseM3U8 (manifest) {
   try {
     const windowStartTime = getM3U8ProgramDateTime(manifest)
     const duration = getM3U8WindowSizeInSeconds(manifest)
-  
+
     if (windowStartTime && duration) {
       const windowEndTime = windowStartTime + duration * 1000
-  
+
       return {
         windowStartTime: windowStartTime,
         windowEndTime: windowEndTime
@@ -89,7 +89,7 @@ function parse (manifest, type, dateWithOffset) {
   const fallback = {
     windowStartTime: null,
     windowEndTime: null,
-    correction: 0 
+    correction: 0
   }
 
   try {
@@ -100,7 +100,7 @@ function parse (manifest, type, dateWithOffset) {
     }
   } catch (e) {
     DebugTool.info('Manifest Parse Error: ' + e.code + ' ' + e.message)
-    Plugins.interface.onManifestParseError({code: e.code, message: e.message})
+    Plugins.interface.onManifestParseError({ code: e.code, message: e.message })
     return fallback
   }
 }

--- a/src/manifest/manifestparser.test.js
+++ b/src/manifest/manifestparser.test.js
@@ -34,18 +34,30 @@ describe('ManifestParser', () => {
       })
     })
 
-    it('returns an error if manifest data has bad data in the attributes', () => {
+    it('returns fallback data if manifest data has bad data in the attributes', () => {
+      const fallbackData = {
+        windowStartTime: null,
+        windowEndTime: null,
+        correction: 0
+      }
+
       const manifest = dashManifests.badAttributes()
       const liveWindowData = ManifestParser.parse(manifest, 'mpd', new Date('2018-12-13T11:00:00.000000Z'))
 
-      expect(liveWindowData).toEqual({error: 'Error parsing DASH manifest attributes'})
+      expect(liveWindowData).toEqual(fallbackData)
     })
 
-    it('returns an error if manifest data is malformed', () => {
+    it('returns fallback data if manifest data is malformed', () => {
+      const fallbackData = {
+        windowStartTime: null,
+        windowEndTime: null,
+        correction: 0
+      }
+
       const manifest = 'not an MPD'
       const liveWindowData = ManifestParser.parse(manifest, 'mpd', new Date('2018-12-13T11:00:00.000000Z'))
 
-      expect(liveWindowData).toEqual({error: 'Error parsing DASH manifest'})
+      expect(liveWindowData).toEqual(fallbackData)
     })
   })
 
@@ -60,18 +72,28 @@ describe('ManifestParser', () => {
       })
     })
 
-    it('returns and error if manifest has an invalid start date', () => {
+    it('returns fallback data if manifest has an invalid start date', () => {
+      const fallbackData = {
+        windowStartTime: null,
+        windowEndTime: null,
+        correction: 0
+      }
       const manifest = hlsManifests.invalidDate
       const liveWindowData = ManifestParser.parse(manifest, 'm3u8')
 
-      expect(liveWindowData).toEqual({error: 'Error parsing HLS manifest'})
+      expect(liveWindowData).toEqual(fallbackData)
     })
 
-    it('returns an error if hls manifest data is malformed', () => {
+    it('returns fallback data if hls manifest data is malformed', () => {
+      const fallbackData = {
+        windowStartTime: null,
+        windowEndTime: null,
+        correction: 0
+      }
       const manifest = 'not an valid manifest'
       const liveWindowData = ManifestParser.parse(manifest, 'm3u8')
 
-      expect(liveWindowData).toEqual({error: 'Error parsing HLS manifest'})
+      expect(liveWindowData).toEqual(fallbackData)
     })
   })
 })

--- a/src/manifest/manifestparser.test.js
+++ b/src/manifest/manifestparser.test.js
@@ -1,6 +1,7 @@
 import ManifestParser from './manifestparser'
 import DashManifests from './stubData/dashmanifests'
 import HlsManifests from './stubData/hlsmanifests'
+import Plugins from '../plugins'
 
 describe('ManifestParser', () => {
   let dashManifests
@@ -9,6 +10,7 @@ describe('ManifestParser', () => {
   beforeEach(() => {
     dashManifests = new DashManifests()
     hlsManifests = new HlsManifests()
+    jest.spyOn(Plugins.interface, 'onManifestParseError')
   })
 
   describe('DASH mpd', () => {
@@ -45,6 +47,7 @@ describe('ManifestParser', () => {
       const liveWindowData = ManifestParser.parse(manifest, 'mpd', new Date('2018-12-13T11:00:00.000000Z'))
 
       expect(liveWindowData).toEqual(fallbackData)
+      expect(Plugins.interface.onManifestParseError).toHaveBeenCalled()
     })
 
     it('returns fallback data if manifest data is malformed', () => {
@@ -58,6 +61,7 @@ describe('ManifestParser', () => {
       const liveWindowData = ManifestParser.parse(manifest, 'mpd', new Date('2018-12-13T11:00:00.000000Z'))
 
       expect(liveWindowData).toEqual(fallbackData)
+      expect(Plugins.interface.onManifestParseError).toHaveBeenCalled()
     })
   })
 
@@ -82,6 +86,7 @@ describe('ManifestParser', () => {
       const liveWindowData = ManifestParser.parse(manifest, 'm3u8')
 
       expect(liveWindowData).toEqual(fallbackData)
+      expect(Plugins.interface.onManifestParseError).toHaveBeenCalled()
     })
 
     it('returns fallback data if hls manifest data is malformed', () => {
@@ -94,6 +99,7 @@ describe('ManifestParser', () => {
       const liveWindowData = ManifestParser.parse(manifest, 'm3u8')
 
       expect(liveWindowData).toEqual(fallbackData)
+      expect(Plugins.interface.onManifestParseError).toHaveBeenCalled()
     })
   })
 })

--- a/src/mediasources.js
+++ b/src/mediasources.js
@@ -166,7 +166,7 @@ function MediaSources () {
     }
 
     const onManifestLoadError = () => {
-      failover(load, failoverError, { isBufferingTimeoutError: false, code: PluginEnums.ERROR_CODES.MANIFEST, message: PluginEnums.ERROR_MESSAGES.MANIFEST })
+      failover(load, failoverError, { isBufferingTimeoutError: false, code: PluginEnums.ERROR_CODES.MANIFEST_LOAD, message: PluginEnums.ERROR_MESSAGES.MANIFEST })
     }
 
     function load () {

--- a/src/mediasources.test.js
+++ b/src/mediasources.test.js
@@ -237,7 +237,7 @@ describe('Media Sources', () => {
         newCdn: 'http://supplier2.com/',
         isInitialPlay: undefined,
         timeStamp: expect.any(Object),
-        code: PluginEnums.ERROR_CODES.MANIFEST,
+        code: PluginEnums.ERROR_CODES.MANIFEST_LOAD,
         message: PluginEnums.ERROR_MESSAGES.MANIFEST
       }
 

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -131,7 +131,7 @@ function PlayerComponent (playbackElement, bigscreenPlayerData, mediaSources, wi
 
     const onError = () => {
       tearDownMediaElement()
-      bubbleFatalError(false, { code: PluginEnums.ERROR_CODES.MANIFEST, message: PluginEnums.ERROR_MESSAGES.MANIFEST })
+      bubbleFatalError(false, { code: PluginEnums.ERROR_CODES.MANIFEST_LOAD, message: PluginEnums.ERROR_MESSAGES.MANIFEST })
     }
 
     mediaSources.refresh(doSeek, onError)

--- a/src/pluginenums.js
+++ b/src/pluginenums.js
@@ -12,7 +12,7 @@ export default {
   ERROR_CODES: {
     MANIFEST_PARSE: 7,
     BUFFERING_TIMEOUT: 8,
-    MANIFEST: 9
+    MANIFEST_LOAD: 9
   },
   ERROR_MESSAGES: {
     BUFFERING_TIMEOUT: 'bigscreen-player-buffering-timeout-error',

--- a/src/pluginenums.js
+++ b/src/pluginenums.js
@@ -10,6 +10,7 @@ export default {
     ERROR: 'error'
   },
   ERROR_CODES: {
+    MANIFEST_PARSE: 7,
     BUFFERING_TIMEOUT: 8,
     MANIFEST: 9
   },

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -39,6 +39,7 @@ export default {
     onScreenCapabilityDetermined: (tvInfo) => callOnAllPlugins('onScreenCapabilityDetermined', tvInfo),
     onPlayerInfoUpdated: (evt) => callOnAllPlugins('onPlayerInfoUpdated', evt),
     onManifestLoaded: (manifest) => callOnAllPlugins('onManifestLoaded', manifest),
+    onManifestParseError: (evt) => callOnAllPlugins('onManifestParseError', evt),
     onQualityChangedRendered: (evt) => callOnAllPlugins('onQualityChangedRendered', evt),
     onSubtitlesLoadError: (evt) => callOnAllPlugins('onSubtitlesLoadError', evt),
     onSubtitlesTimeout: (evt) => callOnAllPlugins('onSubtitlesTimeout', evt),


### PR DESCRIPTION
📺 What

Currently there is no way to know manifest parsing has failed. This PR provides a plugin hook `onManifestParseError` and explicitly defines the fallback behaviour of ManifestParser.

> Tickets: N/A


🛠 How

- Add `onManifestParseError` to the plugin interface.
- Change returning undefined from `convertEpochMsToVideoTimeSeconds` and `convertVideoTimeSecondsToEpochMs` to return null.