### PR TITLE
Handle no default styles passed

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -725,7 +725,17 @@ function MSEStrategy(
   }
 
   function customiseSubtitles(options) {
-    return mediaPlayer && mediaPlayer.updateSettings({ streaming: { text: { imsc: { options } } } })
+    return (
+      mediaPlayer &&
+      options &&
+      mediaPlayer.updateSettings({
+        streaming: {
+          text: {
+            imsc: { options },
+          },
+        },
+      })
+    )
   }
 
   function getDuration() {


### PR DESCRIPTION
📺 What

Fixes an issue where if no default subtitle styles are passed initially, it is not possible to customise them going forward.

Cause - Dash.js is updated with `undefined` as the subtitle options, meaning there is no object available to set options against in future calls 