### PR TITLE
 Video frames not advancing updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#update-default-threhodl",
+        "dashjs": "github:bbc/dash.js#smp-v4.7.3-10",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {
@@ -5606,7 +5606,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#690479ef816412fb3a6ed2267c2c123dcae58d2d",
+      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#f17dd7a81b43a68cb67ed1cb7e0086e6da4f479d",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript-eslint": "^7.2.0"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#update-default-threhodl",
+    "dashjs": "github:bbc/dash.js#smp-v4.7.3-10",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {


### PR DESCRIPTION
📺 What

Update the `videoFramesNotAdvancing` implementation to handle additional invalid or inaccurate values being reported by the Video Quality API.

🛠 How

Deals with 3 observed cases:

- Increases the default `thresholdInSeconds` to `5`. As many WebKit-based TV environment only appear to provide an update to this value every ~2-seconds
- Handle cases where some devices always report the maximum value of 32-bit signed integer as their `totalVideoFrames` value on the Video Quality API when playing a live stream. Caused by some implementations using `totalVideoFrames = mediaTime * frameRate`
- Finally, only trigger when frames are explicitly not changing, i.e `previousFrames !== currentFrames`. Some devices appear to reset `totalVideoFrames` to `0` if the decoder is reinitialised.

