### PR TITLE
 Add Guards Around Setting `cached.currentTime`

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -489,7 +489,9 @@ function MSEStrategy(
     if (mediaPlayer) {
       modifySource(cached.currentTime)
     } else {
-      cached.currentTime = presentationTimeInSeconds
+      if (typeof presentationTimeInSeconds === "number" && isFinite(presentationTimeInSeconds)) {
+        cached.currentTime = presentationTimeInSeconds
+      }
       setUpMediaElement(playbackElement)
       setUpMediaPlayer(presentationTimeInSeconds)
       setUpMediaListeners()
@@ -628,7 +630,7 @@ function MSEStrategy(
     const duration = mediaPlayer && mediaPlayer.isReady() && mediaPlayer.duration()
 
     // If duration is a number, return that, else return cached value (default 0)
-    if (typeof duration === "number" && !isNaN(duration)) {
+    if (typeof duration === "number" && isFinite(duration)) {
       cached.duration = duration
       return duration
     }
@@ -638,7 +640,7 @@ function MSEStrategy(
   function getCurrentTime() {
     const currentTime = mediaElement?.currentTime
 
-    if (currentTime && !isNaN(currentTime)) {
+    if (typeof currentTime === "number" && isFinite(currentTime)) {
       cached.currentTime = currentTime
       return currentTime
     }
@@ -646,7 +648,9 @@ function MSEStrategy(
   }
 
   function refreshManifestBeforeSeek(presentationTimeInSeconds) {
-    cached.currentTime = presentationTimeInSeconds
+    if (typeof presentationTimeInSeconds === "number" && isFinite(presentationTimeInSeconds)) {
+      cached.currentTime = presentationTimeInSeconds
+    }
 
     mediaPlayer.refreshManifest((manifest) => {
       const mediaPresentationDuration = manifest?.mediaPresentationDuration

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -287,6 +287,15 @@ describe("Media Source Extensions Playback Strategy", () => {
       )
       expect(mockDashInstance.on).toHaveBeenCalledWith(dashjsMediaPlayerEvents.METRIC_ADDED, expect.any(Function))
     })
+
+    it("should keep the cached current time at 0 when the load presentationTimeInSeconds is not a number", () => {
+      const mseStrategy = MSEStrategy(mockMediaSources, MediaKinds.VIDEO, playbackElement)
+
+      mseStrategy.load(null)
+
+      mediaElement.currentTime = 0
+      expect(mseStrategy.getCurrentTime()).toBe(0)
+    })
   })
 
   describe("Load when a mediaPlayer exists (e.g. CDN failover)", () => {


### PR DESCRIPTION
📺 What

Fixes an issue where `cached.currentTime` was not being set if `mediaElement.currentTime` was `0`. In situations where the `load` was called with no `initialPlaybackTime` and the `mediaElement.currentTime` was not naturally updated, the time would stay as `undefined`, causing the `readyHelper` to not call the success callback and causing BSP to be stuck in an unready state.

🛠 How

Add, correct and unify guards around the setting of `cached.currentTime` in MSE strategy to ensure the value is a number.

✅ Testing

Added a unit test covering the aforementioned scenario.