### PR TITLE
Use the Correct Name for Functions in MockBigScreenPlayer

### DIFF
--- a/src/mockbigscreenplayer.js
+++ b/src/mockbigscreenplayer.js
@@ -325,7 +325,7 @@ const mockFunctions = {
   },
   customiseSubtitles() {},
   renderSubtitleExample() {},
-  setAudioDescribedEnabled(value) {
+  setAudioDescribed(value) {
     audioDescribedEnabled = value
   },
   isAudioDescribedEnabled() {


### PR DESCRIPTION
📺 What

Corrects a function name used in `MockBigScreenPlayer`.

🛠 How

Renames `setAudioDescribedEnabled` to `setAudioDescribed` to match the actual API.
