### PR TITLE
Set Dash.js log level depending on DebugTool log level

### DIFF
--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -609,6 +609,12 @@ function BigscreenPlayer () {
 
     /**
      * @function
+     * @return {string} - currently set log level @see getLogLevels
+     */
+    getLogLevel: () => DebugTool.getLogLevel,
+
+    /**
+     * @function
      * @param logLevel -  log level to display @see getLogLevels
      */
     setLogLevel: DebugTool.setLogLevel,

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -47,7 +47,7 @@ function BigscreenPlayer () {
       DebugTool.time(evt.data.currentTime)
       callCallbacks(timeUpdateCallbacks, {
         currentTime: evt.data.currentTime,
-        endOfStream: endOfStream
+        endOfStream
       })
     } else {
       let stateObject = { state: evt.data.state }
@@ -95,9 +95,9 @@ function BigscreenPlayer () {
   function deviceTimeToDate (time) {
     if (getWindowStartTime()) {
       return new Date(convertVideoTimeSecondsToEpochMs(time))
-    } else {
+    } 
       return new Date(time * 1000)
-    }
+    
   }
 
   function convertVideoTimeSecondsToEpochMs (seconds) {
@@ -157,7 +157,7 @@ function BigscreenPlayer () {
   }
 
   function callSubtitlesCallbacks (enabled) {
-    callCallbacks(subtitleCallbacks, { enabled: enabled })
+    callCallbacks(subtitleCallbacks, { enabled })
   }
 
   function setSubtitlesEnabled (enabled) {
@@ -397,7 +397,7 @@ function BigscreenPlayer () {
         windowStartTime: getWindowStartTime(),
         windowEndTime: getWindowEndTime(),
         initialPlaybackTime: initialPlaybackTimeEpoch,
-        serverDate: serverDate
+        serverDate
       }
     },
 
@@ -459,19 +459,19 @@ function BigscreenPlayer () {
      * @function
      * @param {boolean} value
      */
-    setSubtitlesEnabled: setSubtitlesEnabled,
+    setSubtitlesEnabled,
 
     /**
      * @function
      * @return if subtitles are currently enabled.
      */
-    isSubtitlesEnabled: isSubtitlesEnabled,
+    isSubtitlesEnabled,
 
     /**
      * @function
      * @return Returns whether or not subtitles are currently enabled.
      */
-    isSubtitlesAvailable: isSubtitlesAvailable,
+    isSubtitlesAvailable,
 
     areSubtitlesCustomisable: () => {
       return !(window.bigscreenPlayer && window.bigscreenPlayer.overrides && window.bigscreenPlayer.overrides.legacySubtitles)
@@ -584,22 +584,20 @@ function BigscreenPlayer () {
      * @function
      * @return The runtime version of the library.
      */
-    getFrameworkVersion: () => {
-      return Version
-    },
+    getFrameworkVersion: () => Version,
 
     /**
      * @function
      * @param {Number} time - Seconds
      * @return the time in milliseconds within the current sliding window.
      */
-    convertVideoTimeSecondsToEpochMs: convertVideoTimeSecondsToEpochMs,
+    convertVideoTimeSecondsToEpochMs,
 
     /**
      * Toggle the visibility of the debug tool overlay.
      * @function
      */
-    toggleDebug: toggleDebug,
+    toggleDebug,
 
     /**
      * @function

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -611,7 +611,7 @@ function BigscreenPlayer () {
      * @function
      * @return {string} - currently set log level @see getLogLevels
      */
-    getLogLevel: () => DebugTool.getLogLevel,
+    getLogLevel: DebugTool.getLogLevel,
 
     /**
      * @function

--- a/src/debugger/debugtool.js
+++ b/src/debugger/debugtool.js
@@ -31,6 +31,10 @@ function DebugTool () {
     }
   }
 
+  function getLogLevel () {
+    return logLevel
+  }
+
   function show () {
     view = DebugView
     view.setRootElement(rootElement)
@@ -107,6 +111,7 @@ function DebugTool () {
     toggleVisibility: toggleVisibility,
     setRootElement: setRootElement,
     setLogLevel: setLogLevel,
+    getLogLevel: getLogLevel,
     logLevels: LOG_LEVELS,
     verbose: verbose,
     info: info,

--- a/src/debugger/debugtool.js
+++ b/src/debugger/debugtool.js
@@ -13,7 +13,7 @@ function DebugTool () {
 
   let visible = false
   let logLevel = LOG_LEVELS.INFO
-  let staticFieldValues = { }
+  let staticFieldValues = {}
 
   let rootElement, view
 
@@ -108,19 +108,19 @@ function DebugTool () {
   }
 
   return {
-    toggleVisibility: toggleVisibility,
-    setRootElement: setRootElement,
-    setLogLevel: setLogLevel,
-    getLogLevel: getLogLevel,
+    toggleVisibility,
+    setRootElement,
+    setLogLevel,
+    getLogLevel,
     logLevels: LOG_LEVELS,
-    verbose: verbose,
-    info: info,
-    error: error,
-    event: event,
-    time: time,
+    verbose,
+    info,
+    error,
+    event,
+    time,
     apicall: Chronicle.apicall,
     keyValue: updateKeyValue,
-    tearDown: tearDown
+    tearDown
   }
 }
 

--- a/src/debugger/debugtool.test.js
+++ b/src/debugger/debugtool.test.js
@@ -1,6 +1,26 @@
 import Chronicle from './chronicle'
 import DebugTool from './debugtool'
 
+describe('Debug Tool, when configuring log levels,', () => {
+  it('should return an object of log levels', () => {
+    expect(DebugTool.logLevels && typeof DebugTool.logLevels === 'object').toBe(true)
+  })
+
+  it('should default to LOG_LEVELS.INFO', () => {
+    expect(DebugTool.getLogLevel()).toEqual(DebugTool.logLevels.INFO)
+  })
+
+  it('does not override log level when setLogLevel argument is undefined', () => {
+    DebugTool.setLogLevel()
+    expect(DebugTool.getLogLevel()).toEqual(DebugTool.logLevels.INFO)
+  })
+
+  it('can set a new log level', () => {
+    DebugTool.setLogLevel(DebugTool.logLevels.ERROR)
+    expect(DebugTool.getLogLevel()).toEqual(DebugTool.logLevels.ERROR)
+  })
+})
+
 describe('Debug Tool, when intercepting keyValue calls,', () => {
   beforeEach(() => {
     jest.spyOn(global, 'Date').mockImplementation(() => {

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -132,7 +132,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
     }
 
     if (event.error && event.error.message) {
-      DebugTool.info('MSE Error: ' + event.error.message + ' Code: ' + event.error.code)
+      DebugTool.info(`MSE Error: ${  event.error.message  } Code: ${  event.error.code}`)
       lastError = event.error
 
       // Don't raise an error on fragment download error
@@ -169,7 +169,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
   }
 
   function onManifestLoaded (event) {
-    DebugTool.info('Manifest loaded. Duration is: ' + event.data.mediaPresentationDuration)
+    DebugTool.info(`Manifest loaded. Duration is: ${  event.data.mediaPresentationDuration}`)
 
     if (event.data) {
       const manifest = event.data
@@ -187,7 +187,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
   }
 
   function onManifestValidityChange (event) {
-    DebugTool.info('Manifest validity changed. Duration is: ' + event.newDuration)
+    DebugTool.info(`Manifest validity changed. Duration is: ${  event.newDuration}`)
   }
 
   function onStreamInitialised () {
@@ -202,13 +202,9 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
   }
 
   function emitPlayerInfo () {
-    if (mediaKind === MediaKinds.VIDEO) {
-      playerMetadata.playbackBitrate = currentPlaybackBitrate(MediaKinds.VIDEO) + currentPlaybackBitrate(MediaKinds.AUDIO)
-    } else {
-      playerMetadata.playbackBitrate = currentPlaybackBitrate(MediaKinds.AUDIO)
-    }
+    playerMetadata.playbackBitrate = mediaKind === MediaKinds.VIDEO ? currentPlaybackBitrate(MediaKinds.VIDEO) + currentPlaybackBitrate(MediaKinds.AUDIO) : currentPlaybackBitrate(MediaKinds.AUDIO);
 
-    DebugTool.keyValue({ key: 'playback bitrate', value: playerMetadata.playbackBitrate + ' kbps' })
+    DebugTool.keyValue({ key: 'playback bitrate', value: `${playerMetadata.playbackBitrate  } kbps` })
 
     Plugins.interface.onPlayerInfoUpdated({
       bufferLength: playerMetadata.bufferLength,
@@ -237,11 +233,11 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
   function onQualityChangeRendered (event) {
     function logBitrate (mediaKind, event) {
       const oldBitrate = isNaN(event.oldQuality) ? '--' : playbackBitrateForRepresentationIndex(event.oldQuality, mediaKind)
-      const oldRepresentation = isNaN(event.oldQuality) ? 'Start' : event.oldQuality + ' (' + oldBitrate + ' kbps)'
-      const newRepresentation = event.newQuality + ' (' + playbackBitrateForRepresentationIndex(event.newQuality, mediaKind) + ' kbps)'
+      const oldRepresentation = isNaN(event.oldQuality) ? 'Start' : `${event.oldQuality  } (${  oldBitrate  } kbps)`
+      const newRepresentation = `${event.newQuality  } (${  playbackBitrateForRepresentationIndex(event.newQuality, mediaKind)  } kbps)`
 
-      DebugTool.keyValue({ key: event.mediaType + ' Representation', value: newRepresentation })
-      DebugTool.info(mediaKind + ' ABR Change Rendered From Representation ' + oldRepresentation + ' To ' + newRepresentation)
+      DebugTool.keyValue({ key: `${event.mediaType  } Representation`, value: newRepresentation })
+      DebugTool.info(`${mediaKind  } ABR Change Rendered From Representation ${  oldRepresentation  } To ${  newRepresentation}`)
     }
 
     if (event.newQuality !== undefined) {
@@ -265,7 +261,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
     }
 
     function log () {
-      DebugTool.info('BaseUrl selected: ' + event.baseUrl.url)
+      DebugTool.info(`BaseUrl selected: ${  event.baseUrl.url}`)
       lastError = undefined
     }
 
@@ -274,7 +270,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
   }
 
   function onServiceLocationAvailable (event) {
-    DebugTool.info('Service Location available: ' + event.entry)
+    DebugTool.info(`Service Location available: ${  event.entry}`)
   }
 
   function onURLResolutionFailed () {
@@ -282,11 +278,9 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
   }
 
   function onMetricAdded (event) {
-    if (event.mediaType === 'video') {
-      if (event.metric === 'DroppedFrames') {
+    if (event.mediaType === 'video' && event.metric === 'DroppedFrames') {
         DebugTool.keyValue({ key: 'Dropped Frames', value: event.value.droppedFrames })
       }
-    }
     if (event.mediaType === mediaKind && event.metric === 'BufferLevel') {
       dashMetrics = mediaPlayer.getDashMetrics()
 
@@ -350,11 +344,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
   }
 
   function setUpMediaElement (playbackElement) {
-    if (mediaKind === MediaKinds.AUDIO) {
-      mediaElement = document.createElement('audio')
-    } else {
-      mediaElement = document.createElement('video')
-    }
+    mediaElement = mediaKind === MediaKinds.AUDIO ? document.createElement('audio') : document.createElement('video');
 
     mediaElement.style.position = 'absolute'
     mediaElement.style.width = '100%'
@@ -411,13 +401,13 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
     startTime = parseInt(startTime)
 
     if (windowType === WindowTypes.STATIC) {
-      return startTime === 0 ? source : source + '#t=' + startTime
-    } else {
+      return startTime === 0 ? source : `${source  }#t=${  startTime}`
+    } 
       const windowStartTimeSeconds = (mediaSources.time().windowStartTime / 1000)
-      const srcWithTimeAnchor = source + '#t=posix:'
+      const srcWithTimeAnchor = `${source  }#t=posix:`
 
       return startTime === 0 ? srcWithTimeAnchor + (windowStartTimeSeconds + 1) : srcWithTimeAnchor + (windowStartTimeSeconds + startTime)
-    }
+    
   }
 
   function getSeekableRange () {
@@ -501,21 +491,19 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
       canBePaused: () => true,
       canBeginSeek: () => true
     },
-    addEventCallback: addEventCallback,
-    removeEventCallback: removeEventCallback,
+    addEventCallback,
+    removeEventCallback,
     addErrorCallback: (thisArg, newErrorCallback) => {
       errorCallback = (event) => newErrorCallback.call(thisArg, event)
     },
     addTimeUpdateCallback: (thisArg, newTimeUpdateCallback) => {
       timeUpdateCallback = () => newTimeUpdateCallback.call(thisArg)
     },
-    load: load,
-    getSeekableRange: getSeekableRange,
-    getCurrentTime: getCurrentTime,
-    getDuration: getDuration,
-    getPlayerElement: () => {
-      return mediaElement
-    },
+    load,
+    getSeekableRange,
+    getCurrentTime,
+    getDuration,
+    getPlayerElement: () => mediaElement,
     tearDown: () => {
       mediaPlayer.reset()
 
@@ -560,7 +548,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
     },
     reset: () => {},
     isEnded: () => isEnded,
-    isPaused: isPaused,
+    isPaused,
     pause: (opts) => {
       if (windowType === WindowTypes.SLIDING) {
         slidingWindowPausedTime = Date.now()
@@ -587,9 +575,7 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
     setPlaybackRate: (rate) => {
       mediaPlayer.setPlaybackRate(rate)
     },
-    getPlaybackRate: () => {
-      return mediaPlayer.getPlaybackRate()
-    }
+    getPlaybackRate: () => mediaPlayer.getPlaybackRate()
   }
 }
 

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -40,10 +40,10 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
     }
   }
 
-  let playerSettings = Utils.merge({
-    debug: {
-      logLevel: 2
-    },
+  const debugSettings = DebugTool.getLogLevel() === DebugTool.logLevels.VERBOSE ? { logLevel: 5, dispatchEvent: true } : { logLevel: 2 }
+
+  const playerSettings = Utils.merge({
+    debug: debugSettings,
     streaming: {
       liveDelay: 1.1,
       bufferToKeep: 4,

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -302,8 +302,8 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
     }
   }
 
-  function onDebugLog (e) {
-    DebugTool.verbose(e.message)
+  function onDebugLog (error) {
+    DebugTool.verbose(error.message)
   }
 
   function publishMediaState (mediaState) {

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -549,13 +549,12 @@ function MSEStrategy (mediaSources, windowType, mediaKind, playbackElement, isUH
     reset: () => {},
     isEnded: () => isEnded,
     isPaused,
-    pause: (opts) => {
+    pause: (opts = {}) => {
       if (windowType === WindowTypes.SLIDING) {
         slidingWindowPausedTime = Date.now()
       }
 
       mediaPlayer.pause()
-      opts = opts || {}
       if (opts.disableAutoResume !== true && windowType === WindowTypes.SLIDING) {
         startAutoResumeTimeout()
       }


### PR DESCRIPTION
📺 What

Set the Dash.js [debug player settings](http://cdn.dashjs.org/latest/jsdoc/module-Settings.html#~DebugSettings__anchor) depending on the overall library log level. 

🛠 How

- Adds new `getLogLevel()` function to DebugTool and player API
- Sets Dash.js player settings for debug based on the LOG_LEVEL set

INFO = `{ logLevel: 2}` dashjs.Debug.LOG_LEVEL_ERROR - Log error messages.
VERBOSE = `{ logLevel: 5, dispatchEvent: true}` // dashjs.Debug.LOG_LEVEL_DEBUG - Log debug messages.
