### PR TITLE
Add Correct Initial Audio Settings

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -42,6 +42,7 @@ function MSEStrategy(
           bufferTimeAtTopQuality: 12,
           bufferTimeAtTopQualityLongForm: 15,
         },
+        lastMediaSettingsCachingInfo: { enabled: false },
       },
     },
     customPlayerSettings
@@ -530,6 +531,10 @@ function MSEStrategy(
       mediaPlayer.setInitialMediaSettingsFor("audio", {
         role: "alternate",
         accessibility: { schemeIdUri: "urn:tva:metadata:cs:AudioPurposeCS:2007", value: "1" },
+      })
+    } else {
+      mediaPlayer.setInitialMediaSettingsFor("audio", {
+        role: "main",
       })
     }
 

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -527,16 +527,17 @@ function MSEStrategy(
     mediaPlayer.updateSettings(dashSettings)
     mediaPlayer.initialize(mediaElement, null)
 
-    if (audioDescribed.enable) {
-      mediaPlayer.setInitialMediaSettingsFor("audio", {
-        role: "alternate",
-        accessibility: { schemeIdUri: "urn:tva:metadata:cs:AudioPurposeCS:2007", value: "1" },
-      })
-    } else {
-      mediaPlayer.setInitialMediaSettingsFor("audio", {
-        role: "main",
-      })
-    }
+    mediaPlayer.setInitialMediaSettingsFor(
+      "audio",
+      audioDescribed.enable
+        ? {
+            role: "alternate",
+            accessibility: { schemeIdUri: "urn:tva:metadata:cs:AudioPurposeCS:2007", value: "1" },
+          }
+        : {
+            role: "main",
+          }
+    )
 
     modifySource(presentationTimeInSeconds)
   }

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -702,7 +702,7 @@ describe("Media Source Extensions Playback Strategy", () => {
   })
 
   describe("Sets up mediaPlayer respecting audioDescribed.enable", () => {
-    it("sets audio described initial audio settings when audio described is enabled", () => {
+    it("sets initial audio settings to the audio described track when audio described is enabled", () => {
       const mseStrategy = MSEStrategy(mockMediaSources, MediaKinds.VIDEO, playbackElement, undefined, undefined, {
         enable: true,
       })
@@ -714,7 +714,7 @@ describe("Media Source Extensions Playback Strategy", () => {
       })
     })
 
-    it("sets main initial audio settings when audio described is not enabled", () => {
+    it("sets initial audio settings to main track when audio described is not enabled", () => {
       const mseStrategy = MSEStrategy(mockMediaSources, MediaKinds.VIDEO, playbackElement, undefined, undefined, {
         enable: false,
       })

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -702,7 +702,7 @@ describe("Media Source Extensions Playback Strategy", () => {
   })
 
   describe("Sets up mediaPlayer respecting audioDescribed.enable", () => {
-    it("sets initial audio track settings when audioDescribed.enable is true", () => {
+    it("sets audio described initial audio settings when audio described is enabled", () => {
       const mseStrategy = MSEStrategy(mockMediaSources, MediaKinds.VIDEO, playbackElement, undefined, undefined, {
         enable: true,
       })
@@ -714,13 +714,15 @@ describe("Media Source Extensions Playback Strategy", () => {
       })
     })
 
-    it("does not set initial audio track settings when audioDescribed.enable is false", () => {
+    it("sets main initial audio settings when audio described is not enabled", () => {
       const mseStrategy = MSEStrategy(mockMediaSources, MediaKinds.VIDEO, playbackElement, undefined, undefined, {
         enable: false,
       })
       mseStrategy.load(null, 10)
 
-      expect(mockDashInstance.setInitialMediaSettingsFor).not.toHaveBeenCalled()
+      expect(mockDashInstance.setInitialMediaSettingsFor).toHaveBeenCalledWith("audio", {
+        role: "main",
+      })
     })
   })
 


### PR DESCRIPTION
📺 What

Dash.js caches the last track used in local storage and selects the audio track based on selection priority and then max bitrate. This can result in the BroadcastMixAD (Audio Described) being selected against the users preference. This can manifest in two scenarios.

1. When the last track selected was BroadcastMixAD, the user turns off their preference out of stream and then the user plays a stream with a BroadcastMixAD track, the BroadcastMixAD track will be selected.
2. If the BroadcastMixAD track has a higher track selection priority in the manifest or has a higher max bitrate, the BroadcastMixAD audio track will be selected.

In both scenarios, the BroadcastMixAD track is selected when the users AD preference is off. This PR disables dash.js's media track caching and sets an initial audio preference.

🛠 How

- Disables `lastMediaSettingsCachingInfo`
- Sets initial audio settings to select `role: main` if Audio Described is not enabled at the start of stream.
- Adds relevant units tests.