### PR TITLE
Ensure AD persists on source change

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -593,8 +593,11 @@ function MSEStrategy(
   }
 
   function modifySource(presentationTimeInSeconds) {
-    const source = mediaSources.currentSource()
-    const anchor = buildSourceAnchor(presentationTimeInSeconds)
+    if (mediaPlayer.isReady()) {
+      // Reset source to apply media settings for the new source
+      // dash.js will reset media settings if a new source is attached while its initialised with a source
+      mediaPlayer.attachSource(null)
+    }
 
     mediaPlayer.setInitialMediaSettingsFor(
       "audio",
@@ -607,6 +610,9 @@ function MSEStrategy(
             role: "main",
           }
     )
+
+    const source = mediaSources.currentSource()
+    const anchor = buildSourceAnchor(presentationTimeInSeconds)
 
     mediaPlayer.attachSource(`${source}${anchor}`)
   }

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -508,13 +508,16 @@ function MSEStrategy(
   function onCurrentTrackChanged(event) {
     if (!isAudioDescribedAvailable()) return
 
+    audioDescribed.enable = isAudioDescribedEnabled()
     const mediaType = event.newMediaInfo.type
+
     DebugTool.info(
       `${mediaType} track changed.${
-        mediaType === "audio" ? (isAudioDescribedEnabled() ? " Audio Described on." : " Audio Described off.") : ""
+        mediaType === "audio" ? (audioDescribed.enable ? " Audio Described on." : " Audio Described off.") : ""
       }`
     )
-    audioDescribed.callback && audioDescribed.callback(isAudioDescribedEnabled())
+
+    audioDescribed.callback && audioDescribed.callback(audioDescribed.enable)
   }
 
   function publishMediaState(mediaState) {
@@ -586,6 +589,13 @@ function MSEStrategy(
 
     mediaPlayer.initialize(mediaElement, null)
 
+    modifySource(presentationTimeInSeconds)
+  }
+
+  function modifySource(presentationTimeInSeconds) {
+    const source = mediaSources.currentSource()
+    const anchor = buildSourceAnchor(presentationTimeInSeconds)
+
     mediaPlayer.setInitialMediaSettingsFor(
       "audio",
       audioDescribed.enable
@@ -597,13 +607,6 @@ function MSEStrategy(
             role: "main",
           }
     )
-
-    modifySource(presentationTimeInSeconds)
-  }
-
-  function modifySource(presentationTimeInSeconds) {
-    const source = mediaSources.currentSource()
-    const anchor = buildSourceAnchor(presentationTimeInSeconds)
 
     mediaPlayer.attachSource(`${source}${anchor}`)
   }


### PR DESCRIPTION
📺 What

* Ensure AD persists on source change

🛠 How

* Move setting track preference down into modify source from initial load.
* On track change update audiodescribed.enable to reflect current state.
