### PR TITLE
Segmented subs should only be available for seekable devices

### DIFF
--- a/src/subtitles/subtitles.js
+++ b/src/subtitles/subtitles.js
@@ -3,6 +3,9 @@ import findSegmentTemplate from "../utils/findtemplate"
 
 function Subtitles(mediaPlayer, autoStart, playbackElement, defaultStyleOpts, mediaSources, callback) {
   const useLegacySubs = window.bigscreenPlayer?.overrides?.legacySubtitles ?? false
+  const isSeekableLiveSupport = window.bigscreenPlayer.liveSupport
+    ? window.bigscreenPlayer.liveSupport === "seekable"
+    : true
 
   let subtitlesEnabled = autoStart
   let subtitlesContainer
@@ -69,7 +72,7 @@ function Subtitles(mediaPlayer, autoStart, playbackElement, defaultStyleOpts, me
 
     const isWhole = findSegmentTemplate(url) == null
 
-    return isWhole || !useLegacySubs
+    return isWhole || (!useLegacySubs && isSeekableLiveSupport)
   }
 
   function setPosition(position) {

--- a/src/subtitles/subtitles.test.js
+++ b/src/subtitles/subtitles.test.js
@@ -394,11 +394,71 @@ describe("Subtitles", () => {
         )
       })
 
-      it("returns false for segmented subtitles when the legacy strategy is forced", (done) => {
+      it("returns true for segmented subtitles when no live support is defined in config", (done) => {
+        isAvailable = true
+        isSegmented = true
+
+        const subtitles = Subtitles(
+          mockMediaPlayer,
+          true,
+          playbackElement,
+          customDefaultStyle,
+          mockMediaSources,
+          () => {
+            expect(subtitles.available()).toBe(true)
+            done()
+          }
+        )
+      })
+
+      it("returns false for segmented subtitles when the device is seekable but also legacy subs", (done) => {
         window.bigscreenPlayer = {
+          liveSupport: "seekable",
           overrides: {
             legacySubtitles: true,
           },
+        }
+
+        isAvailable = true
+        isSegmented = true
+
+        const subtitles = Subtitles(
+          mockMediaPlayer,
+          true,
+          playbackElement,
+          customDefaultStyle,
+          mockMediaSources,
+          () => {
+            expect(subtitles.available()).toBe(false)
+            done()
+          }
+        )
+      })
+
+      it("returns false for segmented subtitles when the device is playable", (done) => {
+        window.bigscreenPlayer = {
+          liveSupport: "playable",
+        }
+
+        isAvailable = true
+        isSegmented = true
+
+        const subtitles = Subtitles(
+          mockMediaPlayer,
+          true,
+          playbackElement,
+          customDefaultStyle,
+          mockMediaSources,
+          () => {
+            expect(subtitles.available()).toBe(false)
+            done()
+          }
+        )
+      })
+
+      it("returns false for segmented subtitles when the device is restartable", (done) => {
+        window.bigscreenPlayer = {
+          liveSupport: "restartable",
         }
 
         isAvailable = true


### PR DESCRIPTION
📺 What

Only report segmented subtitles as available when the bigscreen-player is configured with a `seekable` `liveSupport`. I.e. segmented subtitles are not available for `playable`, `restartable` or `none`.

🛠 How

Check for the `liveSupport` property on the `window.bigscreenPlayer` config object.