### PR TITLE
fix(imsc): subtitle startup race condition

### DIFF
--- a/src/subtitles/imscsubtitles.js
+++ b/src/subtitles/imscsubtitles.js
@@ -316,7 +316,8 @@ function IMSCSubtitles(mediaPlayer, autoStart, parentElement, mediaSources, defa
   }
 
   function isValidTime(time) {
-    return time >= 0
+    // A newly loaded video element reports currentTime as 0
+    return time > 0
   }
 
   function getCurrentTime() {

--- a/src/subtitles/imscsubtitles.test.js
+++ b/src/subtitles/imscsubtitles.test.js
@@ -916,6 +916,25 @@ describe("IMSC Subtitles", () => {
         expect(LoadUrl).not.toHaveBeenCalled()
       })
 
+      it("does not load segments when currentTime is zero", () => {
+        captions = [
+          {
+            type: "application/ttml+xml",
+            url: "mock://some.media/captions/$segment$.m4s",
+            cdn: "foo",
+            segmentLength: 3.84,
+          },
+        ]
+
+        subtitles = IMSCSubtitles(mockMediaPlayer, true, targetElement, mockMediaSources, {})
+
+        mockMediaPlayer.getCurrentTime.mockReturnValue(0)
+
+        jest.advanceTimersByTime(UPDATE_INTERVAL)
+
+        expect(LoadUrl).not.toHaveBeenCalled()
+      })
+
       it("stops loading all segments when the XML transform fails for some segment", () => {
         fromXML.mockImplementationOnce(() => {
           throw new Error("An error occured during transformation.")


### PR DESCRIPTION
📺 What

Fixes a race condition between imscstrategy and the player.

🛠 How

Don't accept zero as an valid time. Drawback is subtitles load later (after the stream instead of in parallel). A more robust solution could compare the calculated segment number with the segment start number in the manifest.
