### PR TITLE
Handle onSuccess not passed

### DIFF
--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -128,7 +128,7 @@ function BigscreenPlayer() {
       mediaSources.time().manifestType,
       PlayerComponent.getLiveSupport(),
       () => {
-        _callbacks.playerReady()
+        _callbacks.playerReady && _callbacks.playerReady()
         subtitles = Subtitles(
           playerComponent,
           enableSubtitles,


### PR DESCRIPTION
📺 What

Adds check to ensure `_callbacks.playerReady` exists for player uses where the `onSuccess` callback is not used.
