### PR TITLE
Update dash.js to smp-v4.7.1-2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#smp-v4.7.1-1",
+        "dashjs": "github:bbc/dash.js#smp-v4.7.1-2",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rollup-plugin-visualizer": "^5.5.2"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#smp-v4.7.1-1",
+    "dashjs": "github:bbc/dash.js#smp-v4.7.1-2",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {


### PR DESCRIPTION
📺 What

Take bbc/dash.js#smp-v4.7.1-2 which guards synthetic media events based on ready state. 

🛠 How

- Update the alias tag
