### PR TITLE
Enable DVB Metrics Reporting

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -518,6 +518,9 @@ function MSEStrategy(
     mediaPlayer.updateSettings(dashSettings)
     mediaPlayer.initialize(mediaElement, null, true)
 
+    //Allow cookies to be sent with DVBReporting Requests
+    mediaPlayer.setXHRWithCredentialsForType("DVBReporting", true)
+
     if (enableBroadcastMixAD) {
       mediaPlayer.setInitialMediaSettingsFor("audio", {
         role: "alternate",

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -59,6 +59,7 @@ const mockDashInstance = {
   getCurrentTrackFor: jest.fn(),
   setCurrentTrack: jest.fn(),
   setInitialMediaSettingsFor: jest.fn(),
+  setXHRWithCredentialsForType: jest.fn(),
 }
 
 const mockDashMediaPlayer = {


### PR DESCRIPTION
📺 What

Allows DASH manifests which specifies a metric reporting block in the following form;

```xml
<Metrics metrics="HttpList(50,MediaSegment),RepSwitchList,PlayList,TcpList,DVBErrors"> 
    <Reporting schemeIdUri="urn:dvb:dash:reporting:2014" value="1" dvb:reportingUrl="h  ttps://example.com/metrics" dvb:probability="1000"/> 
</Metrics>
```
to report to the endpoint.

🛠 How

Changes the Dash.js import to use `dashjs` instead of `index_mediaplayerOnly`, additionally adds `setXHRWithCredentialsForType("DVBReporting", true)` to allow cookies to be passed with any of these reporting requests by the place - this is required in order to ID the session.


✅ Testing [Semi-optional]

Mock player expanded to include `setXHRWithCredentialsForType` method.

[Test Guidelines](https://github.com/bbc/bigscreen-player/wiki/Areas-Impacted)

| Test engineer sign off | :x: |
| ---------------------- | --- |

Bundle size could change as a result of this PR.