### PR TITLE
 Port Subtitle Changes from v4.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#port-pr-4359-subs-flickering",
+        "dashjs": "github:bbc/dash.js#smp-v4.7.3-14",
         "smp-imsc": "github:bbc/imscJS#v1.0.3"
       },
       "devDependencies": {
@@ -5606,7 +5606,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.3",
-      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#f735d34cfc5d6a00390e434df29c1a787848f976",
+      "resolved": "git+ssh://git@github.com/bbc/dash.js.git#04d53f356089f4aa4331122cbfdca6cb4d2764e0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bcp-47-match": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript-eslint": "^7.2.0"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#port-pr-4359-subs-flickering",
+    "dashjs": "github:bbc/dash.js#smp-v4.7.3-14",
     "smp-imsc": "github:bbc/imscJS#v1.0.3"
   },
   "repository": {


### PR DESCRIPTION
📺 What

Port Subtitle Changes from v4.7.4 (#4359) 

🛠 How

Port changes made by @mattjuggins in [#4359](https://github.com/Dash-Industry-Forum/dash.js/pull/4359) released in Dash-Industry-Forum/dash.js v4.7.4.

This port preserves the passing of customisation options to IMSC.