### PR TITLE
Include initial-playback-time and playback-strategy in DebugTool for all sessions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@ const unsafe = [
   "src/playbackstrategy/modifiers/samsungmaple.js",
   "src/playbackstrategy/modifiers/samsungstreaming.js",
   "src/playbackstrategy/modifiers/samsungstreaming2015.js",
+  "src/playbackstrategy/legacyplayeradapter.js",
 ]
 
 const namingConvention = [

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -196,7 +196,11 @@ function BigscreenPlayer() {
       resizer = Resizer()
       DebugTool.init()
       DebugTool.setRootElement(playbackElement)
+
       DebugTool.staticMetric("version", Version)
+      DebugTool.staticMetric("initial-playback-time", bigscreenPlayerData.initialPlaybackTime)
+      DebugTool.staticMetric("strategy", window.bigscreenPlayer && window.bigscreenPlayer.playbackStrategy)
+
       windowType = newWindowType
       serverDate = bigscreenPlayerData.serverDate
 

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -198,8 +198,13 @@ function BigscreenPlayer() {
       DebugTool.setRootElement(playbackElement)
 
       DebugTool.staticMetric("version", Version)
-      DebugTool.staticMetric("initial-playback-time", bigscreenPlayerData.initialPlaybackTime)
-      DebugTool.staticMetric("strategy", window.bigscreenPlayer && window.bigscreenPlayer.playbackStrategy)
+
+      if (typeof bigscreenPlayerData.initialPlaybackTime === "number") {
+        DebugTool.staticMetric("initial-playback-time", bigscreenPlayerData.initialPlaybackTime)
+      }
+      if (typeof window.bigscreenPlayer?.playbackStrategy === "string") {
+        DebugTool.staticMetric("strategy", window.bigscreenPlayer && window.bigscreenPlayer.playbackStrategy)
+      }
 
       windowType = newWindowType
       serverDate = bigscreenPlayerData.serverDate

--- a/src/playbackstrategy/legacyplayeradapter.js
+++ b/src/playbackstrategy/legacyplayeradapter.js
@@ -256,8 +256,6 @@ function LegacyPlayerAdapter(mediaSources, windowType, playbackElement, isUHD, p
       } else {
         mediaPlayer.beginPlayback()
       }
-
-      DebugTool.staticMetric("strategy", getStrategy())
     },
     play: () => {
       isPaused = false

--- a/src/playbackstrategy/legacyplayeradapter.js
+++ b/src/playbackstrategy/legacyplayeradapter.js
@@ -46,14 +46,14 @@ function LegacyPlayerAdapter(mediaSources, windowType, playbackElement, isUHD, p
 
   function eventHandler(event) {
     const handleEvent = {
-      playing: onPlaying,
-      paused: onPaused,
-      buffering: onBuffering,
+      "playing": onPlaying,
+      "paused": onPaused,
+      "buffering": onBuffering,
       "seek-attempted": onSeekAttempted,
       "seek-finished": onSeekFinished,
-      status: onTimeUpdate,
-      complete: onEnded,
-      error: onError,
+      "status": onTimeUpdate,
+      "complete": onEnded,
+      "error": onError,
     }
 
     if (handleEvent.hasOwnProperty(event.type)) {
@@ -252,7 +252,6 @@ function LegacyPlayerAdapter(mediaSources, windowType, playbackElement, isUHD, p
 
       if (!isPlaybackFromLivePoint && typeof mediaPlayer.beginPlaybackFrom === "function") {
         currentTime = startTime
-        DebugTool.dynamicMetric("initial-playback-time", startTime + timeCorrection)
         mediaPlayer.beginPlaybackFrom(startTime + timeCorrection || 0)
       } else {
         mediaPlayer.beginPlayback()

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -454,6 +454,7 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     if (mediaPlayer) {
       modifySource(refreshFailoverTime || failoverTime, failoverZeroPoint)
     } else {
+      DebugTool.dynamicMetric("initial-playback-time", playbackTime)
       failoverTime = playbackTime
       setUpMediaElement(playbackElement)
       setUpMediaPlayer(playbackTime)

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -454,7 +454,6 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     if (mediaPlayer) {
       modifySource(refreshFailoverTime || failoverTime, failoverZeroPoint)
     } else {
-      DebugTool.dynamicMetric("initial-playback-time", playbackTime)
       failoverTime = playbackTime
       setUpMediaElement(playbackElement)
       setUpMediaPlayer(playbackTime)


### PR DESCRIPTION
📺 What

The `initial-playback-time` can be logged to the `DebugTool` as a dynamic metric. This was only done for Native playback (in `legacyPlayerAdapter.js`). This gives visibility to the initial time for MSE devices too.

🛠 How

Adds the DebugTool call in `msestrategy.js` (only for initial load, not on cdn failover).