### PR TITLE
Ensure play on track on switch

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -737,12 +737,16 @@ function MSEStrategy(
     const audioTracks = mediaPlayer.getTracksFor("audio")
     const mainTrack = audioTracks.find((track) => track.roles.includes("main"))
     mediaPlayer.setCurrentTrack(mainTrack)
+
+    if (isPaused()) mediaPlayer.play()
   }
 
   function setAudioDescribedOn() {
     const ADTrack = getAudioDescribedTrack()
     if (ADTrack) {
       mediaPlayer.setCurrentTrack(ADTrack)
+
+      if (isPaused()) mediaPlayer.play()
     }
   }
 


### PR DESCRIPTION
📺 What

Ensure play on track switch so strategies have consistent behaviour.

🛠 How

* Update MSE strategy to `play()` on track switch if paused.


