### PR TITLE
MSE BroadcastMixAD Support

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
                         {
                             // Content from DASH IF testing assests (used in their reference player)
                             // https://reference.dashif.org/dash.js/v2.9.2/samples/dash-if-reference-player/index.htm
-                            url: "https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd",
-                            cdn: "dash.akamaized.net",
+                            url: "https://rdmedia.bbc.co.uk/testcard/simulcast/manifests/avc-ctv-stereo-ad-no_subs-en.mpd",
+                            cdn: "",
                         },
                     ],
                 },

--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
                         {
                             // Content from DASH IF testing assests (used in their reference player)
                             // https://reference.dashif.org/dash.js/v2.9.2/samples/dash-if-reference-player/index.htm
-                            url: "https://rdmedia.bbc.co.uk/testcard/simulcast/manifests/avc-ctv-stereo-ad-no_subs-en.mpd",
-                            cdn: "",
+                            url: "https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd",
+                            cdn: "dash.akamaized.net",
                         },
                     ],
                 },

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -24,6 +24,7 @@ function BigscreenPlayer() {
   let stateChangeCallbacks = []
   let timeUpdateCallbacks = []
   let subtitleCallbacks = []
+  let broadcastMixADCallbacks = []
 
   let playerReadyCallback
   let playerErrorCallback
@@ -180,6 +181,10 @@ function BigscreenPlayer() {
     return subtitles ? subtitles.available() : false
   }
 
+  function callBroadcastMixADCallbacks() {
+    callCallbacks(broadcastMixADCallbacks)
+  }
+
   return /** @alias module:bigscreenplayer/bigscreenplayer */ {
     /**
      * Call first to initialise bigscreen player for playback.
@@ -254,6 +259,7 @@ function BigscreenPlayer() {
       stateChangeCallbacks = []
       timeUpdateCallbacks = []
       subtitleCallbacks = []
+      broadcastMixADCallbacks = []
       endOfStream = undefined
       mediaKind = undefined
       pauseTrigger = undefined
@@ -327,6 +333,28 @@ function BigscreenPlayer() {
       const indexOf = subtitleCallbacks.indexOf(callback)
       if (indexOf !== -1) {
         subtitleCallbacks.splice(indexOf, 1)
+      }
+    },
+
+    /**
+     * Pass a function to be called whenever BroadcastMixAD is enabled or disabled.
+     * @function
+     * @param {Function} callback
+     */
+    registerForBroadcastMixADChanges: (callback) => {
+      broadcastMixADCallbacks.push(callback)
+      return callback
+    },
+
+    /**
+     * Unregisters a previously registered callback for changes to BroadcastMixAD.
+     * @function
+     * @param {Function} callback
+     */
+    unregisterForBroadcastMixADChanges: (callback) => {
+      const indexOf = broadcastMixADCallbacks.indexOf(callback)
+      if (indexOf !== -1) {
+        broadcastMixADCallbacks.splice(indexOf, 1)
       }
     },
 
@@ -567,12 +595,10 @@ function BigscreenPlayer() {
     /**
      * @function
      */
-    setBroadcastMixADOn: () => playerComponent && playerComponent.setBroadcastMixADOn(),
-
-    /**
-     * @function
-     */
-    setBroadcastMixADOff: () => playerComponent && playerComponent.setBroadcastMixADOff(),
+    setBroadcastMixADEnabled: (enabled) => {
+      enabled ? playerComponent.setBroadcastMixADOn() : playerComponent.setBroadcastMixADOff()
+      callBroadcastMixADCallbacks()
+    },
 
     /**
      *

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -554,25 +554,25 @@ function BigscreenPlayer() {
 
     /**
      * @function
-     * @returns {boolean} true if there if an ADSimulcast trackis available
+     * @returns {boolean} true if there if an BroadcastMixAD track is available
      */
-    isADSimulcastAvailable: () => playerComponent && playerComponent.isADSimulcastAvailable(),
+    isBroadcastMixADAvailable: () => playerComponent && playerComponent.isBroadcastMixADAvailable(),
 
     /**
      * @function
      * @returns {boolean} true if there is an the AD audio track is current being used
      */
-    isADSimulcastEnabled: () => playerComponent && playerComponent.isADSimulcastEnabled(),
+    isBroadcastMixADEnabled: () => playerComponent && playerComponent.isBroadcastMixADEnabled(),
 
     /**
      * @function
      */
-    setADSimulcastOn: () => playerComponent && playerComponent.setADSimulcastOn(),
+    setBroadcastMixADOn: () => playerComponent && playerComponent.setBroadcastMixADOn(),
 
     /**
      * @function
      */
-    setADSimulcastOff: () => playerComponent && playerComponent.setADSimulcastOff(),
+    setBroadcastMixADOff: () => playerComponent && playerComponent.setBroadcastMixADOff(),
 
     /**
      *

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -570,6 +570,16 @@ function BigscreenPlayer() {
     },
 
     /**
+     * @function
+     * @param {"audio" | "video" | "text" | "image"} type
+     * @returns {boolean} true if there is an 'alternate' role in any of the adaptation sets for the type
+     */
+    isADAvailable(type) {
+      const tracks = this.getTracksFor(type)
+      return tracks.some((track) => track.roles.includes("alternate"))
+    },
+
+    /**
      *
      * An enum may be used to set the on-screen position of any transport controls
      * (work in progress to remove this - UI concern).

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -181,8 +181,8 @@ function BigscreenPlayer() {
     return subtitles ? subtitles.available() : false
   }
 
-  function callBroadcastMixADCallbacks() {
-    callCallbacks(broadcastMixADCallbacks)
+  function callBroadcastMixADCallbacks(enabled) {
+    callCallbacks(broadcastMixADCallbacks, { enabled })
   }
 
   return /** @alias module:bigscreenplayer/bigscreenplayer */ {
@@ -597,7 +597,7 @@ function BigscreenPlayer() {
      */
     setBroadcastMixADEnabled: (enabled) => {
       enabled ? playerComponent.setBroadcastMixADOn() : playerComponent.setBroadcastMixADOff()
-      callBroadcastMixADCallbacks()
+      callBroadcastMixADCallbacks(enabled)
     },
 
     /**

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -438,6 +438,13 @@ function BigscreenPlayer() {
 
     /**
      * @function
+     * @param {"audio" | "video" | "text" | "image"} type
+     * @returns the current track for the corresponding type
+     */
+    getCurrentTrackFor: (type) => playerComponent && playerComponent.getCurrentTrackFor(type),
+
+    /**
+     * @function
      * @param {Number} id of the track
      * @param {"audio" | "video" | "text" | "image"} type
      */
@@ -571,12 +578,21 @@ function BigscreenPlayer() {
 
     /**
      * @function
-     * @param {"audio" | "video" | "text" | "image"} type
-     * @returns {boolean} true if there is an 'alternate' role in any of the adaptation sets for the type
+     * @returns {boolean} true if there is an 'alternate' role in any of the adaptation sets for the audio type
      */
-    isADAvailable(type) {
-      const tracks = this.getTracksFor(type)
+    isADAvailable() {
+      const tracks = this.getTracksFor("audio")
       return tracks.some((track) => track.roles.includes("alternate"))
+    },
+
+    /**
+     * @function
+     * @returns {boolean} true if there is an the AD audio track is current being used
+     */
+    isADEnabled() {
+      if (!this.isADAvailable()) return false
+      const currentAudioTrack = this.getCurrentTrackFor("audio")
+      return currentAudioTrack ? currentAudioTrack.roles.includes("alternate") : false
     },
 
     /**

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -431,30 +431,6 @@ function BigscreenPlayer() {
 
     /**
      * @function
-     * @param {"audio" | "video" | "text" | "image"} type
-     * @returns all the tracks for the corresponding type
-     */
-    getTracksFor: (type) => playerComponent && playerComponent.getTracksFor(type),
-
-    /**
-     * @function
-     * @param {"audio" | "video" | "text" | "image"} type
-     * @returns the current track for the corresponding type
-     */
-    getCurrentTrackFor: (type) => playerComponent && playerComponent.getCurrentTrackFor(type),
-
-    /**
-     * @function
-     * @param {Number} id of the track
-     * @param {"audio" | "video" | "text" | "image"} type
-     */
-    setCurrentTrack(id, type) {
-      const track = this.getTracksFor(type).find((track) => track.id === id)
-      playerComponent && playerComponent.setCurrentTrack(track)
-    },
-
-    /**
-     * @function
      * @returns if the player is paused.
      */
     isPaused: () => (playerComponent ? playerComponent.isPaused() : true),
@@ -578,22 +554,25 @@ function BigscreenPlayer() {
 
     /**
      * @function
-     * @returns {boolean} true if there is an 'alternate' role in any of the adaptation sets for the audio type
+     * @returns {boolean} true if there if an ADSimulcast trackis available
      */
-    isADAvailable() {
-      const tracks = this.getTracksFor("audio")
-      return tracks.some((track) => track.roles.includes("alternate"))
-    },
+    isADSimulcastAvailable: () => playerComponent && playerComponent.isADSimulcastAvailable(),
 
     /**
      * @function
      * @returns {boolean} true if there is an the AD audio track is current being used
      */
-    isADEnabled() {
-      if (!this.isADAvailable()) return false
-      const currentAudioTrack = this.getCurrentTrackFor("audio")
-      return currentAudioTrack ? currentAudioTrack.roles.includes("alternate") : false
-    },
+    isADSimulcastEnabled: () => playerComponent && playerComponent.isADSimulcastEnabled(),
+
+    /**
+     * @function
+     */
+    setADSimulcastOn: () => playerComponent && playerComponent.setADSimulcastOn(),
+
+    /**
+     * @function
+     */
+    setADSimulcastOff: () => playerComponent && playerComponent.setADSimulcastOff(),
 
     /**
      *

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -598,7 +598,6 @@ function BigscreenPlayer() {
      */
     setBroadcastMixADEnabled: (enabled) => {
       enabled ? playerComponent.setBroadcastMixADOn() : playerComponent.setBroadcastMixADOff()
-      callBroadcastMixADCallbacks(enabled)
     },
 
     /**

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -133,7 +133,8 @@ function BigscreenPlayer() {
       mediaSources,
       windowType,
       mediaStateUpdateCallback,
-      playerErrorCallback
+      playerErrorCallback,
+      callBroadcastMixADCallbacks
     )
 
     subtitles = Subtitles(

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -431,6 +431,23 @@ function BigscreenPlayer() {
 
     /**
      * @function
+     * @param {"audio" | "video" | "text" | "image"} type
+     * @returns all the tracks for the corresponding type
+     */
+    getTracksFor: (type) => playerComponent && playerComponent.getTracksFor(type),
+
+    /**
+     * @function
+     * @param {Number} id of the track
+     * @param {"audio" | "video" | "text" | "image"} type
+     */
+    setCurrentTrack(id, type) {
+      const track = this.getTracksFor(type).find((track) => track.id === id)
+      playerComponent && playerComponent.setCurrentTrack(track)
+    },
+
+    /**
+     * @function
      * @returns if the player is paused.
      */
     isPaused: () => (playerComponent ? playerComponent.isPaused() : true),

--- a/src/bigscreenplayer.test.js
+++ b/src/bigscreenplayer.test.js
@@ -1260,10 +1260,12 @@ describe("Bigscreen Player", () => {
       bigscreenPlayer.setBroadcastMixADEnabled(true)
 
       expect(mockPlayerComponentInstance.setBroadcastMixADOn).toHaveBeenCalledTimes(1)
+      expect(mockPlayerComponentInstance.setBroadcastMixADOff).toHaveBeenCalledTimes(0)
 
       bigscreenPlayer.setBroadcastMixADEnabled(false)
 
       expect(mockPlayerComponentInstance.setBroadcastMixADOn).toHaveBeenCalledTimes(1)
+      expect(mockPlayerComponentInstance.setBroadcastMixADOff).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/bigscreenplayer.test.js
+++ b/src/bigscreenplayer.test.js
@@ -141,6 +141,10 @@ describe("Bigscreen Player", () => {
       getWindowEndTime: jest.fn(),
       setPlaybackRate: jest.fn(),
       getPlaybackRate: jest.fn(),
+      isBroadcastMixADAvailable: jest.fn(),
+      isBroadcastMixADEnabled: jest.fn(),
+      setBroadcastMixADOn: jest.fn(),
+      setBroadcastMixADOff: jest.fn(),
     }
 
     jest.spyOn(PlayerComponent, "getLiveSupport").mockReturnValue(LiveSupport.SEEKABLE)
@@ -1247,6 +1251,39 @@ describe("Bigscreen Player", () => {
       bigscreenPlayer.clearResize()
 
       expect(mockSubtitlesInstance.hide).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("setBroadcastMixADEnabled", () => {
+    it("should turn broadcastMixAD on/off when a value is passed in", () => {
+      initialiseBigscreenPlayer()
+      bigscreenPlayer.setBroadcastMixADEnabled(true)
+
+      expect(mockPlayerComponentInstance.setBroadcastMixADOn).toHaveBeenCalledTimes(1)
+
+      bigscreenPlayer.setBroadcastMixADEnabled(false)
+
+      expect(mockPlayerComponentInstance.setBroadcastMixADOn).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("isBroadcastMixADEnabled", () => {
+    it("calls through to playercomponent enabled when called", () => {
+      initialiseBigscreenPlayer()
+
+      bigscreenPlayer.isBroadcastMixADEnabled()
+
+      expect(mockPlayerComponentInstance.isBroadcastMixADEnabled).toHaveBeenCalled()
+    })
+  })
+
+  describe("isBroadcastMixADAvailable", () => {
+    it("calls through to playercomponent available when called", () => {
+      initialiseBigscreenPlayer()
+
+      bigscreenPlayer.isBroadcastMixADAvailable()
+
+      expect(mockPlayerComponentInstance.isBroadcastMixADAvailable).toHaveBeenCalled()
     })
   })
 

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -455,9 +455,10 @@ function MSEStrategy(
   }
 
   function onCurrentTrackChanged(event) {
+    const mediaType = event.newMediaInfo.type
     DebugTool.info(
-      `${event.mediaType} track changed.${
-        event.mediaType === "audio" ? (isBroadcastMixADEnabled() ? " BroadcastMixAD on." : " BroadcastMixAD off.") : ""
+      `${mediaType} track changed.${
+        mediaType === "audio" ? (isBroadcastMixADEnabled() ? " BroadcastMixAD on." : " BroadcastMixAD off.") : ""
       }`
     )
     callBroadcastMixADCallbacks(isBroadcastMixADEnabled())

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -710,6 +710,8 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     load,
     getSeekableRange,
     getCurrentTime,
+    getTracksFor: (type) => mediaPlayer.getTracksFor(type),
+    setCurrentTrack: (track) => mediaPlayer.setCurrentTrack(track),
     getDuration,
     getPlayerElement: () => mediaElement,
     tearDown: () => {

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -720,6 +720,7 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     getSeekableRange,
     getCurrentTime,
     getTracksFor: (type) => mediaPlayer.getTracksFor(type),
+    getCurrentTrackFor: (type) => mediaPlayer.getCurrentTrackFor(type),
     setCurrentTrack: (track) => mediaPlayer.setCurrentTrack(track),
     getDuration,
     getPlayerElement: () => mediaElement,

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -456,8 +456,8 @@ function MSEStrategy(
 
   function onTrackChangeRendered(event) {
     DebugTool.info(
-      `${event.mediaType} track changed. ${
-        event.mediaType === "audio" ? (isBroadcastMixADEnabled() ? "BroadcastMixAD on." : "BroadcastMixAD off.") : ""
+      `${event.mediaType} track changed.${
+        event.mediaType === "audio" ? (isBroadcastMixADEnabled() ? " BroadcastMixAD on." : " BroadcastMixAD off.") : ""
       }`
     )
     callBroadcastMixADCallbacks(isBroadcastMixADEnabled())
@@ -701,7 +701,6 @@ function MSEStrategy(
   }
 
   function isBroadcastMixADEnabled() {
-    if (!isBroadcastMixADAvailable()) return false
     const currentAudioTrack = mediaPlayer.getCurrentTrackFor("audio")
     return currentAudioTrack ? isTrackBroadcastMixAD(currentAudioTrack) : false
   }

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -106,7 +106,7 @@ function MSEStrategy(
     STREAM_INITIALIZED: "streamInitialized",
     FRAGMENT_CONTENT_LENGTH_MISMATCH: "fragmentContentLengthMismatch",
     QUOTA_EXCEEDED: "quotaExceeded",
-    TRACK_CHANGE_RENDERED: "trackChangeRendered",
+    CURRENT_TRACK_CHANGED: "currentTrackChanged",
   }
 
   function onLoadedMetaData() {
@@ -454,7 +454,7 @@ function MSEStrategy(
     Plugins.interface.onFragmentContentLengthMismatch(event)
   }
 
-  function onTrackChangeRendered(event) {
+  function onCurrentTrackChanged(event) {
     DebugTool.info(
       `${event.mediaType} track changed.${
         event.mediaType === "audio" ? (isBroadcastMixADEnabled() ? " BroadcastMixAD on." : " BroadcastMixAD off.") : ""
@@ -590,7 +590,7 @@ function MSEStrategy(
     mediaPlayer.on(DashJSEvents.GAP_JUMP_TO_END, onGapJump)
     mediaPlayer.on(DashJSEvents.QUOTA_EXCEEDED, onQuotaExceeded)
     mediaPlayer.on(DashJSEvents.MANIFEST_LOADING_FINISHED, manifestLoadingFinished)
-    mediaPlayer.on(DashJSEvents.TRACK_CHANGE_RENDERED, onTrackChangeRendered)
+    mediaPlayer.on(DashJSEvents.CURRENT_TRACK_CHANGED, onCurrentTrackChanged)
   }
 
   function manifestLoadingFinished(event) {
@@ -736,7 +736,7 @@ function MSEStrategy(
       mediaPlayer.off(DashJSEvents.GAP_JUMP, onGapJump)
       mediaPlayer.off(DashJSEvents.GAP_JUMP_TO_END, onGapJump)
       mediaPlayer.off(DashJSEvents.QUOTA_EXCEEDED, onQuotaExceeded)
-      mediaPlayer.off(DashJSEvents.TRACK_CHANGE_RENDERED, onTrackChangeRendered)
+      mediaPlayer.off(DashJSEvents.TRACK_CHANGE_RENDERED, onCurrentTrackChanged)
 
       mediaPlayer = undefined
     }

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -97,6 +97,7 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     STREAM_INITIALIZED: "streamInitialized",
     FRAGMENT_CONTENT_LENGTH_MISMATCH: "fragmentContentLengthMismatch",
     QUOTA_EXCEEDED: "quotaExceeded",
+    TRACK_CHANGE_RENDERED: "trackChangeRendered",
   }
 
   function onLoadedMetaData() {
@@ -444,6 +445,12 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     Plugins.interface.onFragmentContentLengthMismatch(event)
   }
 
+  function onTrackChangeRendered(event) {
+    DebugTool.info(
+      `${event.mediaType} track changed. ${event.newMediaInfo.roles.includes("alternate") ? "AD on." : "AD off."}`
+    )
+  }
+
   function publishMediaState(mediaState) {
     for (let index = 0; index < eventCallbacks.length; index++) {
       eventCallbacks[index](mediaState)
@@ -563,6 +570,7 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     mediaPlayer.on(DashJSEvents.GAP_JUMP_TO_END, onGapJump)
     mediaPlayer.on(DashJSEvents.QUOTA_EXCEEDED, onQuotaExceeded)
     mediaPlayer.on(DashJSEvents.MANIFEST_LOADING_FINISHED, manifestLoadingFinished)
+    mediaPlayer.on(DashJSEvents.TRACK_CHANGE_RENDERED, onTrackChangeRendered)
   }
 
   function manifestLoadingFinished(event) {
@@ -671,6 +679,7 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
       mediaPlayer.off(DashJSEvents.GAP_JUMP, onGapJump)
       mediaPlayer.off(DashJSEvents.GAP_JUMP_TO_END, onGapJump)
       mediaPlayer.off(DashJSEvents.QUOTA_EXCEEDED, onQuotaExceeded)
+      mediaPlayer.off(DashJSEvents.TRACK_CHANGE_RENDERED, onTrackChangeRendered)
 
       mediaPlayer = undefined
     }

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -446,7 +446,7 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
   }
 
   function onTrackChangeRendered(event) {
-    DebugTool.info(`${event.mediaType} track changed. ${isADSimulcastEnabled() ? "AD on." : "AD off."}`)
+    DebugTool.info(`${event.mediaType} track changed. ${isBroadcastMixADEnabled() ? "AD on." : "AD off."}`)
   }
 
   function publishMediaState(mediaState) {
@@ -659,7 +659,7 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     )
   }
 
-  function isTrackADSimulcast(track) {
+  function isTrackBroadcastMixAD(track) {
     return (
       track.roles.includes("alternate") &&
       track.accessibilitiesWithSchemeIdUri.some(
@@ -668,33 +668,33 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     )
   }
 
-  function getADSimulcastTrack() {
+  function getBroadcastMixADTrack() {
     const tracks = mediaPlayer.getTracksFor("audio")
-    return tracks.find((track) => isTrackADSimulcast(track))
+    return tracks.find((track) => isTrackBroadcastMixAD(track))
   }
 
-  function isADSimulcastAvailable() {
+  function isBroadcastMixADAvailable() {
     const tracks = mediaPlayer.getTracksFor("audio")
-    return tracks.some((track) => isTrackADSimulcast(track))
+    return tracks.some((track) => isTrackBroadcastMixAD(track))
   }
 
-  function isADSimulcastEnabled() {
-    if (!isADSimulcastAvailable()) return false
+  function isBroadcastMixADEnabled() {
+    if (!isBroadcastMixADAvailable()) return false
     const currentAudioTrack = mediaPlayer.getCurrentTrackFor("audio")
-    return currentAudioTrack ? isTrackADSimulcast(currentAudioTrack) : false
+    return currentAudioTrack ? isTrackBroadcastMixAD(currentAudioTrack) : false
   }
 
-  function setADSimulcastOff() {
-    if (isADSimulcastEnabled()) {
+  function setBroadcastMixADOff() {
+    if (isBroadcastMixADEnabled()) {
       const audioTracks = mediaPlayer.getTracksFor("audio")
       const mainTrack = audioTracks.find((track) => track.roles.includes("main"))
       mediaPlayer.setCurrentTrack(mainTrack)
     }
   }
 
-  function setADSimulcastOn() {
-    if (!isADSimulcastEnabled()) {
-      const ADTrack = getADSimulcastTrack()
+  function setBroadcastMixADOn() {
+    if (!isBroadcastMixADEnabled()) {
+      const ADTrack = getBroadcastMixADTrack()
       if (ADTrack) {
         mediaPlayer.setCurrentTrack(ADTrack)
       }
@@ -759,10 +759,10 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     load,
     getSeekableRange,
     getCurrentTime,
-    isADSimulcastAvailable,
-    isADSimulcastEnabled,
-    setADSimulcastOn,
-    setADSimulcastOff,
+    isBroadcastMixADAvailable,
+    isBroadcastMixADEnabled,
+    setBroadcastMixADOn,
+    setBroadcastMixADOff,
     getDuration,
     getPlayerElement: () => mediaElement,
     tearDown: () => {

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -26,7 +26,8 @@ function MSEStrategy(
   playbackElement,
   isUHD,
   enableBroadcastMixAD,
-  customPlayerSettings
+  customPlayerSettings,
+  callBroadcastMixADCallbacks
 ) {
   let mediaPlayer
   let mediaElement
@@ -316,6 +317,7 @@ function MSEStrategy(
 
     if (isBroadcastMixADAvailable() && enableBroadcastMixAD) {
       setBroadcastMixADOn()
+      callBroadcastMixADCallbacks(true)
     }
 
     emitPlayerInfo()

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -19,7 +19,15 @@ const DEFAULT_SETTINGS = {
   seekDurationPadding: 1.1,
 }
 
-function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD, customPlayerSettings) {
+function MSEStrategy(
+  mediaSources,
+  windowType,
+  mediaKind,
+  playbackElement,
+  isUHD,
+  enableBroadcastMixAD,
+  customPlayerSettings
+) {
   let mediaPlayer
   let mediaElement
 
@@ -304,6 +312,10 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
     if (setMseDuration && (windowType === WindowTypes.SLIDING || windowType === WindowTypes.GROWING)) {
       // Workaround for no setLiveSeekableRange/clearLiveSeekableRange
       mediaPlayer.setMediaDuration(Number.MAX_SAFE_INTEGER)
+    }
+
+    if (isBroadcastMixADAvailable() && enableBroadcastMixAD) {
+      setBroadcastMixADOn()
     }
 
     emitPlayerInfo()
@@ -670,12 +682,12 @@ function MSEStrategy(mediaSources, windowType, mediaKind, playbackElement, isUHD
 
   function getBroadcastMixADTrack() {
     const audioTracks = mediaPlayer.getTracksFor("audio")
-    return audioTracks.find((track) => isTrackBroadcastMixAD(track))
+    return audioTracks?.find((track) => isTrackBroadcastMixAD(track))
   }
 
   function isBroadcastMixADAvailable() {
     const audioTracks = mediaPlayer.getTracksFor("audio")
-    return audioTracks.some((track) => isTrackBroadcastMixAD(track))
+    return audioTracks?.some((track) => isTrackBroadcastMixAD(track))
   }
 
   function isBroadcastMixADEnabled() {

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -697,19 +697,15 @@ function MSEStrategy(
   }
 
   function setBroadcastMixADOff() {
-    if (isBroadcastMixADEnabled()) {
-      const audioTracks = mediaPlayer.getTracksFor("audio")
-      const mainTrack = audioTracks.find((track) => track.roles.includes("main"))
-      mediaPlayer.setCurrentTrack(mainTrack)
-    }
+    const audioTracks = mediaPlayer.getTracksFor("audio")
+    const mainTrack = audioTracks.find((track) => track.roles.includes("main"))
+    mediaPlayer.setCurrentTrack(mainTrack)
   }
 
   function setBroadcastMixADOn() {
-    if (!isBroadcastMixADEnabled()) {
-      const ADTrack = getBroadcastMixADTrack()
-      if (ADTrack) {
-        mediaPlayer.setCurrentTrack(ADTrack)
-      }
+    const ADTrack = getBroadcastMixADTrack()
+    if (ADTrack) {
+      mediaPlayer.setCurrentTrack(ADTrack)
     }
   }
 

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -593,7 +593,10 @@ describe("Media Source Extensions Playback Strategy", () => {
       setUpMSE(undefined, undefined, undefined, undefined, undefined, undefined, true)
       mseStrategy.load(WindowTypes.STATIC, 10)
 
-      expect(mockDashInstance.setInitialMediaSettingsFor).toHaveBeenCalled()
+      expect(mockDashInstance.setInitialMediaSettingsFor).toHaveBeenCalledWith("audio", {
+        accessibility: { schemeIdUri: "urn:tva:metadata:cs:AudioPurposeCS:2007", value: "1" },
+        role: "alternate",
+      })
     })
 
     it("does not set initial audio track settings when enableBroadcastMixAD is false", () => {

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -1209,7 +1209,7 @@ describe("Media Source Extensions Playback Strategy", () => {
     })
 
     describe("onTrackChangeRendered", () => {
-      it("should ensure debugTool is called with true and callbacks are called with true when the current track is broadcastMixAD", () => {
+      it("should ensure callbacks are called with enabled true when the current track is broadcastMixAD", () => {
         mockDashInstance.getCurrentTrackFor.mockReturnValue(broadcastMixADtrack)
         const callBroadcastMixADCallbacksMock = jest.fn()
         setUpMSE(
@@ -1226,11 +1226,10 @@ describe("Media Source Extensions Playback Strategy", () => {
 
         dashEventCallback(dashjsMediaPlayerEvents.TRACK_CHANGE_RENDERED, { mediaType: "audio" })
 
-        expect(DebugTool.info).toHaveBeenCalledWith("audio track changed. BroadcastMixAD on.")
         expect(callBroadcastMixADCallbacksMock).toHaveBeenCalledWith(true)
       })
 
-      it("should ensure debugTool is called with false and callbacks are called with false when the current track is not broadcastMixAD", () => {
+      it("should ensure callbacks are called with enabled false when the current track is not broadcastMixAD", () => {
         mockDashInstance.getCurrentTrackFor.mockReturnValue(mainTrack)
         const callBroadcastMixADCallbacksMock = jest.fn()
         setUpMSE(
@@ -1247,16 +1246,7 @@ describe("Media Source Extensions Playback Strategy", () => {
 
         dashEventCallback(dashjsMediaPlayerEvents.TRACK_CHANGE_RENDERED, { mediaType: "audio" })
 
-        expect(DebugTool.info).toHaveBeenCalledWith("audio track changed. BroadcastMixAD off.")
         expect(callBroadcastMixADCallbacksMock).toHaveBeenCalledWith(false)
-      })
-
-      it("debug tool does not include broadcastMixAD when mediaType is not audio", () => {
-        mockDashInstance.getCurrentTrackFor.mockReturnValueOnce(mainTrack)
-
-        dashEventCallback(dashjsMediaPlayerEvents.TRACK_CHANGE_RENDERED, { mediaType: "video" })
-
-        expect(DebugTool.info).toHaveBeenCalledWith("video track changed.")
       })
     })
   })

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -42,6 +42,9 @@ const mockDashInstance = {
   getActiveStream: jest.fn(() => ({
     getProcessors: jest.fn(() => []),
   })),
+  getTracksFor: jest.fn(),
+  getCurrentTrackFor: jest.fn(),
+  setCurrentTrack: jest.fn(),
 }
 
 const mockDashMediaPlayer = {
@@ -178,6 +181,7 @@ describe("Media Source Extensions Playback Strategy", () => {
       windowType ?? WindowTypes.STATIC,
       mediaKind ?? MediaKinds.VIDEO,
       playbackElement,
+      false,
       false,
       customPlayerSettings || {}
     )

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -45,6 +45,7 @@ const mockDashInstance = {
   getTracksFor: jest.fn(),
   getCurrentTrackFor: jest.fn(),
   setCurrentTrack: jest.fn(),
+  setInitialMediaSettingsFor: jest.fn(),
 }
 
 const mockDashMediaPlayer = {
@@ -182,8 +183,9 @@ describe("Media Source Extensions Playback Strategy", () => {
       mediaKind ?? MediaKinds.VIDEO,
       playbackElement,
       false,
+      customPlayerSettings || {},
       false,
-      customPlayerSettings || {}
+      () => {}
     )
   }
 

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -1154,7 +1154,7 @@ describe("Media Source Extensions Playback Strategy", () => {
 
     describe("isBroadcastMixADAvailable()", () => {
       it("returns true when there is a broadcastMixAD track", () => {
-        mockDashInstance.getTracksFor.mockReturnValueOnce([broadcastMixADtrack])
+        mockDashInstance.getTracksFor.mockReturnValueOnce([mainTrack, broadcastMixADtrack])
 
         expect(mseStrategy.isBroadcastMixADAvailable()).toBe(true)
       })
@@ -1182,7 +1182,7 @@ describe("Media Source Extensions Playback Strategy", () => {
 
     describe("setBroadcastMixADOff()", () => {
       it("switches to the main track", () => {
-        mockDashInstance.getTracksFor.mockReturnValueOnce([mainTrack])
+        mockDashInstance.getTracksFor.mockReturnValueOnce([mainTrack, broadcastMixADtrack])
 
         mseStrategy.setBroadcastMixADOff()
 
@@ -1192,7 +1192,7 @@ describe("Media Source Extensions Playback Strategy", () => {
 
     describe("setBroadcastMixADOn()", () => {
       it("switches to the broadcastMixAD track if present", () => {
-        mockDashInstance.getTracksFor.mockReturnValueOnce([broadcastMixADtrack])
+        mockDashInstance.getTracksFor.mockReturnValueOnce([mainTrack, broadcastMixADtrack])
 
         mseStrategy.setBroadcastMixADOn()
 

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -66,7 +66,7 @@ describe("Media Source Extensions Playback Strategy", () => {
     METRIC_ADDED: "metricAdded",
     METRIC_CHANGED: "metricChanged",
     FRAGMENT_CONTENT_LENGTH_MISMATCH: "fragmentContentLengthMismatch",
-    TRACK_CHANGE_RENDERED: "trackChangeRendered",
+    CURRENT_TRACK_CHANGED: "currentTrackChanged",
   }
 
   let mseStrategy
@@ -1224,7 +1224,7 @@ describe("Media Source Extensions Playback Strategy", () => {
         )
         mseStrategy.load(WindowTypes.STATIC, 10)
 
-        dashEventCallback(dashjsMediaPlayerEvents.TRACK_CHANGE_RENDERED, { mediaType: "audio" })
+        dashEventCallback(dashjsMediaPlayerEvents.CURRENT_TRACK_CHANGED, { mediaType: "audio" })
 
         expect(callBroadcastMixADCallbacksMock).toHaveBeenCalledWith(true)
       })
@@ -1244,7 +1244,7 @@ describe("Media Source Extensions Playback Strategy", () => {
         )
         mseStrategy.load(WindowTypes.STATIC, 10)
 
-        dashEventCallback(dashjsMediaPlayerEvents.TRACK_CHANGE_RENDERED, { mediaType: "audio" })
+        dashEventCallback(dashjsMediaPlayerEvents.CURRENT_TRACK_CHANGED, { mediaType: "audio" })
 
         expect(callBroadcastMixADCallbacksMock).toHaveBeenCalledWith(false)
       })

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -1224,7 +1224,7 @@ describe("Media Source Extensions Playback Strategy", () => {
         )
         mseStrategy.load(WindowTypes.STATIC, 10)
 
-        dashEventCallback(dashjsMediaPlayerEvents.CURRENT_TRACK_CHANGED, { mediaType: "audio" })
+        dashEventCallback(dashjsMediaPlayerEvents.CURRENT_TRACK_CHANGED, { newMediaInfo: { type: "audio" } })
 
         expect(callBroadcastMixADCallbacksMock).toHaveBeenCalledWith(true)
       })
@@ -1244,7 +1244,7 @@ describe("Media Source Extensions Playback Strategy", () => {
         )
         mseStrategy.load(WindowTypes.STATIC, 10)
 
-        dashEventCallback(dashjsMediaPlayerEvents.CURRENT_TRACK_CHANGED, { mediaType: "audio" })
+        dashEventCallback(dashjsMediaPlayerEvents.CURRENT_TRACK_CHANGED, { newMediaInfo: { type: "audio" } })
 
         expect(callBroadcastMixADCallbacksMock).toHaveBeenCalledWith(false)
       })

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -99,16 +99,20 @@ function PlayerComponent(
     return playbackStrategy && playbackStrategy.getSeekableRange()
   }
 
-  function getTracksFor(type) {
-    return playbackStrategy && playbackStrategy.getTracksFor(type)
+  function isADSimulcastAvailable() {
+    return playbackStrategy && playbackStrategy.isADSimulcastAvailable()
   }
 
-  function getCurrentTrackFor(type) {
-    return playbackStrategy && playbackStrategy.getCurrentTrackFor(type)
+  function isADSimulcastEnabled() {
+    return playbackStrategy && playbackStrategy.isADSimulcastEnabled()
   }
 
-  function setCurrentTrack(track) {
-    return playbackStrategy && playbackStrategy.setCurrentTrack(track)
+  function setADSimulcastOn() {
+    playbackStrategy && playbackStrategy.setADSimulcastOn()
+  }
+
+  function setADSimulcastOff() {
+    playbackStrategy && playbackStrategy.setADSimulcastOff()
   }
 
   function isPaused() {
@@ -419,9 +423,10 @@ function PlayerComponent(
     getPlayerElement,
     isPaused,
     tearDown,
-    getTracksFor,
-    getCurrentTrackFor,
-    setCurrentTrack,
+    isADSimulcastAvailable,
+    isADSimulcastEnabled,
+    setADSimulcastOn,
+    setADSimulcastOff,
   }
 }
 

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -103,6 +103,10 @@ function PlayerComponent(
     return playbackStrategy && playbackStrategy.getTracksFor(type)
   }
 
+  function getCurrentTrackFor(type) {
+    return playbackStrategy && playbackStrategy.getCurrentTrackFor(type)
+  }
+
   function setCurrentTrack(track) {
     return playbackStrategy && playbackStrategy.setCurrentTrack(track)
   }
@@ -416,6 +420,7 @@ function PlayerComponent(
     isPaused,
     tearDown,
     getTracksFor,
+    getCurrentTrackFor,
     setCurrentTrack,
   }
 }

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -14,7 +14,8 @@ function PlayerComponent(
   mediaSources,
   windowType,
   stateUpdateCallback,
-  errorCallback
+  errorCallback,
+  callBroadcastMixADCallbacks
 ) {
   const transferFormat = bigscreenPlayerData.media.transferFormat
 
@@ -39,7 +40,8 @@ function PlayerComponent(
         playbackElement,
         bigscreenPlayerData.media.isUHD,
         bigscreenPlayerData.enabledBroadcastMixAD,
-        bigscreenPlayerData.media.playerSettings
+        bigscreenPlayerData.media.playerSettings,
+        callBroadcastMixADCallbacks
       )
 
       playbackStrategy.addEventCallback(this, eventCallback)

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -39,8 +39,8 @@ function PlayerComponent(
         mediaKind,
         playbackElement,
         bigscreenPlayerData.media.isUHD,
-        bigscreenPlayerData.enableBroadcastMixAD,
         bigscreenPlayerData.media.playerSettings,
+        bigscreenPlayerData.enableBroadcastMixAD,
         callBroadcastMixADCallbacks
       )
 
@@ -103,19 +103,19 @@ function PlayerComponent(
   }
 
   function isBroadcastMixADAvailable() {
-    return playbackStrategy && playbackStrategy.isBroadcastMixADAvailable()
+    return playbackStrategy && playbackStrategy.isBroadcastMixADAvailable?.()
   }
 
   function isBroadcastMixADEnabled() {
-    return playbackStrategy && playbackStrategy.isBroadcastMixADEnabled()
+    return playbackStrategy && playbackStrategy.isBroadcastMixADEnabled?.()
   }
 
   function setBroadcastMixADOn() {
-    playbackStrategy && playbackStrategy.setBroadcastMixADOn()
+    playbackStrategy && playbackStrategy.setBroadcastMixADOn?.()
   }
 
   function setBroadcastMixADOff() {
-    playbackStrategy && playbackStrategy.setBroadcastMixADOff()
+    playbackStrategy && playbackStrategy.setBroadcastMixADOff?.()
   }
 
   function isPaused() {

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -99,20 +99,20 @@ function PlayerComponent(
     return playbackStrategy && playbackStrategy.getSeekableRange()
   }
 
-  function isADSimulcastAvailable() {
-    return playbackStrategy && playbackStrategy.isADSimulcastAvailable()
+  function isBroadcastMixADAvailable() {
+    return playbackStrategy && playbackStrategy.isBroadcastMixADAvailable()
   }
 
-  function isADSimulcastEnabled() {
-    return playbackStrategy && playbackStrategy.isADSimulcastEnabled()
+  function isBroadcastMixADEnabled() {
+    return playbackStrategy && playbackStrategy.isBroadcastMixADEnabled()
   }
 
-  function setADSimulcastOn() {
-    playbackStrategy && playbackStrategy.setADSimulcastOn()
+  function setBroadcastMixADOn() {
+    playbackStrategy && playbackStrategy.setBroadcastMixADOn()
   }
 
-  function setADSimulcastOff() {
-    playbackStrategy && playbackStrategy.setADSimulcastOff()
+  function setBroadcastMixADOff() {
+    playbackStrategy && playbackStrategy.setBroadcastMixADOff()
   }
 
   function isPaused() {
@@ -423,10 +423,10 @@ function PlayerComponent(
     getPlayerElement,
     isPaused,
     tearDown,
-    isADSimulcastAvailable,
-    isADSimulcastEnabled,
-    setADSimulcastOn,
-    setADSimulcastOff,
+    isBroadcastMixADAvailable,
+    isBroadcastMixADEnabled,
+    setBroadcastMixADOn,
+    setBroadcastMixADOff,
   }
 }
 

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -39,7 +39,7 @@ function PlayerComponent(
         mediaKind,
         playbackElement,
         bigscreenPlayerData.media.isUHD,
-        bigscreenPlayerData.enabledBroadcastMixAD,
+        bigscreenPlayerData.enableBroadcastMixAD,
         bigscreenPlayerData.media.playerSettings,
         callBroadcastMixADCallbacks
       )

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -38,6 +38,7 @@ function PlayerComponent(
         mediaKind,
         playbackElement,
         bigscreenPlayerData.media.isUHD,
+        bigscreenPlayerData.enabledBroadcastMixAD,
         bigscreenPlayerData.media.playerSettings
       )
 

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -99,6 +99,14 @@ function PlayerComponent(
     return playbackStrategy && playbackStrategy.getSeekableRange()
   }
 
+  function getTracksFor(type) {
+    return playbackStrategy && playbackStrategy.getTracksFor(type)
+  }
+
+  function setCurrentTrack(track) {
+    return playbackStrategy && playbackStrategy.setCurrentTrack(track)
+  }
+
   function isPaused() {
     return playbackStrategy && playbackStrategy.isPaused()
   }
@@ -407,6 +415,8 @@ function PlayerComponent(
     getPlayerElement,
     isPaused,
     tearDown,
+    getTracksFor,
+    setCurrentTrack,
   }
 }
 


### PR DESCRIPTION
📺 What

Makes BroadcastMixAD available for MSE devices.

🛠 How

* Adds a set of new APIs that check for the availability, whether its enabled and ability to turn it on or off.
* Adds the ability to turn BroadcastMixAD on by default (if the track exists).
* Availability is determined from the audio properties in the manifest. Accessibility schema and the alternate role.
* Use dash.js to change the tracks between BroadcastMixAD and main audio.
* Adds unit tests.

