### PR TITLE
Add new Low Latency Catchup Algorithm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/rd-dash.js#rd-low-latency-playback",
+        "dashjs": "github:bbc/dash.js#smp-v4.7.3-6",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {
@@ -5620,7 +5620,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#b83d4e3aaffedfc11fad4b438ff7c14a55c06e56",
+      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#84ad9d4d3abc3212dd6951bf44961905fc82f672",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5620,7 +5620,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#c7dae2f7e6daacfdac93f7e7df8300bac18ba071",
+      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#b83d4e3aaffedfc11fad4b438ff7c14a55c06e56",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5620,7 +5620,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#501fb69e9f714a73a32f139a1b6f22d393c2a943",
+      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#c7dae2f7e6daacfdac93f7e7df8300bac18ba071",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5620,7 +5620,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#e5d021564568a9ebc0c8d297fbca90c3e4eab734",
+      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#2634995a1205dd17756180df15b8804af3ce453b",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5620,7 +5620,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#2634995a1205dd17756180df15b8804af3ce453b",
+      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#47a2a7728f968ea402556e60ed9ab9a9c31a590b",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5620,7 +5620,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#749cecfee736f152da1538e82a1a799a1d913fe0",
+      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#e5d021564568a9ebc0c8d297fbca90c3e4eab734",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5620,7 +5620,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#47a2a7728f968ea402556e60ed9ab9a9c31a590b",
+      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#501fb69e9f714a73a32f139a1b6f22d393c2a943",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#smp-v4.7.3-5",
+        "dashjs": "github:bbc/rd-dash.js#rd-low-latency-playback",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {
@@ -5620,8 +5620,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#9ce465f3977cf9dc4ab8fd23a859a7932220d419",
-      "integrity": "sha512-eBJ0T4319L2+3Uxv8Rt8wgH6P8Q0mVmhJ4CZ8Cbpb8vN4eUdE7y/+c2n9nlnWjhuKlaGKlPMIoWP7+xS4eAh/g==",
+      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#749cecfee736f152da1538e82a1a799a1d913fe0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript-eslint": "^7.2.0"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#smp-v4.7.3-5",
+    "dashjs": "github:bbc/rd-dash.js#rd-low-latency-playback",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript-eslint": "^7.2.0"
   },
   "dependencies": {
-    "dashjs": "github:bbc/rd-dash.js#rd-low-latency-playback",
+    "dashjs": "github:bbc/dash.js#smp-v4.7.3-6",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {


### PR DESCRIPTION
📺 What

Updates version of Dash.js

🛠 How

Updates the version of Dash.js to `smp-v4.7.3-6` which adds a new catchup mechanism for low latency that switches playback rates in steps instead of on a continuum. This catchup mechanism is expected to be better supported by TVs.

Additionally, introduces a `liveThreshold` to indicate when the user is too far away from the bleeding edge to be considered live.

Fixes issues preventing `maxDrift` from being disabled

Finally, ensures synthetic stalls behave as expected when using catchup in low-latency mode