### PR TITLE
Don't apply `liveDelay` to `WindowTypes.STATIC`

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -454,15 +454,12 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
   }
 
   function getClampedTime(time, range) {
-    if (windowType === WindowTypes.SLIDING) {
-      return Math.min(Math.max(time, 0), mediaPlayer.getDVRWindowSize() - Math.max(liveDelay, seekDurationPadding))
-    }
+    const rangeStart = windowType === WindowTypes.SLIDING ? 0 : range.start
+    const rangeEnd = windowType === WindowTypes.SLIDING ? mediaPlayer.getDVRWindowSize() : range.end
+    const correction =
+      windowType === WindowTypes.STATIC ? seekDurationPadding : Math.max(liveDelay, seekDurationPadding)
 
-    if (windowType === WindowTypes.GROWING) {
-      return Math.min(Math.max(time, range.start), range.end - Math.max(liveDelay, seekDurationPadding))
-    }
-
-    return Math.min(Math.max(time, range.start), range.end - seekDurationPadding)
+    return Math.min(Math.max(time, rangeStart), rangeEnd - correction)
   }
 
   function load(mimeType, playbackTime) {

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -454,12 +454,12 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
   }
 
   function getClampedTime(time, range) {
-    const vod = windowType === WindowTypes.STATIC
-    const sliding = windowType === WindowTypes.SLIDING
+    const isStatic = windowType === WindowTypes.STATIC
+    const isSliding = windowType === WindowTypes.SLIDING
     const clampedRange = {
-      start: sliding ? 0 : range.start,
-      end: sliding ? mediaPlayer.getDVRWindowSize() : range.end,
-      correction: vod ? seekDurationPadding : Math.max(liveDelay, seekDurationPadding),
+      start: isSliding ? 0 : range.start,
+      end: isSliding ? mediaPlayer.getDVRWindowSize() : range.end,
+      correction: isStatic ? seekDurationPadding : Math.max(liveDelay, seekDurationPadding),
     }
 
     return Math.min(Math.max(time, clampedRange.start), clampedRange.end - clampedRange.correction)

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -454,7 +454,11 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
   }
 
   function getClampedTime(time, range) {
-    return Math.min(Math.max(time, range.start), range.end - Math.max(liveDelay, seekDurationPadding))
+    if (windowType === WindowTypes.SLIDING) {
+      return Math.min(Math.max(time, 0), mediaPlayer.getDVRWindowSize() - Math.max(liveDelay, seekDurationPadding))
+    }
+
+    return Math.min(Math.max(time, range.start), range.end - seekDurationPadding)
   }
 
   function load(mimeType, playbackTime) {
@@ -586,10 +590,6 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
   }
 
   function calculateSeekOffset(time) {
-    function getClampedTimeForLive(time) {
-      return Math.min(Math.max(time, 0), mediaPlayer.getDVRWindowSize() - Math.max(liveDelay, seekDurationPadding))
-    }
-
     if (windowType === WindowTypes.SLIDING) {
       const dvrInfo = mediaPlayer.getDashMetrics().getCurrentDVRInfo(mediaKind)
       const offset = TimeUtils.calculateSlidingWindowSeekOffset(
@@ -600,8 +600,9 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
       )
       slidingWindowPausedTime = 0
 
-      return getClampedTimeForLive(offset)
+      return getClampedTime(offset)
     }
+
     return getClampedTime(time, getSeekableRange())
   }
 

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -458,6 +458,10 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
       return Math.min(Math.max(time, 0), mediaPlayer.getDVRWindowSize() - Math.max(liveDelay, seekDurationPadding))
     }
 
+    if (windowType === WindowTypes.GROWING) {
+      return Math.min(Math.max(time, range.start), range.end - Math.max(liveDelay, seekDurationPadding))
+    }
+
     return Math.min(Math.max(time, range.start), range.end - seekDurationPadding)
   }
 

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -319,6 +319,16 @@ describe("Media Source Extensions Playback Strategy", () => {
         expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
         expect(mockDashInstance.attachSource).toHaveBeenCalledWith(`${cdnArray[0].url}#t=15`)
       })
+
+      it("should clamp the seek to the end of the seekable range", () => {
+        const seekDurationPadding = 0
+
+        setUpMSE(undefined, undefined, undefined, undefined, undefined, { streaming: { seekDurationPadding } })
+        mseStrategy.load(null, 0)
+
+        mseStrategy.setCurrentTime(1000)
+        expect(mockDashInstance.seek).toHaveBeenCalledWith(101)
+      })
     })
 
     describe("for SLIDING window", () => {


### PR DESCRIPTION
📺 What
Don't apply `liveDelay` to `WindowTypes.STATIC`, supersedes #301 

🛠 How
Add a checks for `windowType` in `getClampedTime()` and use the implementation from `getClampedTimeForLive()` for `WindowTypes.SLIDING`, the original implementation for `WindowTypes.GROWING`, and #301, with `seekDurationPadding`, for `WindowTypes.STATIC`. Refactored into a single expression with ternary checks preceeding. 

👀 See
#301 
