### PR TITLE
Update dash.js dependency (to include use seek without ready state check)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#smp-v4.7.3-1",
+        "dashjs": "github:bbc/dash.js#seek-without-readystate-check",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#seek-without-readystate-check",
+        "dashjs": "github:bbc/dash.js#smp-v4.7.3-2",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript-eslint": "^7.2.0"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#seek-without-readystate-check",
+    "dashjs": "github:bbc/dash.js#smp-v4.7.3-2",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript-eslint": "^7.2.0"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#smp-v4.7.3-1",
+    "dashjs": "github:bbc/dash.js#seek-without-readystate-check",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {


### PR DESCRIPTION
📺 What

Make use of the latest (`v4.7.3-2`) release of bbc/dash.js.
This allows devices to be configured to bypass the check for the `loadedmetadata` (see https://github.com/bbc/dash.js/pull/92)

🛠 How

Update package.json and package-lock.json