### PR TITLE
Updatable MediaPlayer Settings

### DIFF
--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -788,6 +788,15 @@ function BigscreenPlayer() {
     getInitialPlaybackTime,
     getTimeShiftBufferDepthInMilliseconds,
     getPresentationTimeOffsetInMilliseconds,
+
+    /**
+     * Updates the settings of an active player.
+     *
+     * @param {Partial<import("./types").Settings>} settings The settings to update the player with.
+     */
+    updateSettings(settings) {
+      playerComponent.updateSettings(settings)
+    },
   }
 }
 

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -795,7 +795,7 @@ function BigscreenPlayer() {
      * @param {Partial<import("./types").Settings>} settings The settings to update the player with.
      */
     updateSettings(settings) {
-      playerComponent.updateSettings(settings)
+      playerComponent && playerComponent.updateSettings(settings)
     },
   }
 }

--- a/src/bigscreenplayer.test.js
+++ b/src/bigscreenplayer.test.js
@@ -118,6 +118,7 @@ describe("Bigscreen Player", () => {
       setAudioDescribed: jest.fn(),
       setBitrateConstraint: jest.fn(),
       getPlaybackBitrate: jest.fn(),
+      updateSettings: jest.fn(),
     }
 
     jest.spyOn(PlayerComponent, "getLiveSupport").mockReturnValue(LiveSupport.SEEKABLE)
@@ -1701,5 +1702,15 @@ describe("Bigscreen Player", () => {
 
       expect(mockPlayerComponentInstance.getPlaybackBitrate()).toBe(100)
     })
+  })
+
+  it("should call through to PlayerComponent.updateSettings when updateSettings is called", async () => {
+    const settings = { updatedSetting1: true, updatedSetting2: 1 }
+
+    await asyncInitialiseBigscreenPlayer(createPlaybackElement(), bigscreenPlayerData)
+
+    bigscreenPlayer.updateSettings(settings)
+
+    expect(mockPlayerComponentInstance.updateSettings).toHaveBeenCalledWith(settings)
   })
 })

--- a/src/mediasources.ts
+++ b/src/mediasources.ts
@@ -362,6 +362,14 @@ function MediaSources() {
     subtitlesSources = []
   }
 
+  function updateSettings(settings: {
+    failoverResetTime: typeof failoverResetTimeMs
+    failoverSort: typeof failoverSort
+  }) {
+    if (settings.failoverResetTime) failoverResetTimeMs = settings.failoverResetTime
+    if (settings.failoverSort) failoverSort = settings.failoverSort
+  }
+
   return {
     init,
     failover,
@@ -381,6 +389,7 @@ function MediaSources() {
     time: generateTime,
     transferFormat: getCurrentTransferFormat,
     tearDown,
+    updateSettings,
   }
 }
 

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -1017,6 +1017,29 @@ function MSEStrategy(
     })
   }
 
+  function updateSettings(settings) {
+    if (settings?.failoverResetTime) {
+      mediaSources.updateSettings({ failoverResetTime: settings.failoverResetTime })
+      mediaPlayer.updateSettings({ streaming: { blacklistExpiryTime: mediaSources.failoverResetTime() } })
+    }
+
+    if (settings?.failoverSort) {
+      mediaSources.updateSettings({ failoverSort: settings.failoverSort })
+    }
+
+    if (settings?.streaming?.seekDurationPadding) {
+      seekDurationPadding = settings.streaming.seekDurationPadding
+    }
+
+    // Remove BSP specific settings
+    delete settings.failoverResetTime
+    delete settings.failoverSort
+    delete settings.streaming?.seekDurationPadding
+
+    // If we still have settings, pass them to Dash
+    if (Object.keys(settings).length > 0) mediaPlayer.updateSettings(settings)
+  }
+
   return {
     transitions: {
       canBePaused: () => true,
@@ -1063,6 +1086,7 @@ function MSEStrategy(
     getPlaybackRate: () => mediaPlayer.getPlaybackRate(),
     setBitrateConstraint,
     getPlaybackBitrate: (mediaKind) => currentPlaybackBitrateInKbps(mediaKind),
+    updateSettings,
   }
 }
 

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -58,13 +58,16 @@ function MSEStrategy(
   let errorCallback
   let timeUpdateCallback
 
-  const seekDurationPadding = isNaN(playerSettings.streaming?.seekDurationPadding)
+  let seekDurationPadding = isNaN(playerSettings.streaming?.seekDurationPadding)
     ? DEFAULT_SETTINGS.seekDurationPadding
     : playerSettings.streaming?.seekDurationPadding
+
   const liveDelay = isNaN(playerSettings.streaming?.delay?.liveDelay)
     ? DEFAULT_SETTINGS.liveDelay
     : playerSettings.streaming?.delay?.liveDelay
+
   let isEnded = false
+
   const cached = {
     seekableRange: undefined,
     duration: 0,
@@ -1017,24 +1020,27 @@ function MSEStrategy(
     })
   }
 
-  function updateSettings(settings) {
+  function updateSettings(playerSettings) {
+    const settings = Utils.deepClone(playerSettings)
+
     if (settings?.failoverResetTime) {
       mediaSources.updateSettings({ failoverResetTime: settings.failoverResetTime })
       mediaPlayer.updateSettings({ streaming: { blacklistExpiryTime: mediaSources.failoverResetTime() } })
+
+      delete settings.failoverResetTime
     }
 
     if (settings?.failoverSort) {
       mediaSources.updateSettings({ failoverSort: settings.failoverSort })
+
+      delete settings.failoverSort
     }
 
     if (settings?.streaming?.seekDurationPadding) {
       seekDurationPadding = settings.streaming.seekDurationPadding
-    }
 
-    // Remove BSP specific settings
-    delete settings.failoverResetTime
-    delete settings.failoverSort
-    delete settings.streaming?.seekDurationPadding
+      delete settings.streaming?.seekDurationPadding
+    }
 
     // If we still have settings, pass them to Dash
     if (Object.keys(settings).length > 0) mediaPlayer.updateSettings(settings)

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -455,6 +455,10 @@ function PlayerComponent(
     return playbackStrategy?.getPlaybackBitrate(mediaKind)
   }
 
+  function updateSettings(settings) {
+    playbackStrategy?.updateSettings(settings)
+  }
+
   return {
     play,
     pause,
@@ -477,6 +481,7 @@ function PlayerComponent(
     setSubtitles,
     setBitrateConstraint,
     getPlaybackBitrate,
+    updateSettings,
   }
 }
 

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -456,7 +456,7 @@ function PlayerComponent(
   }
 
   function updateSettings(settings) {
-    playbackStrategy?.updateSettings(settings)
+    if (playbackStrategy?.updateSettings) playbackStrategy.updateSettings(settings)
   }
 
   return {

--- a/src/playercomponent.test.js
+++ b/src/playercomponent.test.js
@@ -251,6 +251,30 @@ describe("Player Component", () => {
 
       expect(mockAudioDescribedCallback).not.toHaveBeenCalled()
     })
+
+    it("Calls through to the strategy's updateSettings if it exists", async () => {
+      const updateSettings = jest.fn()
+      const settings = { updatedSetting1: true, updatedSetting2: 1 }
+      const mockStrategy = createMockPlaybackStrategy(LiveSupport.SEEKABLE, { updateSettings })
+      const mockPlaybackStrategyClass = jest.fn().mockReturnValue(mockStrategy)
+      StrategyPicker.mockResolvedValueOnce(mockPlaybackStrategyClass)
+
+      const playbackElement = createPlaybackElement()
+
+      const playerComponent = new PlayerComponent(
+        playbackElement,
+        bigscreenPlayerData,
+        mockMediaSources,
+        jest.fn(),
+        jest.fn()
+      )
+
+      await jest.runOnlyPendingTimersAsync()
+
+      playerComponent.updateSettings(settings)
+
+      expect(updateSettings).toHaveBeenCalledWith(settings)
+    })
   })
 
   describe("pause", () => {

--- a/src/playercomponent.test.js
+++ b/src/playercomponent.test.js
@@ -275,6 +275,27 @@ describe("Player Component", () => {
 
       expect(updateSettings).toHaveBeenCalledWith(settings)
     })
+
+    it("Does not throw if the strategy does not have updateSettings", async () => {
+      const settings = { updatedSetting1: true, updatedSetting2: 1 }
+      const mockStrategy = createMockPlaybackStrategy(LiveSupport.SEEKABLE)
+      const mockPlaybackStrategyClass = jest.fn().mockReturnValue(mockStrategy)
+      StrategyPicker.mockResolvedValueOnce(mockPlaybackStrategyClass)
+
+      const playbackElement = createPlaybackElement()
+
+      const playerComponent = new PlayerComponent(
+        playbackElement,
+        bigscreenPlayerData,
+        mockMediaSources,
+        jest.fn(),
+        jest.fn()
+      )
+
+      await jest.runOnlyPendingTimersAsync()
+
+      expect(() => playerComponent.updateSettings(settings)).not.toThrow()
+    })
   })
 
   describe("pause", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type CaptionsConnection = Connection & {
   segmentLength: number
 }
 
-type Settings = MediaPlayerSettingClass & {
+export type Settings = MediaPlayerSettingClass & {
   failoverResetTime: number
   failoverSort: (sources: Connection[]) => Connection[]
   streaming: {


### PR DESCRIPTION
📺 What
Allows for updating of MediaPlayer settings on an existing instance, similar to DashJS.

🛠 How
Handles our extensions to settings and passes the rest to Dash. Only for MSE Strategy - will simply do nothing for other strategies.

# TODO
* [ ] Figure out `seekDurationPadding`
* [ ] MediaSources Unit Tests
