### PR TITLE
BADGERS-535: publish error when segment download fails on final CDN

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -217,8 +217,9 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
 
       // Don't raise an error on fragment download error
       if (
-        event.error.code === DashJSEvents.DOWNLOAD_CONTENT_ERROR_CODE ||
-        event.error.code === DashJSEvents.DOWNLOAD_INIT_SEGMENT_ERROR_CODE
+        (event.error.code === DashJSEvents.DOWNLOAD_CONTENT_ERROR_CODE ||
+          event.error.code === DashJSEvents.DOWNLOAD_INIT_SEGMENT_ERROR_CODE) &&
+        mediaSources.availableSources().length > 1
       ) {
         return
       }

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -1241,7 +1241,7 @@ describe("Media Source Extensions Playback Strategy", () => {
       expect(Plugins.interface.onErrorHandled).not.toHaveBeenCalledWith()
     })
 
-    it("should not publish error event on initial segment download error", () => {
+    it("should not publish error event on init segment download error if more than one CDN available", () => {
       const mockEvent = {
         error: {
           message: "initial segment download error",
@@ -1259,6 +1259,30 @@ describe("Media Source Extensions Playback Strategy", () => {
       dashEventCallback(dashjsMediaPlayerEvents.ERROR, mockEvent)
 
       expect(mockErrorCallback).not.toHaveBeenCalled()
+    })
+
+    it("should publish error event on init segment download error if only one CDN available", () => {
+      const mockEvent = {
+        error: {
+          message: "initial segment download error",
+          code: 28,
+        },
+      }
+
+      setUpMSE()
+
+      const mockErrorCallback = jest.fn()
+      mseStrategy.addErrorCallback(null, mockErrorCallback)
+
+      mseStrategy.load(null, 0)
+
+      const noop = () => {}
+      mediaSources.failover(noop, noop, { isBufferingTimeoutError: true })
+      mediaSources.failover(noop, noop, { isBufferingTimeoutError: true })
+
+      dashEventCallback(dashjsMediaPlayerEvents.ERROR, mockEvent)
+
+      expect(mockErrorCallback).toHaveBeenCalled()
     })
 
     it("should not publish error event on content download error", () => {

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -1285,7 +1285,7 @@ describe("Media Source Extensions Playback Strategy", () => {
       expect(mockErrorCallback).toHaveBeenCalled()
     })
 
-    it("should not publish error event on content download error", () => {
+    it("should not publish error event on content download error if more than one CDN available", () => {
       const mockEvent = {
         error: {
           message: "content download error",
@@ -1303,6 +1303,30 @@ describe("Media Source Extensions Playback Strategy", () => {
       dashEventCallback(dashjsMediaPlayerEvents.ERROR, mockEvent)
 
       expect(mockErrorCallback).not.toHaveBeenCalled()
+    })
+
+    it("should publish error event on content download error if only one CDN available", () => {
+      const mockEvent = {
+        error: {
+          message: "content download error",
+          code: 27,
+        },
+      }
+
+      setUpMSE()
+
+      const mockErrorCallback = jest.fn()
+      mseStrategy.addErrorCallback(null, mockErrorCallback)
+
+      mseStrategy.load(null, 0)
+
+      const noop = () => {}
+      mediaSources.failover(noop, noop, { isBufferingTimeoutError: true })
+      mediaSources.failover(noop, noop, { isBufferingTimeoutError: true })
+
+      dashEventCallback(dashjsMediaPlayerEvents.ERROR, mockEvent)
+
+      expect(mockErrorCallback).toHaveBeenCalled()
     })
 
     it("should initiate a failover with correct parameters on manifest download error", () => {


### PR DESCRIPTION
📺 What

Publish errors when segment downloads fail, and there is only one available CDN remaining (none left to failover to). 

This prevents the player from entering an infinite buffering state where segments aren't being requested and the CDN isn't failing over, instead forcing the player to fatal error.

🛠 How

Only ignores `DOWNLOAD_CONTENT` & `DOWNLOAD_INIT_SEGMENT` errors when there is more than one available CDN remaining; otherwise we publish the error.
