### PR TITLE
Fix live delay clamping for OD content

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -338,7 +338,7 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
   }
 
   function getClampedTime(time, range) {
-    return Math.min(Math.max(time, range.start), range.end - playerSettings.streaming.liveDelay)
+    return Math.min(Math.max(time, range.start), range.end)
   }
 
   function load(mimeType, playbackTime) {

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -731,13 +731,13 @@ describe("Media Source Extensions Playback Strategy", () => {
       expect(mockDashInstance.seek).toHaveBeenCalledWith(0)
     })
 
-    it("should clamp the seek to 1.1s before the end of the seekable range", () => {
+    it("should clamp the seek to the end of the seekable range", () => {
       setUpMSE()
       mseStrategy.load(null, 0)
 
-      mseStrategy.setCurrentTime(101)
+      mseStrategy.setCurrentTime(1000)
 
-      expect(mockDashInstance.seek).toHaveBeenCalledWith(99.9)
+      expect(mockDashInstance.seek).toHaveBeenCalledWith(101)
     })
 
     describe("sliding window", () => {
@@ -759,7 +759,7 @@ describe("Media Source Extensions Playback Strategy", () => {
         expect(mockVideoElement.currentTime).toBe(0)
       })
 
-      it("should always clamp the seek to 1.1s before the end of the seekable range", () => {
+      it("should always clamp the seek to value of live delay before the end of the seekable range", () => {
         mseStrategy.setCurrentTime(101)
 
         expect(mockDashInstance.seek).toHaveBeenCalledWith(99.9)
@@ -839,7 +839,7 @@ describe("Media Source Extensions Playback Strategy", () => {
 
         mseStrategy.setCurrentTime(90)
 
-        expect(mockDashInstance.seek).toHaveBeenCalledWith(78.9)
+        expect(mockDashInstance.seek).toHaveBeenCalledWith(80)
       })
     })
   })


### PR DESCRIPTION
📺 What

Fixes issue where the `liveDelay` is subtracted from the end even for On Demand content.

🛠 How

No longer subtract this value unless using the `getClampedTimeForLive` function. 