### PR TITLE
Update dash.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "bigscreen-player",
-      "version": "5.5.3",
+      "version": "5.6.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#smp-v3.2.0-5",
+        "dashjs": "github:bbc/dash.js#smp-v3.2.0-8",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {
@@ -3775,7 +3775,7 @@
     },
     "node_modules/dashjs": {
       "version": "3.2.0",
-      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#a8f79514a4200764c41af4d086b0bcc2887a7025",
+      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#5b8b4de675485fcde20292a03ca48d1ec38c2c6b",
       "license": "BSD-3-Clause",
       "dependencies": {
         "codem-isoboxer": "0.3.6",
@@ -12637,8 +12637,8 @@
       }
     },
     "dashjs": {
-      "version": "git+ssh://git@github.com/bbc/dash.js.git#a8f79514a4200764c41af4d086b0bcc2887a7025",
-      "from": "dashjs@github:bbc/dash.js#smp-v3.2.0-5",
+      "version": "git+ssh://git@github.com/bbc/dash.js.git#5b8b4de675485fcde20292a03ca48d1ec38c2c6b",
+      "from": "dashjs@github:bbc/dash.js#smp-v3.2.0-8",
       "requires": {
         "codem-isoboxer": "0.3.6",
         "fast-deep-equal": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "rollup-plugin-visualizer": "^5.5.2"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#smp-v3.2.0-5",
+    "dashjs": "github:bbc/dash.js#smp-v3.2.0-8",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {


### PR DESCRIPTION
📺 What

Update dash.js dependency (contains fixes for ending live event streams).

> Tickets: IPLAYERTVV1-13093

🛠 How

Update package and package-lock files.