### PR TITLE
Add audio-quality, video-quality, and max-bitrate to the on-screen debugger

### DIFF
--- a/src/debugger/chronicle.test.ts
+++ b/src/debugger/chronicle.test.ts
@@ -88,10 +88,10 @@ describe("Chronicle", () => {
 
     chronicle.setCurrentElementTime(32)
 
-    chronicle.appendMetric("bitrate", 16)
+    chronicle.appendMetric("buffer-length", 16)
 
     expect(chronicle.retrieve()).toEqual([
-      { category: EntryCategory.METRIC, currentElementTime: 32, sessionTime: 0, kind: "bitrate", data: 16 },
+      { category: EntryCategory.METRIC, currentElementTime: 32, sessionTime: 0, kind: "buffer-length", data: 16 },
     ])
   })
 
@@ -162,29 +162,29 @@ describe("Chronicle", () => {
     it("does not record a new metric if the array value is the same", () => {
       const chronicle = new Chronicle()
 
-      chronicle.appendMetric("representation-audio", [0, 67])
+      chronicle.appendMetric("seekable-range", [0, 67])
 
       jest.advanceTimersByTime(2345)
 
-      chronicle.appendMetric("representation-audio", [0, 67])
+      chronicle.appendMetric("seekable-range", [0, 67])
 
       jest.advanceTimersByTime(3456)
       chronicle.setCurrentElementTime(0.3)
 
-      chronicle.appendMetric("representation-audio", [1, 128])
+      chronicle.appendMetric("seekable-range", [1, 128])
 
       expect(chronicle.retrieve()).toEqual([
-        expect.objectContaining({ kind: "representation-audio", data: [0, 67], sessionTime: 0, currentElementTime: 0 }),
+        expect.objectContaining({ kind: "seekable-range", data: [0, 67], sessionTime: 0, currentElementTime: 0 }),
         expect.objectContaining({
-          kind: "representation-audio",
+          kind: "seekable-range",
           data: [1, 128],
           sessionTime: 2345 + 3456,
           currentElementTime: 0.3,
         }),
       ])
 
-      expect(chronicle.getLatestMetric("representation-audio")).toMatchObject({
-        kind: "representation-audio",
+      expect(chronicle.getLatestMetric("seekable-range")).toMatchObject({
+        kind: "seekable-range",
         data: [1, 128],
       })
     })
@@ -203,13 +203,6 @@ describe("Chronicle", () => {
     it("accepts an array-like as a metric value", () => {
       const chronicle = new Chronicle()
       const code = () => chronicle.appendMetric("seekable-range", [0, 30])
-
-      expect(code).not.toThrow()
-    })
-
-    it("accepts nested array-likes as a metric value", () => {
-      const chronicle = new Chronicle()
-      const code = () => chronicle.appendMetric("representation-video", [9, 14931])
 
       expect(code).not.toThrow()
     })
@@ -285,7 +278,7 @@ describe("Chronicle", () => {
     it("accepts nested array-likes as a metric value", () => {
       const chronicle = new Chronicle()
 
-      const code = () => chronicle.setMetric("representation-audio", [0, 67])
+      const code = () => chronicle.setMetric("seekable-range", [0, 67])
 
       expect(code).not.toThrow()
     })

--- a/src/debugger/chronicle.ts
+++ b/src/debugger/chronicle.ts
@@ -36,48 +36,54 @@ type CreateMetric<Kind extends string, Data extends Primitives> = {
   data: Data
 }
 
+type AudioDownloadQuality = CreateMetric<"audio-download-quality", [qualityIndex: number, bitrate: number]>
+type AudioPlaybackQuality = CreateMetric<"audio-playback-quality", [qualityIndex: number, bitrate: number]>
+type AudioMaxQuality = CreateMetric<"audio-max-quality", [qualityIndex: number, bitrate: number]>
 type AutoResume = CreateMetric<"auto-resume", number>
 type BufferLength = CreateMetric<"buffer-length", number>
 type CDNsAvailable = CreateMetric<"cdns-available", string[]>
 type CurrentUrl = CreateMetric<"current-url", string>
 type Duration = CreateMetric<"duration", number>
-type DownloadQuality = CreateMetric<"download-quality", [kind: MediaKinds, qualityIndex: number, bitrate: number]>
 type FramesDropped = CreateMetric<"frames-dropped", number>
 type InitialPlaybackTime = CreateMetric<"initial-playback-time", [time: number, timeline: Timeline]>
-type MaxQuality = CreateMetric<"max-quality", [kind: MediaKinds, qualityIndex: number, bitrate: number]>
 type MediaElementEnded = CreateMetric<"ended", HTMLMediaElement["ended"]>
 type MediaElementPaused = CreateMetric<"paused", HTMLMediaElement["paused"]>
 type MediaElementPlaybackRate = CreateMetric<"playback-rate", HTMLMediaElement["playbackRate"]>
 type MediaElementReadyState = CreateMetric<"ready-state", HTMLMediaElement["readyState"]>
 type MediaElementSeeking = CreateMetric<"seeking", HTMLMediaElement["seeking"]>
-type PlaybackQuality = CreateMetric<"playback-quality", [kind: MediaKinds, qualityIndex: number, bitrate: number]>
 type PlaybackStrategy = CreateMetric<"strategy", string>
 type SeekableRange = CreateMetric<"seekable-range", [start: number, end: number]>
 type SubtitleCDNsAvailable = CreateMetric<"subtitle-cdns-available", string[]>
 type SubtitleCurrentUrl = CreateMetric<"subtitle-current-url", string>
 type Version = CreateMetric<"version", string>
+type VideoDownloadQuality = CreateMetric<"video-download-quality", [qualityIndex: number, bitrate: number]>
+type VideoPlaybackQuality = CreateMetric<"video-playback-quality", [qualityIndex: number, bitrate: number]>
+type VideoMaxQuality = CreateMetric<"video-max-quality", [qualityIndex: number, bitrate: number]>
 
 export type Metric =
+  | AudioDownloadQuality
+  | AudioMaxQuality
+  | AudioPlaybackQuality
   | AutoResume
   | BufferLength
   | CDNsAvailable
   | CurrentUrl
-  | DownloadQuality
   | Duration
   | FramesDropped
   | InitialPlaybackTime
-  | MaxQuality
   | MediaElementEnded
   | MediaElementPaused
   | MediaElementPlaybackRate
   | MediaElementReadyState
   | MediaElementSeeking
-  | PlaybackQuality
   | PlaybackStrategy
   | SeekableRange
   | SubtitleCDNsAvailable
   | SubtitleCurrentUrl
   | Version
+  | VideoDownloadQuality
+  | VideoMaxQuality
+  | VideoPlaybackQuality
 
 export type MetricKind = Metric["kind"]
 export type MetricForKind<Kind extends MetricKind> = Extract<Metric, { kind: Kind }>

--- a/src/debugger/chronicle.ts
+++ b/src/debugger/chronicle.ts
@@ -37,21 +37,21 @@ type CreateMetric<Kind extends string, Data extends Primitives> = {
 }
 
 type AutoResume = CreateMetric<"auto-resume", number>
-type BitRate = CreateMetric<"bitrate", number>
 type BufferLength = CreateMetric<"buffer-length", number>
 type CDNsAvailable = CreateMetric<"cdns-available", string[]>
 type CurrentUrl = CreateMetric<"current-url", string>
 type Duration = CreateMetric<"duration", number>
+type DownloadQuality = CreateMetric<"download-quality", [kind: MediaKinds, qualityIndex: number, bitrate: number]>
 type FramesDropped = CreateMetric<"frames-dropped", number>
 type InitialPlaybackTime = CreateMetric<"initial-playback-time", [time: number, timeline: Timeline]>
+type MaxQuality = CreateMetric<"max-quality", [kind: MediaKinds, qualityIndex: number, bitrate: number]>
 type MediaElementEnded = CreateMetric<"ended", HTMLMediaElement["ended"]>
 type MediaElementPaused = CreateMetric<"paused", HTMLMediaElement["paused"]>
 type MediaElementPlaybackRate = CreateMetric<"playback-rate", HTMLMediaElement["playbackRate"]>
 type MediaElementReadyState = CreateMetric<"ready-state", HTMLMediaElement["readyState"]>
 type MediaElementSeeking = CreateMetric<"seeking", HTMLMediaElement["seeking"]>
+type PlaybackQuality = CreateMetric<"playback-quality", [kind: MediaKinds, qualityIndex: number, bitrate: number]>
 type PlaybackStrategy = CreateMetric<"strategy", string>
-type RepresentationAudio = CreateMetric<"representation-audio", [qualityIndex: number, bitrate: number]>
-type RepresentationVideo = CreateMetric<"representation-video", [qualityIndex: number, bitrate: number]>
 type SeekableRange = CreateMetric<"seekable-range", [start: number, end: number]>
 type SubtitleCDNsAvailable = CreateMetric<"subtitle-cdns-available", string[]>
 type SubtitleCurrentUrl = CreateMetric<"subtitle-current-url", string>
@@ -59,21 +59,21 @@ type Version = CreateMetric<"version", string>
 
 export type Metric =
   | AutoResume
-  | BitRate
   | BufferLength
   | CDNsAvailable
   | CurrentUrl
+  | DownloadQuality
   | Duration
   | FramesDropped
   | InitialPlaybackTime
+  | MaxQuality
   | MediaElementEnded
   | MediaElementPaused
   | MediaElementPlaybackRate
   | MediaElementReadyState
   | MediaElementSeeking
+  | PlaybackQuality
   | PlaybackStrategy
-  | RepresentationAudio
-  | RepresentationVideo
   | SeekableRange
   | SubtitleCDNsAvailable
   | SubtitleCurrentUrl

--- a/src/debugger/debugtool.test.ts
+++ b/src/debugger/debugtool.test.ts
@@ -202,13 +202,13 @@ describe("initialised Debug Tool", () => {
     it("appends the metric to the log", () => {
       jest.advanceTimersByTime(1)
 
-      DebugTool.dynamicMetric("bitrate", 1000)
+      DebugTool.dynamicMetric("buffer-length", 10)
       DebugTool.dynamicMetric("seeking", true)
       DebugTool.dynamicMetric("seeking", false)
 
       expect(DebugTool.getDebugLogs()).toEqual([
         expect.objectContaining({ kind: "session-start" }),
-        expect.objectContaining({ kind: "bitrate", data: 1000 }),
+        expect.objectContaining({ kind: "buffer-length", data: 10 }),
         expect.objectContaining({ kind: "seeking", data: true }),
         expect.objectContaining({ kind: "seeking", data: false }),
       ])

--- a/src/debugger/debugtool.ts
+++ b/src/debugger/debugtool.ts
@@ -41,7 +41,7 @@ interface DebugTool {
   toggleVisibility(): void
 }
 
-function shouldDisplayEntry(entry: TimestampedEntry): boolean {
+function shouldDisplayMediaElemenEvent(entry: TimestampedEntry): boolean {
   return (
     !isTrace(entry) ||
     entry.kind !== "event" ||
@@ -81,11 +81,7 @@ function createDebugTool() {
       return
     }
 
-    if (newLogLevel === LogLevels.DEBUG) {
-      viewController.setFilters([])
-    } else {
-      viewController.setFilters([shouldDisplayEntry])
-    }
+    viewController.setFilters(newLogLevel === LogLevels.DEBUG ? [] : [shouldDisplayMediaElemenEvent])
 
     currentLogLevel = newLogLevel
   }

--- a/src/debugger/debugview.ts
+++ b/src/debugger/debugview.ts
@@ -70,16 +70,20 @@ function renderDynamicLogs(dynamic: string[]) {
   if (logContainer) logContainer.textContent = dynamic.join("\n")
 }
 
-function renderStaticLogs(staticLogs: Entry[]) {
+function renderStaticLogs(staticLogs: (Entry | null)[]) {
   staticLogs.forEach((entry) => renderStaticLog(entry))
 }
 
-function render({ dynamic: dynamicLogs, static: staticLogs }: { dynamic: string[]; static: Entry[] }) {
+function render({ dynamic: dynamicLogs, static: staticLogs }: { dynamic: string[]; static: (Entry | null)[] }) {
   renderDynamicLogs(dynamicLogs)
   renderStaticLogs(staticLogs)
 }
 
-function renderStaticLog(entry: Entry) {
+function renderStaticLog(entry: Entry | null) {
+  if (entry == null) {
+    return
+  }
+
   const { id, key, value } = entry
 
   const existingElement = document.querySelector(`#${id}`)

--- a/src/debugger/debugviewcontroller.test.ts
+++ b/src/debugger/debugviewcontroller.test.ts
@@ -19,7 +19,7 @@ describe("Debug View", () => {
     const chronicle = new Chronicle()
     controller.showView()
 
-    chronicle.appendMetric("bitrate", 0)
+    chronicle.appendMetric("buffer-length", 0)
     chronicle.appendMetric("frames-dropped", 4)
     chronicle.appendMetric("duration", 30)
 
@@ -30,7 +30,7 @@ describe("Debug View", () => {
     expect(DebugView.render).toHaveBeenCalledWith(
       expect.objectContaining({
         static: [
-          { id: "bitrate", key: "bitrate", value: 0 },
+          { id: "buffer-length", key: "buffer length", value: 0 },
           { id: "frames-dropped", key: "frames dropped", value: 4 },
           { id: "duration", key: "duration", value: 30 },
         ],
@@ -278,7 +278,7 @@ describe("Debug View", () => {
     const chronicle = new Chronicle()
     controller.showView()
 
-    chronicle.appendMetric("bitrate", 0)
+    chronicle.appendMetric("buffer-length", 0)
 
     controller.addEntries(chronicle.retrieve())
     controller.addTime({ currentElementTime: 100, sessionTime: 0 })
@@ -290,7 +290,7 @@ describe("Debug View", () => {
     expect(DebugView.render).toHaveBeenCalledTimes(1)
     expect(DebugView.render).toHaveBeenCalledWith(
       expect.objectContaining({
-        static: [{ id: "bitrate", key: "bitrate", value: 0 }],
+        static: [{ id: "buffer-length", key: "buffer length", value: 0 }],
         dynamic: ["00:00:00.000 - Video time: 100.00"],
       })
     )

--- a/src/models/mediakinds.ts
+++ b/src/models/mediakinds.ts
@@ -1,8 +1,10 @@
-export const MediaKinds = {
-  AUDIO: "audio",
-  VIDEO: "video",
-} as const
+const AUDIO = "audio" as const
+const VIDEO = "video" as const
 
+export const MediaKinds = { AUDIO, VIDEO } as const
+
+export type Audio = typeof AUDIO
+export type Video = typeof VIDEO
 export type MediaKinds = (typeof MediaKinds)[keyof typeof MediaKinds]
 
 export default MediaKinds

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -458,7 +458,7 @@ function MSEStrategy(
       DebugTool.info(
         `${abrChangePart}${
           typeof playerMetadata.playbackBitrate === "number"
-            ? `. Total playback quality is ${playerMetadata.playbackBitrate.toFixed(0)} kbps`
+            ? `. Currently playing at ${playerMetadata.playbackBitrate.toFixed(0)} kbps`
             : ""
         }`
       )

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -44,6 +44,7 @@ const mockDashInstance = {
   isReady: jest.fn(),
   getDashMetrics: jest.fn().mockReturnValue(mockDashMetrics),
   getDashAdapter: jest.fn().mockReturnValue(mockDashAdapter),
+  getQualityFor: jest.fn(),
   getBitrateInfoListFor: jest.fn(),
   getTopBitrateInfoFor: jest.fn(),
   getAverageThroughput: jest.fn(),

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -45,6 +45,7 @@ const mockDashInstance = {
   getDashMetrics: jest.fn().mockReturnValue(mockDashMetrics),
   getDashAdapter: jest.fn().mockReturnValue(mockDashAdapter),
   getBitrateInfoListFor: jest.fn(),
+  getTopBitrateInfoFor: jest.fn(),
   getAverageThroughput: jest.fn(),
   getDVRWindowSize: jest.fn(),
   updateSettings: jest.fn(),
@@ -504,6 +505,8 @@ describe("Media Source Extensions Playback Strategy", () => {
         { bitrate: 200000 },
         { bitrate: 3000000 },
       ])
+
+      mockDashInstance.getTopBitrateInfoFor.mockReturnValue({ qualityIndex: 2, bitrate: 3000000 })
 
       const mseStrategy = MSEStrategy(mockMediaSources, MediaKinds.VIDEO, playbackElement)
 


### PR DESCRIPTION
📺 What

Title. The on-screen fields are derived from Chronicle records:

- `video-download-quality`
- `video-playback-quality`
- `video-max-quality`
- `audio-download-quality`
- `audio-playback-quality`
- `audio-max-quality`

Also removes the message on quality switch rendered, and reformats the message on quality switch requested. 

🛠 How

Replaces the fields `bitrate`, `representation-audio`, and `representation-video`. Merges `playback-rate` into the `media-element-state` field in the on-screen debugger to save some vertical space.

✅ Testing

- [x] Renders on-screen debugger with on-demand stream
- [x] Renders on-screen debugger with livestream


| Test engineer sign off | :x: |
| ---------------------- | --- |

👀 See

![image](https://github.com/user-attachments/assets/825ea314-c065-44ab-9e9f-6a2a2a8f5268)
