### PR TITLE
upstream fix: remove prepack from Dash.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#badgers-hotfix-rm-prepare",
+        "dashjs": "github:bbc/dash.js#smp-v4.7.1-1",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#smp-v4.7.1-0",
+        "dashjs": "github:bbc/dash.js#badgers-hotfix-rm-prepare",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rollup-plugin-visualizer": "^5.5.2"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#smp-v4.7.1-0",
+    "dashjs": "github:bbc/dash.js#badgers-hotfix-rm-prepare",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rollup-plugin-visualizer": "^5.5.2"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#badgers-hotfix-rm-prepare",
+    "dashjs": "github:bbc/dash.js#smp-v4.7.1-1",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {


### PR DESCRIPTION
📺 What

Title.

🛠 How

Take new Dash.js release.