### PR TITLE
Add guard around _stateUpdateCallback

### DIFF
--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -364,7 +364,11 @@ function PlayerComponent(
       stateUpdateData.message = opts.message
     }
 
-    _stateUpdateCallback(stateUpdateData)
+    // guard against attempting to call _stateUpdateCallback after a tearDown
+    // can happen if tearing down whilst an async cdn failover is being attempted
+    if (_stateUpdateCallback) {
+      _stateUpdateCallback(stateUpdateData)
+    }
   }
 
   function loadMedia(type, startTime, thenPause) {

--- a/src/playercomponent.test.js
+++ b/src/playercomponent.test.js
@@ -1050,6 +1050,7 @@ describe("Player Component", () => {
       jest.useFakeTimers()
 
       setUpPlayerComponent()
+      forceMediaSourcesError = true
 
       return StrategyPicker.default().then(() => {
         mockStrategy.mockingHooks.fireEvent(MediaState.WAITING)
@@ -1058,7 +1059,9 @@ describe("Player Component", () => {
 
         jest.advanceTimersByTime(30000)
 
-        expect(mockStateUpdateCallback.mock.calls[0][0].data.state).not.toBe(MediaState.FATAL_ERROR)
+        // expect 1 call as player goes into WAITING when event is fired above, but should not
+        // have a call after the time advances as the timer will have been cleared
+        expect(mockStateUpdateCallback.mock.calls).toHaveLength(1)
 
         jest.useRealTimers()
       })
@@ -1068,6 +1071,7 @@ describe("Player Component", () => {
       jest.useFakeTimers()
 
       setUpPlayerComponent()
+      forceMediaSourcesError = true
 
       return StrategyPicker.default().then(() => {
         // trigger a error event to start the fatal error timeout,
@@ -1079,7 +1083,9 @@ describe("Player Component", () => {
 
         jest.advanceTimersByTime(5000)
 
-        expect(mockStateUpdateCallback.mock.calls[0][0].data.state).not.toBe(MediaState.FATAL_ERROR)
+        // expect 1 call as player goes into WAITING when fireError is called above, but should not
+        // have a call after the time advances as the timer will have been cleared
+        expect(mockStateUpdateCallback.mock.calls).toHaveLength(1)
 
         jest.useRealTimers()
       })


### PR DESCRIPTION
📺 What

Prevents an unhandled exception when the player is torn down, but an async callback from a CDN failover error returns.

🛠 How

As the player has been torn down, we can safely ignore the return and just guard against the _stateUpdateCallback existing.

This PR also updates a couple of unit tests that were found to not be implemented correctly whilst investigating this unhandled exception.