### PR TITLE
Ensure legacy subtitle styling is applied for both 720 and 1080 height video containers

### DIFF
--- a/src/subtitles/legacysubtitles.js
+++ b/src/subtitles/legacysubtitles.js
@@ -46,18 +46,30 @@ function LegacySubtitles(mediaPlayer, autoStart, parentElement, mediaSources) {
     container.id = "playerCaptionsContainer"
     DOMHelpers.addClass(container, "playerCaptions")
 
+    const videoHeight = parentElement.clientHeight
+
     container.style.position = "absolute"
     container.style.bottom = "0px"
     container.style.right = "0px"
-    container.style.width = "1216px"
-    container.style.fontSize = "42px"
     container.style.fontWeight = "bold"
     container.style.textAlign = "center"
     container.style.textShadow = "#161616 2px 2px 1px"
     container.style.color = "#ebebeb"
-    container.style.paddingRight = "32px"
-    container.style.paddingLeft = "32px"
-    container.style.paddingBottom = "40px"
+
+    if (videoHeight === 1080) {
+      container.style.width = "1824px"
+      container.style.fontSize = "63px"
+      container.style.paddingRight = "48px"
+      container.style.paddingLeft = "48px"
+      container.style.paddingBottom = "60px"
+    } else {
+      // Assume 720 if not 1080. Styling implementation could be cleaner, but this is a quick fix for legacy subtitles
+      container.style.width = "1216px"
+      container.style.fontSize = "42px"
+      container.style.paddingRight = "32px"
+      container.style.paddingLeft = "32px"
+      container.style.paddingBottom = "40px"
+    }
 
     // TODO: We don't need this extra Div really... can we get rid of render() and use the passed in container?
     subtitlesRenderer = Renderer("playerCaptions", xml, mediaPlayer)


### PR DESCRIPTION
📺 What

Adds legacy subtitle styling for 1080 layout devices as well as defaulting to 720.

🛠 How

Checks the `parentElement`'s `clientHeight`. Change the styling values depending on result.