### PR TITLE
Handle calling plugins with context

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -7,7 +7,7 @@ function callOnAllPlugins(funcKey, evt) {
   const clonedEvent = PlaybackUtils.deepClone(evt)
   const selectedPlugins = plugins
     .filter((plugin) => plugin[funcKey] && typeof plugin[funcKey] === "function")
-    .map((plugin) => plugin[funcKey])
+    .map((plugin, index, arr) => plugin[funcKey].bind(arr[index]))
 
   CallCallbacks(selectedPlugins, clonedEvent)
 }

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -7,7 +7,7 @@ function callOnAllPlugins(funcKey, evt) {
   const clonedEvent = PlaybackUtils.deepClone(evt)
   const selectedPlugins = plugins
     .filter((plugin) => plugin[funcKey] && typeof plugin[funcKey] === "function")
-    .map((plugin, index, arr) => plugin[funcKey].bind(arr[index]))
+    .map((plugin) => plugin[funcKey].bind(plugin))
 
   CallCallbacks(selectedPlugins, clonedEvent)
 }

--- a/src/plugins.test.js
+++ b/src/plugins.test.js
@@ -47,4 +47,53 @@ describe("Plugins", () => {
       expect(fatalErrorPlugin.onFatalError).toHaveBeenCalled()
     }
   })
+
+  it("Calls plugins including context and defers any errors thrown", () => {
+    expect.assertions(4)
+
+    const fatalErrorPlugin = {
+      onFatalError: jest.fn(),
+    }
+
+    class ErrorHandlingClass {
+      constructor() {
+        this.state = "bad"
+      }
+
+      report() {
+        return this.state
+      }
+
+      onFatalError() {
+        this.report()
+      }
+    }
+
+    const classBasedErrorHandler = new ErrorHandlingClass()
+
+    const classSpy = jest.spyOn(classBasedErrorHandler, "report")
+
+    const newError = new Error("oops")
+
+    fatalErrorPlugin.onFatalError.mockImplementationOnce(() => {
+      throw newError
+    })
+
+    plugins.registerPlugin(classBasedErrorHandler)
+    plugins.registerPlugin(fatalErrorPlugin)
+
+    jest.useFakeTimers()
+
+    try {
+      expect(() => {
+        plugins.interface.onFatalError()
+      }).not.toThrow()
+      jest.advanceTimersByTime(1)
+    } catch (error) {
+      // Test for the async error case, linting hates it!
+      expect(error).toBe(newError)
+      expect(fatalErrorPlugin.onFatalError).toHaveBeenCalled()
+      expect(classSpy).toHaveBeenCalled()
+    }
+  })
 })


### PR DESCRIPTION
📺 What

fix: handle calling plugins with context

🛠 How

- Use the whole object as `this` context when mapping selected plugins. 
