### PR TITLE
Do not use string.split on non-segmented subtitles

### DIFF
--- a/src/subtitles/imscsubtitles.js
+++ b/src/subtitles/imscsubtitles.js
@@ -83,7 +83,9 @@ function IMSCSubtitles(mediaPlayer, autoStart, parentElement, mediaSources, defa
         }
 
         try {
-          const xmlText = isSubtitlesWhole() ? responseText : responseText.split(/<\?xml[^?]+\?>/i)[1] || responseText
+          const xmlText = isSubtitlesWhole()
+            ? responseText.replace(/^.*<\?xml[^?]+\?>/i, "")
+            : responseText.split(/<\?xml[^?]+\?>/i)[1] || responseText
           const xml = fromXML(xmlText)
           const times = xml.getMediaTimeEvents()
 

--- a/src/subtitles/imscsubtitles.js
+++ b/src/subtitles/imscsubtitles.js
@@ -83,7 +83,12 @@ function IMSCSubtitles(mediaPlayer, autoStart, parentElement, mediaSources, defa
         }
 
         try {
-          const xml = fromXML(responseText.split(/<\?xml[^?]+\?>/i)[1] || responseText)
+          const preTime = Date.now()
+          const xmlText = responseText.split(/<\?xml[^?]+\?>/i)[1] || responseText
+          console.log("xml split time:", Date.now() - preTime)
+          const postTextTime = Date.now()
+          const xml = fromXML(xmlText)
+          console.log("xml parse time:", Date.now() - postTextTime)
           const times = xml.getMediaTimeEvents()
 
           segments.push({

--- a/src/subtitles/imscsubtitles.js
+++ b/src/subtitles/imscsubtitles.js
@@ -85,10 +85,10 @@ function IMSCSubtitles(mediaPlayer, autoStart, parentElement, mediaSources, defa
         try {
           const preTime = Date.now()
           const xmlText = responseText.split(/<\?xml[^?]+\?>/i)[1] || responseText
-          DebugTool.info(`xml split time: ${Date.now()}` - preTime)
+          DebugTool.info(`xml split time: ${Date.now() - preTime}`)
           const postTextTime = Date.now()
           const xml = fromXML(xmlText)
-          DebugTool.info(`xml parse time: ${Date.now()}` - postTextTime)
+          DebugTool.info(`xml parse time: ${Date.now() - postTextTime}`)
           const times = xml.getMediaTimeEvents()
 
           segments.push({

--- a/src/subtitles/imscsubtitles.js
+++ b/src/subtitles/imscsubtitles.js
@@ -85,10 +85,10 @@ function IMSCSubtitles(mediaPlayer, autoStart, parentElement, mediaSources, defa
         try {
           const preTime = Date.now()
           const xmlText = responseText.split(/<\?xml[^?]+\?>/i)[1] || responseText
-          console.log("xml split time:", Date.now() - preTime)
+          DebugTool.info(`xml split time: ${Date.now()}` - preTime)
           const postTextTime = Date.now()
           const xml = fromXML(xmlText)
-          console.log("xml parse time:", Date.now() - postTextTime)
+          DebugTool.info(`xml parse time: ${Date.now()}` - postTextTime)
           const times = xml.getMediaTimeEvents()
 
           segments.push({

--- a/src/subtitles/imscsubtitles.js
+++ b/src/subtitles/imscsubtitles.js
@@ -83,12 +83,8 @@ function IMSCSubtitles(mediaPlayer, autoStart, parentElement, mediaSources, defa
         }
 
         try {
-          const preTime = Date.now()
-          const xmlText = responseText.replace(/^.*<\?xml[^?]+\?>/i, "") || responseText
-          DebugTool.info(`xml split time: ${Date.now() - preTime}`)
-          const postTextTime = Date.now()
+          const xmlText = isSubtitlesWhole() ? responseText : responseText.split(/<\?xml[^?]+\?>/i)[1] || responseText
           const xml = fromXML(xmlText)
-          DebugTool.info(`xml parse time: ${Date.now() - postTextTime}`)
           const times = xml.getMediaTimeEvents()
 
           segments.push({

--- a/src/subtitles/imscsubtitles.js
+++ b/src/subtitles/imscsubtitles.js
@@ -84,7 +84,7 @@ function IMSCSubtitles(mediaPlayer, autoStart, parentElement, mediaSources, defa
 
         try {
           const preTime = Date.now()
-          const xmlText = responseText.split(/<\?xml[^?]+\?>/i)[1] || responseText
+          const xmlText = responseText.replace(/<\?xml[^?]+\?>/i, "") || responseText
           DebugTool.info(`xml split time: ${Date.now() - preTime}`)
           const postTextTime = Date.now()
           const xml = fromXML(xmlText)

--- a/src/subtitles/imscsubtitles.js
+++ b/src/subtitles/imscsubtitles.js
@@ -83,10 +83,16 @@ function IMSCSubtitles(mediaPlayer, autoStart, parentElement, mediaSources, defa
         }
 
         try {
+          const preTrimTime = Date.now()
           const xmlText = isSubtitlesWhole()
             ? responseText.replace(/^.*<\?xml[^?]+\?>/i, "")
             : responseText.split(/<\?xml[^?]+\?>/i)[1] || responseText
+          DebugTool.info(`XML trim duration: ${Date.now() - preTrimTime}`)
+
+          const preParseTime = Date.now()
           const xml = fromXML(xmlText)
+          DebugTool.info(`XML parse duration: ${Date.now() - preParseTime}`)
+
           const times = xml.getMediaTimeEvents()
 
           segments.push({

--- a/src/subtitles/imscsubtitles.js
+++ b/src/subtitles/imscsubtitles.js
@@ -84,14 +84,22 @@ function IMSCSubtitles(mediaPlayer, autoStart, parentElement, mediaSources, defa
 
         try {
           const preTrimTime = Date.now()
+
           const xmlText = isSubtitlesWhole()
             ? responseText.replace(/^.*<\?xml[^?]+\?>/i, "")
             : responseText.split(/<\?xml[^?]+\?>/i)[1] || responseText
-          DebugTool.info(`XML trim duration: ${Date.now() - preTrimTime}`)
+
+          if (isSubtitlesWhole()) {
+            DebugTool.info(`XML trim duration: ${Date.now() - preTrimTime}`)
+          }
 
           const preParseTime = Date.now()
+
           const xml = fromXML(xmlText)
-          DebugTool.info(`XML parse duration: ${Date.now() - preParseTime}`)
+
+          if (isSubtitlesWhole()) {
+            DebugTool.info(`XML parse duration: ${Date.now() - preParseTime}`)
+          }
 
           const times = xml.getMediaTimeEvents()
 

--- a/src/subtitles/imscsubtitles.js
+++ b/src/subtitles/imscsubtitles.js
@@ -84,7 +84,7 @@ function IMSCSubtitles(mediaPlayer, autoStart, parentElement, mediaSources, defa
 
         try {
           const preTime = Date.now()
-          const xmlText = responseText.replace(/<\?xml[^?]+\?>/i, "") || responseText
+          const xmlText = responseText.replace(/^.*<\?xml[^?]+\?>/i, "") || responseText
           DebugTool.info(`xml split time: ${Date.now() - preTime}`)
           const postTextTime = Date.now()
           const xml = fromXML(xmlText)


### PR DESCRIPTION
📺 What

Due to a performance issue running string.split on large subtitle segments, replace the use of string.split with a more efficient replacement.

🛠 How

Replace string.split with alternative use of string.replace.
