### PR TITLE
Don't Pass Abort Signal Into Playback Strategy

### DIFF
--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -65,7 +65,6 @@ function PlayerComponent(
         mediaSources,
         mediaKind,
         playbackElement,
-        abortSignal,
         bigscreenPlayerData.media.isUHD,
         bigscreenPlayerData.media.playerSettings,
         {

--- a/src/playercomponent.test.js
+++ b/src/playercomponent.test.js
@@ -149,7 +149,6 @@ describe("Player Component", () => {
         mockMediaSources,
         MediaKinds.VIDEO,
         playbackElement,
-        mockAbortSignal,
         undefined,
         undefined,
         { callback: audioDescribedCallback, enable: false }


### PR DESCRIPTION
📺 What

Ensure the order of the playback strategy by not passing the abort signal further down (without updating the strategies signature).

🛠 How

Removes `abortSignal` parameter in the call to `strategy`.
