### PR TITLE
Stash before running prepush hook tests

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+git stash push -qu
 npm test
+git stash pop -q


### PR DESCRIPTION
📺 What
Runs `git stash push -qu` before the prepush hook tests and runs `git stash pop -q` after them. This allows for unstaged in development tests to be present without having to pass whilst still verifying what is being pushed. Prevents potentially running `--no-verify` or similar to just get something pushed.

🛠 How
Source Control

✅ Testing
Tested by changing a test to fail (`expect(true).toBe(false)`) and not staging it whilst pushing this change - test was not included in index and did not affect prepush hook checks.

