### PR TITLE
BADGERS-177 Failover with MPD times in MSE strategy

### DIFF
--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -102,14 +102,13 @@ function BigscreenPlayer() {
 
   function bigscreenPlayerDataLoaded(bigscreenPlayerData, enableSubtitles) {
     if (windowType !== WindowTypes.STATIC) {
-      bigscreenPlayerData.time = mediaSources.time()
       serverDate = bigscreenPlayerData.serverDate
 
       initialPlaybackTimeEpoch = bigscreenPlayerData.initialPlaybackTime
       // overwrite initialPlaybackTime with video time (it comes in as epoch time for a sliding/growing window)
       bigscreenPlayerData.initialPlaybackTime = SlidingWindowUtils.convertToSeekableVideoTime(
         bigscreenPlayerData.initialPlaybackTime,
-        bigscreenPlayerData.time.windowStartTime
+        mediaSources.time().windowStartTime
       )
     }
 

--- a/src/bigscreenplayer.test.js
+++ b/src/bigscreenplayer.test.js
@@ -117,7 +117,7 @@ function initialiseBigscreenPlayer(options = {}) {
     callbacks = { onSuccess: successCallback, onError: errorCallback }
   }
 
-  bigscreenPlayer.init(playbackElement, bigscreenPlayerData, windowType, subtitlesEnabled, callbacks)
+  bigscreenPlayer.init(playbackElement, { ...bigscreenPlayerData }, windowType, subtitlesEnabled, callbacks)
 }
 
 describe("Bigscreen Player", () => {
@@ -786,14 +786,12 @@ describe("Bigscreen Player", () => {
       initialiseBigscreenPlayer({ windowType: WindowTypes.SLIDING })
 
       const callback = jest.fn()
-      const endOfStreamWindow = bigscreenPlayerData.time.windowEndTime - 2
+      const endOfStreamWindow = 100 - 2
 
       bigscreenPlayer.registerForTimeUpdates(callback)
 
-      mockPlayerComponentInstance.getSeekableRange.mockReturnValue({
-        start: bigscreenPlayerData.time.windowStartTime,
-        end: bigscreenPlayerData.time.windowEndTime,
-      })
+      mockPlayerComponentInstance.getSeekableRange.mockReturnValue({ start: 10, end: 100 })
+
       mockPlayerComponentInstance.getCurrentTime.mockReturnValue(endOfStreamWindow)
 
       bigscreenPlayer.setCurrentTime(endOfStreamWindow)
@@ -817,12 +815,10 @@ describe("Bigscreen Player", () => {
       const callback = jest.fn()
       bigscreenPlayer.registerForTimeUpdates(callback)
 
-      const middleOfStreamWindow = bigscreenPlayerData.time.windowEndTime / 2
+      const middleOfStreamWindow = 100 / 2
 
-      mockPlayerComponentInstance.getSeekableRange.mockReturnValue({
-        start: bigscreenPlayerData.time.windowStartTime,
-        end: bigscreenPlayerData.time.windowEndTime,
-      })
+      mockPlayerComponentInstance.getSeekableRange.mockReturnValue({ start: 10, end: 100 })
+
       mockPlayerComponentInstance.getCurrentTime.mockReturnValue(middleOfStreamWindow)
 
       bigscreenPlayer.setCurrentTime(middleOfStreamWindow)

--- a/src/manifest/stubData/dashmanifests.js
+++ b/src/manifest/stubData/dashmanifests.js
@@ -111,7 +111,7 @@ const DashManifests = Object.fromEntries(
 function appendTimingResource(manifestEl, timingResource) {
   const timingEl = manifestEl.createElement("UTCTiming")
   timingEl.setAttribute("schemeIdUri", "urn:mpeg:dash:utc:http-xsdate:2014")
-  timingEl.setAttribute("value", timingResource ?? "https://time.akamai.com/?iso")
+  timingEl.setAttribute("value", timingResource ?? "https://time.some-cdn.com/?iso")
 
   manifestEl.querySelector("MPD").append(timingEl)
 }

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -61,12 +61,33 @@ describe("Media Source Extensions Playback Strategy", () => {
   let playbackElement
   let cdnArray = []
   let mediaSources
-  let mockAudioElement
-  let mockVideoElement
+  let mediaElement
   let testManifestObject
   let mockTimeModel
 
+  const mockMediaElement = (mediaKind) => {
+    const mediaEl = document.createElement(mediaKind)
+
+    mediaEl.__mocked__ = true
+
+    jest.spyOn(mediaEl, "addEventListener").mockImplementation((eventType, handler) => {
+      eventHandlers[eventType] = handler
+      eventCallbacks = (eventType, event) => eventHandlers[eventType].call(this, event)
+    })
+
+    jest.spyOn(mediaEl, "removeEventListener")
+
+    return mediaEl
+  }
+
+  const isMockedElement = (el) => el instanceof HTMLElement && el.__mocked__
+
   beforeEach(() => {
+    jest.clearAllMocks()
+    delete window.bigscreenPlayer
+
+    mediaElement = undefined
+
     window.bigscreenPlayer = {}
 
     // For DVRInfo Based Seekable Range
@@ -90,24 +111,16 @@ describe("Media Source Extensions Playback Strategy", () => {
       getIndexForRepresentation: () => 0,
     })
 
-    mockAudioElement = document.createElement("audio")
-    mockVideoElement = document.createElement("video")
     playbackElement = document.createElement("div")
 
     jest.spyOn(document, "createElement").mockImplementationOnce((elementType) => {
-      if (elementType === "audio") {
-        return mockAudioElement
-      } else if (elementType === "video") {
-        return mockVideoElement
+      if (["audio", "video"].includes(elementType)) {
+        mediaElement = mockMediaElement(elementType)
+        return mediaElement
       }
-    })
 
-    jest.spyOn(mockVideoElement, "addEventListener").mockImplementation((eventType, handler) => {
-      eventHandlers[eventType] = handler
-      eventCallbacks = (eventType, event) => eventHandlers[eventType].call(this, event)
+      return document.createElement(elementType)
     })
-
-    jest.spyOn(mockVideoElement, "removeEventListener")
 
     cdnArray = [
       { url: "http://testcdn1/test/", cdn: "http://testcdn1/test/" },
@@ -141,27 +154,17 @@ describe("Media Source Extensions Playback Strategy", () => {
     }
   })
 
-  afterEach(() => {
-    jest.clearAllMocks()
-    delete window.bigscreenPlayer
-    mockVideoElement = undefined
-    mockAudioElement = undefined
-  })
-
   function setUpMSE(timeCorrection, windowType, mediaKind, windowStartTimeMS, windowEndTimeMS, customPlayerSettings) {
-    const defaultWindowType = windowType || WindowTypes.STATIC
-    const defaultMediaKind = mediaKind || MediaKinds.VIDEO
-
     mockTimeModel = {
-      correction: timeCorrection || 0,
-      windowStartTime: windowStartTimeMS || 0,
-      windowEndTime: windowEndTimeMS || 0,
+      correction: timeCorrection ?? 0,
+      windowStartTime: windowStartTimeMS ?? 0,
+      windowEndTime: windowEndTimeMS ?? 0,
     }
 
     mseStrategy = MSEStrategy(
       mediaSources,
-      defaultWindowType,
-      defaultMediaKind,
+      windowType ?? WindowTypes.STATIC,
+      mediaKind ?? MediaKinds.VIDEO,
       playbackElement,
       false,
       customPlayerSettings || {}
@@ -190,8 +193,10 @@ describe("Media Source Extensions Playback Strategy", () => {
 
       mseStrategy.load(null, 0)
 
-      expect(playbackElement.firstChild).toBe(mockVideoElement)
       expect(playbackElement.childElementCount).toBe(1)
+      expect(playbackElement.firstChild).toBeInstanceOf(HTMLVideoElement)
+      expect(playbackElement.firstChild).toBe(mediaElement)
+      expect(isMockedElement(playbackElement.firstChild)).toBe(true)
     })
 
     it("should create an audio element and add it to the media element", () => {
@@ -201,15 +206,18 @@ describe("Media Source Extensions Playback Strategy", () => {
 
       mseStrategy.load(null, 0)
 
-      expect(playbackElement.firstChild).toBe(mockAudioElement)
       expect(playbackElement.childElementCount).toBe(1)
+
+      expect(playbackElement.firstChild).toBeInstanceOf(HTMLAudioElement)
+      expect(playbackElement.firstChild).toBe(mediaElement)
+      expect(isMockedElement(playbackElement.firstChild)).toBe(true)
     })
 
     it("should initialise MediaPlayer with the expected parameters when no start time is present", () => {
       setUpMSE()
       mseStrategy.load(null)
 
-      expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true)
+      expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
       expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url)
     })
 
@@ -248,7 +256,7 @@ describe("Media Source Extensions Playback Strategy", () => {
         setUpMSE()
         mseStrategy.load(null, 0)
 
-        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true)
+        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
         expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url)
       })
 
@@ -256,7 +264,7 @@ describe("Media Source Extensions Playback Strategy", () => {
         setUpMSE()
         mseStrategy.load(null, 15)
 
-        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true)
+        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
         expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=15`)
       })
     })
@@ -271,22 +279,22 @@ describe("Media Source Extensions Playback Strategy", () => {
       it("should initialise MediaPlayer with the expected parameters when startTime is zero", () => {
         mseStrategy.load(null, 0)
 
-        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true)
-        expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=posix:101`)
+        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
+        expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=101`)
       })
 
       it("should initialise MediaPlayer with the expected parameters when startTime is set to 0.1", () => {
         mseStrategy.load(null, 0.1)
 
-        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true)
-        expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=posix:101`)
+        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
+        expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=101`)
       })
 
       it("should initialise MediaPlayer with the expected parameters when startTime is set", () => {
         mseStrategy.load(null, 60)
 
-        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true)
-        expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=posix:160`)
+        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
+        expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=160`)
       })
     })
 
@@ -300,21 +308,21 @@ describe("Media Source Extensions Playback Strategy", () => {
       it("should initialise MediaPlayer with the expected parameters when startTime is zero", () => {
         mseStrategy.load(null, 0)
 
-        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true)
+        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
         expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=posix:101`)
       })
 
       it("should initialise MediaPlayer with the expected parameters when startTime is set to 0.1", () => {
         mseStrategy.load(null, 0.1)
 
-        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true)
+        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
         expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=posix:101`)
       })
 
       it("should initialise MediaPlayer with the expected parameters when startTime is set", () => {
         mseStrategy.load(null, 60)
 
-        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true)
+        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
         expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=posix:160`)
       })
     })
@@ -323,13 +331,13 @@ describe("Media Source Extensions Playback Strategy", () => {
       setUpMSE()
       mseStrategy.load(null, 0)
 
-      expect(mockVideoElement.addEventListener).toHaveBeenCalledWith("timeupdate", expect.any(Function))
-      expect(mockVideoElement.addEventListener).toHaveBeenCalledWith("playing", expect.any(Function))
-      expect(mockVideoElement.addEventListener).toHaveBeenCalledWith("pause", expect.any(Function))
-      expect(mockVideoElement.addEventListener).toHaveBeenCalledWith("waiting", expect.any(Function))
-      expect(mockVideoElement.addEventListener).toHaveBeenCalledWith("seeking", expect.any(Function))
-      expect(mockVideoElement.addEventListener).toHaveBeenCalledWith("seeked", expect.any(Function))
-      expect(mockVideoElement.addEventListener).toHaveBeenCalledWith("ended", expect.any(Function))
+      expect(mediaElement.addEventListener).toHaveBeenCalledWith("timeupdate", expect.any(Function))
+      expect(mediaElement.addEventListener).toHaveBeenCalledWith("playing", expect.any(Function))
+      expect(mediaElement.addEventListener).toHaveBeenCalledWith("pause", expect.any(Function))
+      expect(mediaElement.addEventListener).toHaveBeenCalledWith("waiting", expect.any(Function))
+      expect(mediaElement.addEventListener).toHaveBeenCalledWith("seeking", expect.any(Function))
+      expect(mediaElement.addEventListener).toHaveBeenCalledWith("seeked", expect.any(Function))
+      expect(mediaElement.addEventListener).toHaveBeenCalledWith("ended", expect.any(Function))
       expect(mockDashInstance.on).toHaveBeenCalledWith(dashjsMediaPlayerEvents.ERROR, expect.any(Function))
       expect(mockDashInstance.on).toHaveBeenCalledWith(dashjsMediaPlayerEvents.MANIFEST_LOADED, expect.any(Function))
       expect(mockDashInstance.on).toHaveBeenCalledWith(
@@ -359,7 +367,7 @@ describe("Media Source Extensions Playback Strategy", () => {
 
       mseStrategy.load(null, 0)
 
-      expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true)
+      expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
       expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url)
 
       // Player component would do this with its buffering timeout logic
@@ -377,7 +385,7 @@ describe("Media Source Extensions Playback Strategy", () => {
 
       mseStrategy.load(null, 45)
 
-      expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true)
+      expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
       expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=45`)
 
       mediaSources.failover(noop, noop, failoverInfo)
@@ -398,38 +406,41 @@ describe("Media Source Extensions Playback Strategy", () => {
 
       mseStrategy.load(null, 45)
 
-      expect(mockDashInstance.initialize).toHaveBeenCalledWith(mockVideoElement, null, true)
+      expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
       expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=45`)
 
       mediaSources.failover(noop, noop, failoverInfo)
 
-      mockVideoElement.currentTime = 86
+      mediaElement.currentTime = 86
       eventHandlers.timeupdate()
       mseStrategy.load(null, 0)
 
       expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[1].url}#t=86`)
     })
 
-    it("should attach a new source with current DVR window time for SLIDING window", () => {
-      setUpMSE(51, WindowTypes.SLIDING, MediaKinds.VIDEO, 51000, 251000)
-      mediaSources.time.mockReturnValue(mockTimeModel)
-      mockDashInstance.getSource.mockReturnValue("src")
+    it.each(Object.entries(MediaKinds))(
+      "attaches a new '%s' source to play back at current MPD time for SLIDING window",
+      (_, mediaKind) => {
+        setUpMSE(51, WindowTypes.SLIDING, mediaKind, 51000, 251000)
+        mediaSources.time.mockReturnValue(mockTimeModel)
+        mockDashInstance.getSource.mockReturnValue("src")
 
-      mseStrategy.load(null, 0)
+        mseStrategy.load(null, 0)
 
-      expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=posix:52`)
+        expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=52`)
 
-      mediaSources.failover(jest.fn(), jest.fn(), failoverInfo)
+        mediaSources.failover(jest.fn(), jest.fn(), failoverInfo)
 
-      mockDashInstance.getDashMetrics.mockReturnValueOnce({
-        getCurrentDVRInfo: () => ({ time: 124, range: { start: 124, end: 324 } }),
-      })
+        mockDashInstance.getDashMetrics.mockReturnValueOnce({
+          getCurrentDVRInfo: (kind) => (kind === mediaKind ? { time: 124, range: { start: 124, end: 324 } } : null),
+        })
 
-      eventHandlers.timeupdate()
-      mseStrategy.load(null, 0)
+        eventHandlers.timeupdate()
+        mseStrategy.load(null, 0)
 
-      expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[1].url}#t=posix:124`)
-    })
+        expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[1].url}#t=124`)
+      }
+    )
 
     it("should fire download error event when in growing window", () => {
       jest.spyOn(Plugins.interface, "onErrorHandled")
@@ -534,9 +545,12 @@ describe("Media Source Extensions Playback Strategy", () => {
   describe("getCurrentTime()", () => {
     it("returns the correct time from the DASH Mediaplayer", () => {
       setUpMSE()
-      mockVideoElement.currentTime = 10
 
       mseStrategy.load(null, 0)
+
+      expect(mseStrategy.getCurrentTime()).toBe(0)
+
+      mediaElement.currentTime = 10
 
       expect(mseStrategy.getCurrentTime()).toBe(10)
     })
@@ -570,7 +584,8 @@ describe("Media Source Extensions Playback Strategy", () => {
 
       mseStrategy.load(null, 0)
 
-      expect(mseStrategy.getPlayerElement()).toBe(mockVideoElement)
+      expect(mseStrategy.getPlayerElement()).toBeInstanceOf(HTMLVideoElement)
+      expect(mseStrategy.getPlayerElement()).toBe(mediaElement)
     })
 
     it("returns the media player audio element", () => {
@@ -578,7 +593,8 @@ describe("Media Source Extensions Playback Strategy", () => {
 
       mseStrategy.load(null, 0)
 
-      expect(mseStrategy.getPlayerElement()).toBe(mockAudioElement)
+      expect(mseStrategy.getPlayerElement()).toBeInstanceOf(HTMLAudioElement)
+      expect(mseStrategy.getPlayerElement()).toBe(mediaElement)
     })
   })
 
@@ -598,13 +614,13 @@ describe("Media Source Extensions Playback Strategy", () => {
 
       mseStrategy.tearDown()
 
-      expect(mockVideoElement.removeEventListener).toHaveBeenCalledWith("timeupdate", expect.any(Function))
-      expect(mockVideoElement.removeEventListener).toHaveBeenCalledWith("playing", expect.any(Function))
-      expect(mockVideoElement.removeEventListener).toHaveBeenCalledWith("pause", expect.any(Function))
-      expect(mockVideoElement.removeEventListener).toHaveBeenCalledWith("waiting", expect.any(Function))
-      expect(mockVideoElement.removeEventListener).toHaveBeenCalledWith("seeking", expect.any(Function))
-      expect(mockVideoElement.removeEventListener).toHaveBeenCalledWith("seeked", expect.any(Function))
-      expect(mockVideoElement.removeEventListener).toHaveBeenCalledWith("ended", expect.any(Function))
+      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("timeupdate", expect.any(Function))
+      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("playing", expect.any(Function))
+      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("pause", expect.any(Function))
+      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("waiting", expect.any(Function))
+      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("seeking", expect.any(Function))
+      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("seeked", expect.any(Function))
+      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("ended", expect.any(Function))
       expect(mockDashInstance.off).toHaveBeenCalledWith(dashjsMediaPlayerEvents.ERROR, expect.any(Function))
       expect(mockDashInstance.off).toHaveBeenCalledWith(
         dashjsMediaPlayerEvents.QUALITY_CHANGE_RENDERED,
@@ -777,7 +793,7 @@ describe("Media Source Extensions Playback Strategy", () => {
       it("should always clamp the seek to the start of the seekable range", () => {
         mseStrategy.setCurrentTime(-0.1)
 
-        expect(mockVideoElement.currentTime).toBe(0)
+        expect(mediaElement.currentTime).toBe(0)
       })
 
       it("should always clamp the seek to 1.1s before the end of the seekable range", () => {
@@ -835,7 +851,7 @@ describe("Media Source Extensions Playback Strategy", () => {
       beforeEach(() => {
         setUpMSE(0, WindowTypes.GROWING)
         mseStrategy.load(null, 0)
-        mockVideoElement.currentTime = 50
+        mediaElement.currentTime = 50
         mockDashInstance.refreshManifest.mockReset()
       })
 
@@ -1128,7 +1144,7 @@ describe("Media Source Extensions Playback Strategy", () => {
       setUpMSE()
 
       mseStrategy.load(null, 0)
-      mockVideoElement.currentTime = 10
+      mediaElement.currentTime = 10
 
       dashEventCallback(dashjsMediaPlayerEvents.ERROR, mockEvent)
 
@@ -1181,7 +1197,7 @@ describe("Media Source Extensions Playback Strategy", () => {
       mseStrategy.addErrorCallback(null, mockErrorCallback)
 
       mseStrategy.load(null, 0)
-      mockVideoElement.currentTime = 10
+      mediaElement.currentTime = 10
 
       dashEventCallback(dashjsMediaPlayerEvents.ERROR, mockEvent)
 
@@ -1202,7 +1218,7 @@ describe("Media Source Extensions Playback Strategy", () => {
       mseStrategy.addErrorCallback(null, mockErrorCallback)
 
       mseStrategy.load(null, 0)
-      mockVideoElement.currentTime = 10
+      mediaElement.currentTime = 10
 
       dashEventCallback(dashjsMediaPlayerEvents.ERROR, mockEvent)
 
@@ -1223,7 +1239,7 @@ describe("Media Source Extensions Playback Strategy", () => {
       mseStrategy.addErrorCallback(null, mockErrorCallback)
 
       mseStrategy.load(null, 0)
-      mockVideoElement.currentTime = 10
+      mediaElement.currentTime = 10
 
       dashEventCallback(dashjsMediaPlayerEvents.ERROR, mockEvent)
 
@@ -1242,7 +1258,7 @@ describe("Media Source Extensions Playback Strategy", () => {
       setUpMSE()
 
       mseStrategy.load(null, 0)
-      mockVideoElement.currentTime = 10
+      mediaElement.currentTime = 10
 
       dashEventCallback(dashjsMediaPlayerEvents.ERROR, mockErrorEvent)
       expect(mediaSources.failover).not.toHaveBeenCalled()

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -47,7 +47,9 @@ function PlayerComponent(
 
       bubbleErrorCleared()
 
-      initialMediaPlay(bigscreenPlayerData.media, bigscreenPlayerData.initialPlaybackTime)
+      mediaMetaData = bigscreenPlayerData.media
+
+      loadMedia(bigscreenPlayerData.media.type, bigscreenPlayerData.initialPlaybackTime)
     })
     .catch((error) => {
       errorCallback && errorCallback(error)
@@ -139,6 +141,7 @@ function PlayerComponent(
         seekToTime = undefined
         thenPause = false
       }
+
       loadMedia(mediaMetaData.type, seekToTime, thenPause)
     }
 
@@ -362,10 +365,6 @@ function PlayerComponent(
     }
 
     _stateUpdateCallback(stateUpdateData)
-  }
-  function initialMediaPlay(media, startTime) {
-    mediaMetaData = media
-    loadMedia(media.type, startTime)
   }
 
   function loadMedia(type, startTime, thenPause) {

--- a/src/utils/mse/build-source-anchor.js
+++ b/src/utils/mse/build-source-anchor.js
@@ -1,0 +1,55 @@
+import WindowTypes from "../../models/windowtypes"
+
+/** @enum */
+const TimelineZeroPoints = {
+  MPD: "mpdTime",
+  VIDEO: "videoTime",
+  WALLCLOCK: "wallclockTime",
+}
+
+/**
+ * Calculat time anchor tag for playback within dashjs
+ *
+ * Anchor tags applied to the MPD source for playback:
+ *
+ * #t=<time> - Seeks MPD timeline. By itself it means time since the beginning of the first period defined in the DASH manifest.
+ * #t=posix:<time> - Seeks availability timeline.
+ *
+ * @param {number} seconds
+ * @param {TimelineZeroPoints} [zeroPoint = TimelineZeroPoints.VIDEO]
+ * @returns {string}
+ */
+export default function buildSourceAnchor(
+  seconds,
+  zeroPoint,
+  { initialSeekableRangeStartSeconds = 0, windowType = WindowTypes.STATIC } = {}
+) {
+  if (typeof seconds !== "number" || !isFinite(seconds)) {
+    return ""
+  }
+
+  const wholeSeconds = parseInt(seconds)
+
+  if (zeroPoint === TimelineZeroPoints.MPD) {
+    return `#t=${wholeSeconds}`
+  }
+
+  if (zeroPoint === TimelineZeroPoints.WALLCLOCK) {
+    return `#t=posix:${wholeSeconds}`
+  }
+
+  // zeroPoint is video time
+  if (windowType === WindowTypes.SLIDING) {
+    return `#t=${initialSeekableRangeStartSeconds + (wholeSeconds === 0 ? 1 : wholeSeconds)}`
+  }
+
+  if (windowType === WindowTypes.GROWING) {
+    return `#t=posix:${initialSeekableRangeStartSeconds + (wholeSeconds === 0 ? 1 : wholeSeconds)}`
+  }
+
+  // window type is static
+
+  return wholeSeconds === 0 ? "" : `#t=${wholeSeconds}`
+}
+
+export { TimelineZeroPoints }

--- a/src/utils/mse/build-source-anchor.js
+++ b/src/utils/mse/build-source-anchor.js
@@ -16,7 +16,7 @@ const TimelineZeroPoints = {
  * #t=posix:<time> - Seeks availability timeline.
  *
  * @param {number} seconds
- * @param {TimelineZeroPoints} [zeroPoint = TimelineZeroPoints.VIDEO]
+ * @param {string} [zeroPoint = TimelineZeroPoints.VIDEO]
  * @returns {string}
  */
 export default function buildSourceAnchor(

--- a/src/utils/mse/build-source-anchor.test.js
+++ b/src/utils/mse/build-source-anchor.test.js
@@ -1,0 +1,83 @@
+import WindowTypes from "../../models/windowtypes"
+import TimeUtils from "../timeutils"
+import buildSourceAnchor from "./build-source-anchor"
+
+beforeEach(() => {
+  jest.useFakeTimers({ now: 1000 })
+})
+
+it.each([undefined, null, NaN, Infinity])("returns an empty string for '%s'", (value) => {
+  expect(buildSourceAnchor(value)).toBe("")
+})
+
+describe("when an MPD time is provided", () => {
+  it.each([0, 12, 420])("returns `#t=%d` for a STATIC window with zero point in MPD time", (time) => {
+    expect(buildSourceAnchor(time, "mpdTime", { windowType: WindowTypes.STATIC })).toBe(`#t=${time}`)
+  })
+
+  it.each([0, 12, 420])("returns `#t=%d` for a GROWING window with zero point in MPD time", (time) => {
+    expect(buildSourceAnchor(time, "mpdTime", { windowType: WindowTypes.GROWING })).toBe(`#t=${time}`)
+  })
+
+  it.each([
+    Date.now() / 1000,
+    new Date("1970-01-01T00:00:00Z").getTime() / 1000,
+    (Date.now() - new Date("1970-01-01T00:01:00Z").getTime()) / 1000,
+  ])("returns `#t=%i` for a SLIDING window given MPD time", (time) => {
+    expect(buildSourceAnchor(time, "mpdTime", { windowType: WindowTypes.SLIDING })).toBe(`#t=${Math.floor(time)}`)
+  })
+})
+
+describe("when a video time is provided", () => {
+  it("returns an empty string when video time is 0 for a STATIC window", () => {
+    expect(buildSourceAnchor(0, undefined, { windowType: WindowTypes.STATIC })).toBe("")
+  })
+
+  // [tag:DeviceIssue]
+  it("returns anchor #t as 'wall-clock time stream was available + 1' given video time 0 and GROWING window", () => {
+    const initialSeekableRangeStartSeconds = Date.now() / 1000
+
+    expect(buildSourceAnchor(0, undefined, { initialSeekableRangeStartSeconds, windowType: WindowTypes.GROWING })).toBe(
+      `#t=posix:${1 + Math.floor(initialSeekableRangeStartSeconds)}`
+    )
+  })
+
+  // [tag:DeviceIssue]
+  it("returns anchor #t=1 in MPD time given video time 0 and SLIDING window", () => {
+    const initialSeekableRangeStartSeconds = Date.now() / 1000
+
+    expect(buildSourceAnchor(0, undefined, { initialSeekableRangeStartSeconds, windowType: WindowTypes.SLIDING })).toBe(
+      `#t=${1 + Math.floor(initialSeekableRangeStartSeconds)}`
+    )
+  })
+})
+
+describe.each([12, 420])("when a video time is provided", (videoTimeSeconds) => {
+  it(`returns anchor #t=${videoTimeSeconds} in MPD time given video time '${videoTimeSeconds}' and STATIC window`, () => {
+    expect(buildSourceAnchor(videoTimeSeconds, undefined, { windowType: WindowTypes.STATIC })).toBe(
+      `#t=${videoTimeSeconds}`
+    )
+  })
+
+  it(`returns anchor #t in wall-clock (availability) time given video time '${videoTimeSeconds}' and GROWING window`, () => {
+    const initialSeekableRangeStartSeconds = Date.now() / 1000
+
+    expect(
+      buildSourceAnchor(videoTimeSeconds, undefined, {
+        initialSeekableRangeStartSeconds,
+        windowType: WindowTypes.GROWING,
+      })
+    ).toBe(`#t=posix:${initialSeekableRangeStartSeconds + videoTimeSeconds}`)
+  })
+
+  it(`returns anchor #t in MPD time given video time '${videoTimeSeconds}' and SLIDING window`, () => {
+    const initialSeekableRangeStartSeconds = Date.now() / 1000 - TimeUtils.durationToSeconds("PT2H1M")
+
+    expect(
+      buildSourceAnchor(videoTimeSeconds, undefined, {
+        initialSeekableRangeStartSeconds,
+        windowType: WindowTypes.SLIDING,
+      })
+    ).toBe(`#t=${initialSeekableRangeStartSeconds + videoTimeSeconds}`)
+  })
+})


### PR DESCRIPTION
📺 What

Pass current MPD time to Dash.js to restart playback with a new source at the same point in time on CDN failover.

🛠 How

- Move `buildSourceAnchor` to a new file. Make it handle MPD time and video time.
- Modify MSEStrategy to pass failover time as an MPD time instead of a video time.

Note:

    This is a PR to merge into branch badgers-177, not master. I've chunked the ticket into two PRs to make reviews easier.
