### PR TITLE
Support setting and getting of playback bitrate

### DIFF
--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -472,6 +472,24 @@ function BigscreenPlayer() {
     getPlaybackRate: () => playerComponent && playerComponent.getPlaybackRate(),
 
     /**
+     * Set constrained bitrate given a min/max range and mediakind.
+     */
+    setConstrainedBitrateInKbps: (mediaKind, minBitrate, maxBitrate) => {
+      if (playerComponent) {
+        playerComponent.setConstrainedBitrateInKbps(mediaKind, minBitrate, maxBitrate)
+      }
+    },
+
+    /**
+     * Returns current playback bitrate for media kind.
+     */
+    getPlaybackBitrate: (mediaKind) => {
+      if (playerComponent) {
+        return playerComponent.getPlaybackBitrate(mediaKind)
+      }
+    },
+
+    /**
      * Returns the media asset's current time in seconds.
      * @function
      * @returns {Number}

--- a/src/bigscreenplayer.test.js
+++ b/src/bigscreenplayer.test.js
@@ -116,6 +116,8 @@ describe("Bigscreen Player", () => {
       isAudioDescribedAvailable: jest.fn(),
       isAudioDescribedEnabled: jest.fn(),
       setAudioDescribed: jest.fn(),
+      setConstrainedBitrateInKbps: jest.fn(),
+      getPlaybackBitrate: jest.fn(),
     }
 
     jest.spyOn(PlayerComponent, "getLiveSupport").mockReturnValue(LiveSupport.SEEKABLE)
@@ -1667,6 +1669,37 @@ describe("Bigscreen Player", () => {
       bigscreenPlayer.getDebugLogs()
 
       expect(DebugTool.getDebugLogs).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("Set and get playback bitrate", () => {
+    const mediaKind = "video"
+    const minBitrate = 100
+    const maxBitrate = 200
+
+    it("should set bitrate on the strategy", async () => {
+      await asyncInitialiseBigscreenPlayer(createPlaybackElement(), bigscreenPlayerData)
+      bigscreenPlayer.setConstrainedBitrateInKbps(mediaKind, minBitrate, maxBitrate)
+
+      expect(mockPlayerComponentInstance.setConstrainedBitrateInKbps).toHaveBeenLastCalledWith(
+        mediaKind,
+        minBitrate,
+        maxBitrate
+      )
+    })
+
+    it("should not set the bitrate if playerComponent is not initialised", async () => {
+      bigscreenPlayer.setConstrainedBitrateInKbps(mediaKind, minBitrate, maxBitrate)
+
+      expect(mockPlayerComponentInstance.setConstrainedBitrateInKbps).not.toHaveBeenCalled()
+    })
+
+    it("should return the bitrate given a media kind", async () => {
+      await asyncInitialiseBigscreenPlayer(createPlaybackElement(), bigscreenPlayerData)
+      mockPlayerComponentInstance.getPlaybackBitrate.mockReturnValue(100)
+      bigscreenPlayer.getPlaybackBitrate(mediaKind)
+
+      expect(mockPlayerComponentInstance.getPlaybackBitrate()).toBe(100)
     })
   })
 })

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -415,7 +415,7 @@ function MSEStrategy(
 
     const bitrateInfoList = mediaPlayer.getBitrateInfoListFor(mediaKind)
 
-    return bitrateInfoList[index].bitrate ?? 0
+    return bitrateInfoList?.[index].bitrate ?? 0
   }
 
   function onQualityChangeRequested(event) {
@@ -995,6 +995,26 @@ function MSEStrategy(
     }
   }
 
+  /*
+   * Set constrained audio or video bitrate
+   */
+  function setConstrainedBitrateInKbps(mediaKind, minBitrate, maxBitrate) {
+    mediaPlayer.updateSettings({
+      streaming: {
+        abr: {
+          minBitrate: {
+            audio: mediaKind === MediaKinds.AUDIO ? minBitrate : -1,
+            video: mediaKind === MediaKinds.VIDEO ? minBitrate : -1,
+          },
+          maxBitrate: {
+            audio: mediaKind === MediaKinds.AUDIO ? maxBitrate : -1,
+            video: mediaKind === MediaKinds.VIDEO ? maxBitrate : -1,
+          },
+        },
+      },
+    })
+  }
+
   return {
     transitions: {
       canBePaused: () => true,
@@ -1039,6 +1059,8 @@ function MSEStrategy(
     setCurrentTime,
     setPlaybackRate: (rate) => mediaPlayer.setPlaybackRate(rate),
     getPlaybackRate: () => mediaPlayer.getPlaybackRate(),
+    setConstrainedBitrateInKbps,
+    getPlaybackBitrate: (mediaKind) => currentPlaybackBitrateInKbps(mediaKind),
   }
 }
 

--- a/src/playbackstrategy/msestrategy.test.js
+++ b/src/playbackstrategy/msestrategy.test.js
@@ -89,6 +89,8 @@ function createMockDashInstance() {
     setInitialMediaSettingsFor: jest.fn(),
     setAutoPlay: jest.fn(),
     setProtectionData: jest.fn(),
+    setConstrainedBitrateInKbps: jest.fn(),
+    getPlaybackBitrate: jest.fn(),
   }
 }
 
@@ -1913,6 +1915,25 @@ describe("Media Source Extensions Playback Strategy", () => {
       const subtitlesElement = playbackElement.querySelector("#bsp_subtitles")
 
       expect(mockDashInstance.attachTTMLRenderingDiv).toHaveBeenCalledWith(subtitlesElement)
+    })
+  })
+
+  describe("Playback bitrate", () => {
+    it("setContrainedBitrateInKbps should call media player updateSettings", () => {
+      const mseStrategy = MSEStrategy(mockMediaSources, MediaKinds.VIDEO, playbackElement)
+      mseStrategy.load(null, 0)
+      mseStrategy.setConstrainedBitrateInKbps("video", 100, 200)
+
+      expect(mockDashInstance.updateSettings).toHaveBeenCalled()
+    })
+
+    it("getPlaybackBitrate returns the current playback bitrate in kbps", () => {
+      const mseStrategy = MSEStrategy(mockMediaSources, MediaKinds.VIDEO, playbackElement)
+      mseStrategy.load(null, 0)
+      mockDashInstance.getBitrateInfoListFor.mockReturnValue([{ bitrate: 100000 }])
+      const bitrate = mseStrategy.getPlaybackBitrate("video")
+
+      expect(bitrate).toBe(100)
     })
   })
 })

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -447,6 +447,14 @@ function PlayerComponent(
     fatalError = undefined
   }
 
+  function setConstrainedBitrateInKbps(mediaKind, minBitrate, maxBitrate) {
+    playbackStrategy?.setConstrainedBitrateInKbps(mediaKind, minBitrate, maxBitrate)
+  }
+
+  function getPlaybackBitrate(mediaKind) {
+    return playbackStrategy?.getPlaybackBitrate(mediaKind)
+  }
+
   return {
     play,
     pause,
@@ -467,6 +475,8 @@ function PlayerComponent(
     isAudioDescribedEnabled,
     setAudioDescribed,
     setSubtitles,
+    setConstrainedBitrateInKbps,
+    getPlaybackBitrate,
   }
 }
 

--- a/src/playercomponent.test.js
+++ b/src/playercomponent.test.js
@@ -56,6 +56,8 @@ function createMockPlaybackStrategy(liveSupport = LiveSupport.SEEKABLE, extraFie
     isAudioDescribedEnabled: jest.fn(),
     setAudioDescribedOn: jest.fn(),
     setAudioDescribedOff: jest.fn(),
+    setConstrainedBitrateInKbps: jest.fn(),
+    getPlaybackBitrate: jest.fn(),
     ...extraFields,
   }
 }
@@ -1609,6 +1611,37 @@ describe("Player Component", () => {
       playerComponent.tearDown()
 
       expect(mockStrategy.tearDown).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("Set and get playback bitrate", () => {
+    it("setConstrainedBitrateInKbps calls the the strategy to update settings", async () => {
+      const playerComponent = new PlayerComponent(
+        createPlaybackElement(),
+        bigscreenPlayerData,
+        mockMediaSources,
+        jest.fn(),
+        jest.fn()
+      )
+      await jest.runOnlyPendingTimersAsync()
+      playerComponent.setConstrainedBitrateInKbps("video", 100, 200)
+
+      expect(mockStrategy.setConstrainedBitrateInKbps).toHaveBeenCalledWith("video", 100, 200)
+    })
+
+    it("getPlaybackBitrate returns the strategy playback bitrate", async () => {
+      mockStrategy.getPlaybackBitrate.mockReturnValueOnce(100)
+      const playerComponent = new PlayerComponent(
+        createPlaybackElement(),
+        bigscreenPlayerData,
+        mockMediaSources,
+        jest.fn(),
+        jest.fn()
+      )
+      await jest.runOnlyPendingTimersAsync()
+
+      expect(playerComponent.getPlaybackBitrate()).toBe(100)
+      expect(mockStrategy.getPlaybackBitrate).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
📺 What

Changes to interface to support the setting of a bitrate, given a media kind (Audio/video), minimum and maximum bitrate for the selection of a representation within the bitrate range.

Provides an interface for returning the current bitrate setting.

🛠 How

Two new functions, `setConstrainedBitrateInKbps` and `getPlaybackBitrate` for setting and getting the playback bitrate respectively.
