### PR TITLE
Add releasinator config file

### DIFF
--- a/.releasinator.json
+++ b/.releasinator.json
@@ -1,0 +1,8 @@
+{
+  "publish": "release",
+  "versioning": "semver",
+  "tagPattern": "$.$.$",
+  "displayPattern": "$.$.$",
+  "enforceUserFacingLabel": false,
+  "projectType": "npm-like"
+}


### PR DESCRIPTION
📺 What

In preparation for a change to the release automation, adds a config file for the bot "releasinator" (previously tvr-buildatron)

🛠 How

Copy existing release behaviour over into a config file in the root directory.

✅ Testing 

After this change is merged, and the change to the release automation happens (likely Fri 28th March) a secondary "test" PR will be opened and merged. 
If the changes are successful a "test" release will be created and should not have any particular differences other than the name/image of the bot making the release.