### PR TITLE
Fix installation issues caused by Husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "CONTRIBUTING.md"
   ],
   "scripts": {
-    "prepare": "husky install",
-    "postinstall": "npm run build",
+    "prepare": "[ ! -d dist/ ] && npm run build || exit 0",
+    "postinstall": "[ ! -d .git/ ] && husky install || exit 0",
     "docs": "jsdoc -c jsdoc.conf.json",
     "build": "npm run build:clean && npm run build:bundle",
     "build:clean": "rm -rf dist",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "CONTRIBUTING.md"
   ],
   "scripts": {
-    "prepare": "[ ! -d dist/ ] && npm run build || exit 0",
-    "postinstall": "husky install",
+    "prepare": "[ ! -d dist/ ] && husky install && npm run build || exit 0",
     "docs": "jsdoc -c jsdoc.conf.json",
     "build": "npm run build:clean && npm run build:bundle",
     "build:clean": "rm -rf dist",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "CONTRIBUTING.md"
   ],
   "scripts": {
-    "prepare": "[ ! -d dist/ ] && npm run build || exit 0",
+    "prepare": "[ -d dist/ ] && npm run build || exit 0",
     "postinstall": "[ ! -d .git/ ] && husky install || exit 0",
     "docs": "jsdoc -c jsdoc.conf.json",
     "build": "npm run build:clean && npm run build:bundle",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,11 @@
   "type": "module",
   "files": [
     "dist",
-    "package.json",
-    "README.md",
-    "LICENSE",
     "CONTRIBUTING.md"
   ],
   "scripts": {
-    "prepare": "[ ! -d dist/ ] && husky install && npm run build || exit 0",
+    "prepare": "husky install",
+    "postinstall": "npm run build",
     "docs": "jsdoc -c jsdoc.conf.json",
     "build": "npm run build:clean && npm run build:bundle",
     "build:clean": "rm -rf dist",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "CONTRIBUTING.md"
   ],
   "scripts": {
-    "prepare": "[ -d dist/ ] && npm run build || exit 0",
-    "postinstall": "[ ! -d .git/ ] && husky install || exit 0",
+    "prepare": "[ ! -d dist/ ] && npm run build || exit 0",
+    "postinstall": "[ -d .git/ ] && husky install || exit 0",
     "docs": "jsdoc -c jsdoc.conf.json",
     "build": "npm run build:clean && npm run build:bundle",
     "build:clean": "rm -rf dist",


### PR DESCRIPTION
📺 What

Fix issue where installing this package as a dependency in a project causes errors due to husky install step recently introduced. 

🛠 How

Add check to only install husky if `.git` directory is there. When installed as a dependency, this won't be there. 

Also removed some files from the `files` array in the `package.json` as they are included by default. 