### PR TITLE
Add target-latency and current-latency to debug view

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -188,6 +188,8 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
 
   function onTimeUpdate() {
     DebugTool.updateElementTime(mediaElement.currentTime)
+    DebugTool.dynamicMetric("current-latency", mediaPlayer.getCurrentLiveLatency())
+    DebugTool.dynamicMetric("target-latency", mediaPlayer.getTargetLiveDelay())
 
     const currentMpdTimeSeconds =
       windowType === WindowTypes.SLIDING

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -30,6 +30,8 @@ const mockDashInstance = {
   isReady: jest.fn(),
   refreshManifest: jest.fn(),
   getDashMetrics: jest.fn(),
+  getTargetLiveDelay: jest.fn(),
+  getCurrentLiveLatency: jest.fn(),
   getDashAdapter: jest.fn(),
   getBitrateInfoListFor: jest.fn(),
   getAverageThroughput: jest.fn(),


### PR DESCRIPTION
📺 What

Adds MSE target latency and current latency reporting to the debug menu. Useful when debugging low-latency content, particularly on TV hardware where some decoder behaviours do not match what might be expected

🛠 How

Uses existing `DebugTool.dynamicMetric()` method to add these metrics each time a `timeupdate` event is called.

✅ Testing

Added underlying dash.js functions to the `mockDashInstance`.  No additional unit tests were added.

[Test Guidelines](https://github.com/bbc/bigscreen-player/wiki/Areas-Impacted)

| Test engineer sign off | :x: |
| ---------------------- | --- |


👀 See

New fields are seen below when the MSE strategy is chosen. The values` NaN` and 0 are seen when VOD content is played.

<img width="1270" alt="Screenshot 2024-10-30 at 17 06 22" src="https://github.com/user-attachments/assets/613f7ab4-bfd9-4f8a-9b6d-895e0a66500f">

The same changes are shown again, but using live low-latency content. Extra fields, along with the existing playback rate field, can be used to determine whether low-latency content is performing as expected.

<img width="1500" alt="Screenshot 2024-10-30 at 17 06 54" src="https://github.com/user-attachments/assets/d1ef1969-98ba-42bb-b777-dff644438f7b">


♿ Accessibility [optional]

[Any accessibility features or considerations that this PR addresses should be listed here]
