### PR TITLE
Use full entrypoint of dash.js, allow protection data to be used

### DIFF
--- a/src/mediasources.ts
+++ b/src/mediasources.ts
@@ -1,4 +1,4 @@
-import type { CaptionsConnection, Connection, MediaDescriptor } from "./types"
+import type { CaptionsConnection, Connection, MediaDescriptor, MediaProtectionData } from "./types"
 
 import PlaybackUtils from "./utils/playbackutils"
 import Plugins from "./plugins"
@@ -37,6 +37,7 @@ function MediaSources() {
 
   let subtitlesSources: CaptionsConnection[] = []
   let current: SourceType = SourceType.MEDIA
+  let protectionData: MediaProtectionData | null = null
 
   let failoverResetTokens: number[] = []
   let time: TimeInfo | null = null
@@ -66,6 +67,8 @@ function MediaSources() {
 
       sources[SourceType.MEDIA] = PlaybackUtils.cloneArray(media.urls ?? []) as Connection[]
       sources[SourceType.AUDIO_DESCRIBED] = PlaybackUtils.cloneArray(media.audioDescribed ?? []) as Connection[]
+
+      protectionData = media.protectionData || null
 
       subtitlesSources = PlaybackUtils.cloneArray(media.captions ?? []) as CaptionsConnection[]
 
@@ -234,6 +237,10 @@ function MediaSources() {
       })
   }
 
+  function getCurrentProtectionData(): MediaProtectionData | null {
+    return protectionData
+  }
+
   function getCurrentUrl(): string {
     return sources[current].length > 0 ? sources[current][0].url.toString() : ""
   }
@@ -367,6 +374,7 @@ function MediaSources() {
     currentSubtitlesSource: getCurrentSubtitlesUrl,
     currentSubtitlesSegmentLength: getCurrentSubtitlesSegmentLength,
     currentSubtitlesCdn: getCurrentSubtitlesCdn,
+    currentProtectionData: getCurrentProtectionData,
     subtitlesRequestTimeout: getSubtitlesRequestTimeout,
     availableSources: availableUrls,
     failoverResetTime,

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -1,4 +1,4 @@
-import { MediaPlayer } from "dashjs/index_mediaplayerOnly"
+import { MediaPlayer } from "dashjs"
 import MediaState from "../models/mediastate"
 import DebugTool from "../debugger/debugtool"
 import MediaKinds from "../models/mediakinds"

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -527,9 +527,15 @@ function MSEStrategy(
 
   function setUpMediaPlayer(presentationTimeInSeconds) {
     const dashSettings = getDashSettings(playerSettings)
+    const protectionData = mediaSources.currentProtectionData()
 
     mediaPlayer = MediaPlayer().create()
     mediaPlayer.updateSettings(dashSettings)
+
+    if (protectionData) {
+      mediaPlayer.setProtectionData(protectionData)
+    }
+
     mediaPlayer.initialize(mediaElement, null)
 
     mediaPlayer.setInitialMediaSettingsFor(

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -1,4 +1,4 @@
-import { MediaPlayer } from "dashjs"
+import { MediaPlayer } from "dashjs/index"
 import MediaState from "../models/mediastate"
 import DebugTool from "../debugger/debugtool"
 import MediaKinds from "../models/mediakinds"

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -1,4 +1,4 @@
-import { MediaPlayer } from "dashjs/index_mediaplayerOnly"
+import { MediaPlayer } from "dashjs"
 import ManifestModifier from "../manifest/manifestmodifier"
 import MediaKinds from "../models/mediakinds"
 import { ManifestType } from "../models/manifesttypes"
@@ -8,7 +8,7 @@ import { autoResumeAtStartOfRange } from "../dynamicwindowutils"
 import Plugins from "../plugins"
 import MSEStrategy from "./msestrategy"
 
-jest.mock("dashjs/index_mediaplayerOnly", () => ({ MediaPlayer: jest.fn() }))
+jest.mock("dashjs", () => ({ MediaPlayer: jest.fn() }))
 jest.mock("../dynamicwindowutils")
 jest.mock("../debugger/debugtool")
 jest.mock("../manifest/manifestmodifier")
@@ -74,6 +74,7 @@ const mockMediaSources = {
   time: jest.fn(),
   failoverResetTime: jest.fn().mockReturnValue(10),
   currentSource: jest.fn().mockReturnValue(""),
+  currentProtectionData: jest.fn(),
   availableSources: jest.fn().mockReturnValue([]),
   failover: jest.fn().mockResolvedValue(),
 }

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -1,4 +1,4 @@
-import { MediaPlayer } from "dashjs"
+import { MediaPlayer } from "dashjs/index"
 import ManifestModifier from "../manifest/manifestmodifier"
 import MediaKinds from "../models/mediakinds"
 import { ManifestType } from "../models/manifesttypes"
@@ -8,7 +8,7 @@ import { autoResumeAtStartOfRange } from "../dynamicwindowutils"
 import Plugins from "../plugins"
 import MSEStrategy from "./msestrategy"
 
-jest.mock("dashjs", () => ({ MediaPlayer: jest.fn() }))
+jest.mock("dashjs/index", () => ({ MediaPlayer: jest.fn() }))
 jest.mock("../dynamicwindowutils")
 jest.mock("../debugger/debugtool")
 jest.mock("../manifest/manifestmodifier")

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -64,6 +64,7 @@ const mockDashInstance = {
   setCurrentTrack: jest.fn(),
   setInitialMediaSettingsFor: jest.fn(),
   setAutoPlay: jest.fn(),
+  setProtectionData: jest.fn(),
 }
 
 const mockDashMediaPlayer = {
@@ -246,6 +247,19 @@ describe("Media Source Extensions Playback Strategy", () => {
           streaming: expect.objectContaining({ seekDurationPadding }),
         })
       )
+    })
+
+    it("should use currentProtectionData when available", () => {
+      const mockData = { mockKey: "some-data" }
+      mockMediaSources.currentProtectionData.mockReturnValueOnce(mockData)
+
+      const mseStrategy = MSEStrategy(mockMediaSources, MediaKinds.VIDEO, playbackElement)
+
+      mseStrategy.load(null, 0)
+
+      expect(mockMediaSources.currentProtectionData).toHaveBeenCalled()
+      expect(mockDashInstance.setProtectionData).toHaveBeenCalledWith(mockData)
+      expect(mockDashInstance.initialize).toHaveBeenCalledWith(mediaElement, null)
     })
 
     it("should initialise MediaPlayer with a source anchor when time is zero", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { type MediaPlayerSettingClass } from "dashjs"
+import { ProtectionDataSet, type MediaPlayerSettingClass } from "dashjs"
 import { type Timeline } from "./models/timeline"
 
 export type Connection = {
@@ -34,6 +34,8 @@ export type PlaybackTime = {
   timeline: Timeline
 }
 
+export type MediaProtectionData = ProtectionDataSet
+
 export type MediaDescriptor = {
   kind: "audio" | "video"
   /** f.ex. 'video/mp4' */
@@ -41,6 +43,7 @@ export type MediaDescriptor = {
   /** source type. f.ex. 'application/dash+xml' */
   type: string
   urls: Connection[]
+  protectionData?: MediaProtectionData
   captions?: CaptionsConnection[]
   audioDescribed?: Connection[]
   /** Location for a captions file */


### PR DESCRIPTION
📺 What

Take the full dash.js entrypoint vs `index_mediaplayerOnly`, pass through dash.js protection data.

🛠 How

- Update the dash.js entrypoint. Use the index vs the built `main` package entrypoint to allow consuming applications to decide what to bundle.
- Use the same shape protection data as dash.js within the optional `media.protectionData`. This is exposed via the types.
- Expose the protection data within mediaSources with the `currentProtectionData` function.
- Set protection data on the dash.js media player.

