### PR TITLE
Move onPlaybackFrozen to message and not error

### DIFF
--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -1016,7 +1016,7 @@ function MSEStrategy(
 
   function onPlaybackFrozen(event) {
     Plugins.interface.onPlaybackFrozen(event)
-    DebugTool.error(`${event.cause}. Total frames - ${event.totalVideoFrames}`)
+    DebugTool.info(`${event.cause}. Total frames - ${event.totalVideoFrames}`)
   }
 
   return {


### PR DESCRIPTION
📺 What

Reduce `onPlaybackFrozen` false positives being reported to chronicle. 

🛠 How

Move from `error` to `info` debug reporting