### PR TITLE
Video frames not advancing ignore webkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#smp-v4.7.3-12",
+        "dashjs": "github:bbc/dash.js#video-frames-not-advancing-ignore-webkit",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {
@@ -5606,7 +5606,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#5948e1d2f771948f4da940ab82f233cf54c1432f",
+      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#8c1091170272e123b474605b1907e8c189406ddf",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#video-frames-not-advancing-ignore-webkit",
+        "dashjs": "github:bbc/dash.js#smp-v4.7.3-13",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {
@@ -5606,7 +5606,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#8c1091170272e123b474605b1907e8c189406ddf",
+      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#4bb68044d2da568eaa4acecd36b7b6e06d509844",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript-eslint": "^7.2.0"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#smp-v4.7.3-12",
+    "dashjs": "github:bbc/dash.js#video-frames-not-advancing-ignore-webkit",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript-eslint": "^7.2.0"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#video-frames-not-advancing-ignore-webkit",
+    "dashjs": "github:bbc/dash.js#smp-v4.7.3-13",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {


### PR DESCRIPTION
📺 What

Updates Dash.js to smp-v4.7.3-13

🛠 How

Updates Dash.js to smp-v4.7.3-13, brings in change to ignore WebKit devices from the `videoFramesNotAdvancing` method.