### PR TITLE
Fix subtitles not cleaned up when seeking back

### DIFF
--- a/src/subtitles/imscsubtitles.js
+++ b/src/subtitles/imscsubtitles.js
@@ -158,6 +158,10 @@ function IMSCSubtitles(mediaPlayer, autoStart, parentElement, mediaSources, defa
     return customStyles
   }
 
+  function isCurrentTimeBehindCurrentSubtitles(currentTime, segments, segmentIndex) {
+    return currentTime < segments[segmentIndex].times[currentSegmentRendered.previousSubtitleIndex]
+  }
+
   function removeCurrentSubtitlesElement() {
     if (currentSubtitlesElement) {
       DOMHelpers.safeRemoveElement(currentSubtitlesElement)
@@ -184,7 +188,7 @@ function IMSCSubtitles(mediaPlayer, autoStart, parentElement, mediaSources, defa
     let segment
 
     for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex++) {
-      if (currentTime < segments[segmentIndex].times[currentSegmentRendered.previousSubtitleIndex]) {
+      if (isCurrentTimeBehindCurrentSubtitles(currentTime, segments, segmentIndex)) {
         removeCurrentSubtitlesElement()
       }
 


### PR DESCRIPTION
📺 What

Currently seeking back in time during playback does not clean up subtitles, so the subtitles displayed before seeking are still visible. This ticket fixes this bug.

> Tickets: IPLAYERTVV1-12266

🛠 How

Cleans up current subtitles element if current time is behind the display time of the subtitle currently on sceen.