### PR TITLE
Reset mediaElement and mediaPlayer on call to reset when configured

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -701,7 +701,26 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
         },
       }
     },
-    reset: () => {},
+    reset: () => {
+      mediaPlayer.destroy()
+
+      mediaElement.removeEventListener("timeupdate", onTimeUpdate)
+      mediaElement.removeEventListener("loadedmetadata", onLoadedMetaData)
+      mediaElement.removeEventListener("loadeddata", onLoadedData)
+      mediaElement.removeEventListener("play", onPlay)
+      mediaElement.removeEventListener("playing", onPlaying)
+      mediaElement.removeEventListener("pause", onPaused)
+      mediaElement.removeEventListener("waiting", onWaiting)
+      mediaElement.removeEventListener("seeking", onSeeking)
+      mediaElement.removeEventListener("seeked", onSeeked)
+      mediaElement.removeEventListener("ended", onEnded)
+      mediaElement.removeEventListener("ratechange", onRateChange)
+
+      DOMHelpers.safeRemoveElement(mediaElement)
+
+      mediaPlayer = undefined
+      mediaElement = undefined
+    },
     isEnded: () => isEnded,
     isPaused,
     pause: (opts = {}) => {

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -633,26 +633,9 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     )
   }
 
-  return {
-    transitions: {
-      canBePaused: () => true,
-      canBeginSeek: () => true,
-    },
-    addEventCallback,
-    removeEventCallback,
-    addErrorCallback: (thisArg, newErrorCallback) => {
-      errorCallback = (event) => newErrorCallback.call(thisArg, event)
-    },
-    addTimeUpdateCallback: (thisArg, newTimeUpdateCallback) => {
-      timeUpdateCallback = () => newTimeUpdateCallback.call(thisArg)
-    },
-    load,
-    getSeekableRange,
-    getCurrentTime,
-    getDuration,
-    getPlayerElement: () => mediaElement,
-    tearDown: () => {
-      mediaPlayer.reset()
+  function cleanUpMediaPlayer() {
+    if (mediaPlayer && mediaElement) {
+      mediaPlayer.destroy()
 
       mediaElement.removeEventListener("timeupdate", onTimeUpdate)
       mediaElement.removeEventListener("loadedmetadata", onLoadedMetaData)
@@ -681,9 +664,33 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
 
       DOMHelpers.safeRemoveElement(mediaElement)
 
-      lastError = undefined
       mediaPlayer = undefined
       mediaElement = undefined
+    }
+  }
+
+  return {
+    transitions: {
+      canBePaused: () => true,
+      canBeginSeek: () => true,
+    },
+    addEventCallback,
+    removeEventCallback,
+    addErrorCallback: (thisArg, newErrorCallback) => {
+      errorCallback = (event) => newErrorCallback.call(thisArg, event)
+    },
+    addTimeUpdateCallback: (thisArg, newTimeUpdateCallback) => {
+      timeUpdateCallback = () => newTimeUpdateCallback.call(thisArg)
+    },
+    load,
+    getSeekableRange,
+    getCurrentTime,
+    getDuration,
+    getPlayerElement: () => mediaElement,
+    tearDown: () => {
+      cleanUpMediaPlayer()
+
+      lastError = undefined
       eventCallbacks = []
       errorCallback = undefined
       timeUpdateCallback = undefined
@@ -703,24 +710,7 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     },
     reset: () => {
       if (window.bigscreenPlayer.overrides && window.bigscreenPlayer.overrides.resetMSEPlayer) {
-        mediaPlayer.destroy()
-
-        mediaElement.removeEventListener("timeupdate", onTimeUpdate)
-        mediaElement.removeEventListener("loadedmetadata", onLoadedMetaData)
-        mediaElement.removeEventListener("loadeddata", onLoadedData)
-        mediaElement.removeEventListener("play", onPlay)
-        mediaElement.removeEventListener("playing", onPlaying)
-        mediaElement.removeEventListener("pause", onPaused)
-        mediaElement.removeEventListener("waiting", onWaiting)
-        mediaElement.removeEventListener("seeking", onSeeking)
-        mediaElement.removeEventListener("seeked", onSeeked)
-        mediaElement.removeEventListener("ended", onEnded)
-        mediaElement.removeEventListener("ratechange", onRateChange)
-
-        DOMHelpers.safeRemoveElement(mediaElement)
-
-        mediaPlayer = undefined
-        mediaElement = undefined
+        cleanUpMediaPlayer()
       }
     },
     isEnded: () => isEnded,

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -702,24 +702,26 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
       }
     },
     reset: () => {
-      mediaPlayer.destroy()
+      if (window.bigscreenPlayer.overrides && window.bigscreenPlayer.overrides.resetMSEPlayer) {
+        mediaPlayer.destroy()
 
-      mediaElement.removeEventListener("timeupdate", onTimeUpdate)
-      mediaElement.removeEventListener("loadedmetadata", onLoadedMetaData)
-      mediaElement.removeEventListener("loadeddata", onLoadedData)
-      mediaElement.removeEventListener("play", onPlay)
-      mediaElement.removeEventListener("playing", onPlaying)
-      mediaElement.removeEventListener("pause", onPaused)
-      mediaElement.removeEventListener("waiting", onWaiting)
-      mediaElement.removeEventListener("seeking", onSeeking)
-      mediaElement.removeEventListener("seeked", onSeeked)
-      mediaElement.removeEventListener("ended", onEnded)
-      mediaElement.removeEventListener("ratechange", onRateChange)
+        mediaElement.removeEventListener("timeupdate", onTimeUpdate)
+        mediaElement.removeEventListener("loadedmetadata", onLoadedMetaData)
+        mediaElement.removeEventListener("loadeddata", onLoadedData)
+        mediaElement.removeEventListener("play", onPlay)
+        mediaElement.removeEventListener("playing", onPlaying)
+        mediaElement.removeEventListener("pause", onPaused)
+        mediaElement.removeEventListener("waiting", onWaiting)
+        mediaElement.removeEventListener("seeking", onSeeking)
+        mediaElement.removeEventListener("seeked", onSeeked)
+        mediaElement.removeEventListener("ended", onEnded)
+        mediaElement.removeEventListener("ratechange", onRateChange)
 
-      DOMHelpers.safeRemoveElement(mediaElement)
+        DOMHelpers.safeRemoveElement(mediaElement)
 
-      mediaPlayer = undefined
-      mediaElement = undefined
+        mediaPlayer = undefined
+        mediaElement = undefined
+      }
     },
     isEnded: () => isEnded,
     isPaused,

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -634,20 +634,9 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
   }
 
   function cleanUpMediaPlayer() {
-    if (mediaPlayer && mediaElement) {
+    if (mediaPlayer) {
       mediaPlayer.destroy()
 
-      mediaElement.removeEventListener("timeupdate", onTimeUpdate)
-      mediaElement.removeEventListener("loadedmetadata", onLoadedMetaData)
-      mediaElement.removeEventListener("loadeddata", onLoadedData)
-      mediaElement.removeEventListener("play", onPlay)
-      mediaElement.removeEventListener("playing", onPlaying)
-      mediaElement.removeEventListener("pause", onPaused)
-      mediaElement.removeEventListener("waiting", onWaiting)
-      mediaElement.removeEventListener("seeking", onSeeking)
-      mediaElement.removeEventListener("seeked", onSeeked)
-      mediaElement.removeEventListener("ended", onEnded)
-      mediaElement.removeEventListener("ratechange", onRateChange)
       mediaPlayer.off(DashJSEvents.ERROR, onError)
       mediaPlayer.off(DashJSEvents.MANIFEST_LOADED, onManifestLoaded)
       mediaPlayer.off(DashJSEvents.MANIFEST_VALIDITY_CHANGED, onManifestValidityChange)
@@ -662,9 +651,24 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
       mediaPlayer.off(DashJSEvents.GAP_JUMP_TO_END, onGapJump)
       mediaPlayer.off(DashJSEvents.QUOTA_EXCEEDED, onQuotaExceeded)
 
+      mediaPlayer = undefined
+    }
+
+    if (mediaElement) {
+      mediaElement.removeEventListener("timeupdate", onTimeUpdate)
+      mediaElement.removeEventListener("loadedmetadata", onLoadedMetaData)
+      mediaElement.removeEventListener("loadeddata", onLoadedData)
+      mediaElement.removeEventListener("play", onPlay)
+      mediaElement.removeEventListener("playing", onPlaying)
+      mediaElement.removeEventListener("pause", onPaused)
+      mediaElement.removeEventListener("waiting", onWaiting)
+      mediaElement.removeEventListener("seeking", onSeeking)
+      mediaElement.removeEventListener("seeked", onSeeked)
+      mediaElement.removeEventListener("ended", onEnded)
+      mediaElement.removeEventListener("ratechange", onRateChange)
+
       DOMHelpers.safeRemoveElement(mediaElement)
 
-      mediaPlayer = undefined
       mediaElement = undefined
     }
   }

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -748,13 +748,13 @@ describe("Media Source Extensions Playback Strategy", () => {
   })
 
   describe("tearDown()", () => {
-    it("should reset the MediaPlayer", () => {
+    it("should destroy the MediaPlayer", () => {
       setUpMSE()
       mseStrategy.load(null, 0)
 
       mseStrategy.tearDown()
 
-      expect(mockDashInstance.reset).toHaveBeenCalledWith()
+      expect(mockDashInstance.destroy).toHaveBeenCalledWith()
     })
 
     it("should tear down bindings to MediaPlayer Events correctly", () => {

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -656,58 +656,94 @@ describe("Media Source Extensions Playback Strategy", () => {
   })
 
   describe("reset()", () => {
-    it("should destroy the player and listeners", () => {
-      setUpMSE()
-      mseStrategy.load(null, 0)
-
-      expect(playbackElement.childElementCount).toBe(1)
-
-      mseStrategy.reset()
-
-      expect(mockDashInstance.destroy).toHaveBeenCalledWith()
-
-      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("timeupdate", expect.any(Function))
-      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("loadedmetadata", expect.any(Function))
-      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("loadeddata", expect.any(Function))
-      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("play", expect.any(Function))
-      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("playing", expect.any(Function))
-      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("pause", expect.any(Function))
-      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("waiting", expect.any(Function))
-      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("seeking", expect.any(Function))
-      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("seeked", expect.any(Function))
-      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("ended", expect.any(Function))
-      expect(mediaElement.removeEventListener).toHaveBeenCalledWith("ratechange", expect.any(Function))
-
-      expect(playbackElement.childElementCount).toBe(0)
-    })
-
-    it("should setup player and element on a load after a reset", () => {
-      setUpMSE()
-      mseStrategy.load(null, 0)
-
-      mseStrategy.reset()
-
-      jest.clearAllMocks()
-
-      jest.spyOn(document, "createElement").mockImplementationOnce((elementType) => {
-        if (["audio", "video"].includes(elementType)) {
-          mediaElement = mockMediaElement(elementType)
-          return mediaElement
+    describe("when resetMSEPlayer is configured as true", () => {
+      beforeEach(() => {
+        window.bigscreenPlayer.overrides = {
+          resetMSEPlayer: true,
         }
-
-        return document.createElement(elementType)
       })
 
-      mseStrategy.load(null, 0)
+      it("should destroy the player and listeners", () => {
+        setUpMSE()
+        mseStrategy.load(null, 0)
 
-      expect(mockDashInstance.initialize).toHaveBeenCalledTimes(1)
-      expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
-      expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url)
+        expect(playbackElement.childElementCount).toBe(1)
 
-      expect(playbackElement.childElementCount).toBe(1)
-      expect(playbackElement.firstChild).toBeInstanceOf(HTMLVideoElement)
-      expect(playbackElement.firstChild).toBe(mediaElement)
-      expect(isMockedElement(playbackElement.firstChild)).toBe(true)
+        mseStrategy.reset()
+
+        expect(mockDashInstance.destroy).toHaveBeenCalledWith()
+
+        expect(mediaElement.removeEventListener).toHaveBeenCalledWith("timeupdate", expect.any(Function))
+        expect(mediaElement.removeEventListener).toHaveBeenCalledWith("loadedmetadata", expect.any(Function))
+        expect(mediaElement.removeEventListener).toHaveBeenCalledWith("loadeddata", expect.any(Function))
+        expect(mediaElement.removeEventListener).toHaveBeenCalledWith("play", expect.any(Function))
+        expect(mediaElement.removeEventListener).toHaveBeenCalledWith("playing", expect.any(Function))
+        expect(mediaElement.removeEventListener).toHaveBeenCalledWith("pause", expect.any(Function))
+        expect(mediaElement.removeEventListener).toHaveBeenCalledWith("waiting", expect.any(Function))
+        expect(mediaElement.removeEventListener).toHaveBeenCalledWith("seeking", expect.any(Function))
+        expect(mediaElement.removeEventListener).toHaveBeenCalledWith("seeked", expect.any(Function))
+        expect(mediaElement.removeEventListener).toHaveBeenCalledWith("ended", expect.any(Function))
+        expect(mediaElement.removeEventListener).toHaveBeenCalledWith("ratechange", expect.any(Function))
+
+        expect(playbackElement.childElementCount).toBe(0)
+      })
+
+      it("should setup player and element on a load after a reset", () => {
+        setUpMSE()
+        mseStrategy.load(null, 0)
+
+        mseStrategy.reset()
+
+        jest.clearAllMocks()
+
+        jest.spyOn(document, "createElement").mockImplementationOnce((elementType) => {
+          if (["audio", "video"].includes(elementType)) {
+            mediaElement = mockMediaElement(elementType)
+            return mediaElement
+          }
+
+          return document.createElement(elementType)
+        })
+
+        mseStrategy.load(null, 0)
+
+        expect(mockDashInstance.initialize).toHaveBeenCalledTimes(1)
+        expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null, true)
+        expect(mockDashInstance.attachSource).toHaveBeenCalledWith(cdnArray[0].url)
+
+        expect(playbackElement.childElementCount).toBe(1)
+        expect(playbackElement.firstChild).toBeInstanceOf(HTMLVideoElement)
+        expect(playbackElement.firstChild).toBe(mediaElement)
+        expect(isMockedElement(playbackElement.firstChild)).toBe(true)
+      })
+    })
+    describe("when resetMSEPlayer is configured as false", () => {
+      beforeEach(() => {
+        window.bigscreenPlayer.overrides = {
+          resetMSEPlayer: false,
+        }
+      })
+
+      it("should not destroy the player or listeners", () => {
+        setUpMSE()
+        mseStrategy.load(null, 0)
+        mseStrategy.reset()
+
+        expect(mockDashInstance.destroy).not.toHaveBeenCalledWith()
+        expect(playbackElement.childElementCount).toBe(1)
+
+        expect(mediaElement.removeEventListener).not.toHaveBeenCalledWith("timeupdate", expect.any(Function))
+        expect(mediaElement.removeEventListener).not.toHaveBeenCalledWith("loadedmetadata", expect.any(Function))
+        expect(mediaElement.removeEventListener).not.toHaveBeenCalledWith("loadeddata", expect.any(Function))
+        expect(mediaElement.removeEventListener).not.toHaveBeenCalledWith("play", expect.any(Function))
+        expect(mediaElement.removeEventListener).not.toHaveBeenCalledWith("playing", expect.any(Function))
+        expect(mediaElement.removeEventListener).not.toHaveBeenCalledWith("pause", expect.any(Function))
+        expect(mediaElement.removeEventListener).not.toHaveBeenCalledWith("waiting", expect.any(Function))
+        expect(mediaElement.removeEventListener).not.toHaveBeenCalledWith("seeking", expect.any(Function))
+        expect(mediaElement.removeEventListener).not.toHaveBeenCalledWith("seeked", expect.any(Function))
+        expect(mediaElement.removeEventListener).not.toHaveBeenCalledWith("ended", expect.any(Function))
+        expect(mediaElement.removeEventListener).not.toHaveBeenCalledWith("ratechange", expect.any(Function))
+      })
     })
   })
 


### PR DESCRIPTION
📺 What

Reset mediaElement and mediaPlayer on call to reset when configured with `resetMSEPlayer`

Reset currently does nothing as we normally just attach a new source on failover. This will change that behaviour and create a new mediaElement and player. This is to resolve an issue on certain devices.

Move to using destroy instead of reset on the dash mediaPlayer. This cleans up any memory left around of the player.

🛠 How

Move the teardown logic for resetting the player into a new cleanUpMediaPlayer function and use this for both reset and teardown.

Added a new setting `resetMSEPlayer`
