### PR TITLE
fix: change the geterror jsdoc param to Function

### DIFF
--- a/src/testutils/geterror.js
+++ b/src/testutils/geterror.js
@@ -3,7 +3,7 @@ class NoErrorThrownError extends Error {}
 /**
  * @see {@link https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-expect.md#how-to-catch-a-thrown-error-for-testing-without-violating-this-rule} [2023-06-16]
  *
- * @param {() => unknown} call
+ * @param {Function} call
  * @returns {Promise<Error>}
  */
 export default async function getError(call) {


### PR DESCRIPTION
📺 What

Update a jsdoc comment that breaks the `docs` build step.

🛠 How

- Specify `Function` as the param type

