### PR TITLE
Remove linting step from publish Github Action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,6 @@ jobs:
         with:
           node-version: 16
       - run: npm ci
-      - run: npm run lint
       - run: npm test
 
   publish-npm:


### PR DESCRIPTION
📺 What

Fix the NPM Publish Github Action by removing the linting step.

Linting occurs on PR checks and pre-commit so doesn't need to also run on publish.


🛠 How

Remove linting step from publish Github Action