### PR TITLE
Update Dash.js Version with Buffer Level Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5606,7 +5606,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#a90553c473672d42da063f809506dcd30281bb4e",
+      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#04ab721a17ea990dfd5ee03b166e5becfd686c1f",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5606,7 +5606,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#04ab721a17ea990dfd5ee03b166e5becfd686c1f",
+      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#6dcfc760f22be58dba6fc93581d56b0299d76a40",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5606,7 +5606,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#78ce634608afce1df7bf86fab2258ba211177f5e",
+      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#9eb089469662f8e1d08a534028a7cae942bc1dbd",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/rd-dash.js#buffer-level-reporting",
+        "dashjs": "github:bbc/dash.js#smp-v4.7.3-8",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {
@@ -5606,7 +5606,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#9eb089469662f8e1d08a534028a7cae942bc1dbd",
+      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#605226e657372e5ed0b03b70f6af8fe3b44dab01",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#smp-v4.7.3-7",
+        "dashjs": "github:bbc/rd-dash.js#buffer-level-reporting",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {
@@ -5606,7 +5606,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#8b7c98db6c79135253975d3ff805124b66674092",
+      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#a90553c473672d42da063f809506dcd30281bb4e",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5606,7 +5606,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#6dcfc760f22be58dba6fc93581d56b0299d76a40",
+      "resolved": "git+ssh://git@github.com/bbc/rd-dash.js.git#78ce634608afce1df7bf86fab2258ba211177f5e",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript-eslint": "^7.2.0"
   },
   "dependencies": {
-    "dashjs": "github:bbc/rd-dash.js#buffer-level-reporting",
+    "dashjs": "github:bbc/dash.js#smp-v4.7.3-8",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript-eslint": "^7.2.0"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#smp-v4.7.3-7",
+    "dashjs": "github:bbc/rd-dash.js#buffer-level-reporting",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {


### PR DESCRIPTION
📺 What

Updates Dash.js with a new version that includes a bug fix for buffer level reporting when using DVB metrics.

🛠 How

Fixes an issue in Dash.js where the buffer level of text tacks is continually reported even when the track is disabled.

The buffer level value reported is a minimum. This results in the DVB Buffer Level being reported as 0 when subtitles are not in use.