### PR TITLE
Live reload on changes to the development build

### DIFF
--- a/rollup.dev.config.js
+++ b/rollup.dev.config.js
@@ -31,6 +31,8 @@ export default {
     serve({
       open: true,
     }),
-    liveReload("dist"),
+    liveReload({
+      watch: ["index.html", "dist-local"],
+    }),
   ],
 }


### PR DESCRIPTION
📺 What

Update the live reload watcher.

🛠 How

Update the live-reload rollup plugin usage to watch `dist-local` and `index.html`.
