### PR TITLE
Add video fragment response headers to the debug view

### DIFF
--- a/docs/tutorials/00-getting-started.md
+++ b/docs/tutorials/00-getting-started.md
@@ -78,6 +78,9 @@ The full set of options for BigscreenPlayer is:
 const optionalData = {
   initialPlaybackTime: 0, // Time (in seconds) to begin playback from
   enableSubtitles: false,
+  debug: {
+    fragmentResponseHeaders: [], // video fragment response headers to output in the debug tool
+  },
   media: {
     type: "application/dash+xml",
     kind: MediaKinds.VIDEO, // Can be VIDEO, or AUDIO

--- a/src/bigscreenplayer.js
+++ b/src/bigscreenplayer.js
@@ -109,7 +109,7 @@ function BigscreenPlayer() {
     }
   }
 
-  function bigscreenPlayerDataLoaded({ media, enableSubtitles, subtitlesAlwaysOnTop, enableAudioDescribed }) {
+  function bigscreenPlayerDataLoaded({ media, enableSubtitles, subtitlesAlwaysOnTop, enableAudioDescribed, debug }) {
     abortSignal.throwIfAborted(AbortStages.DATA_LOADED)
 
     const initialPresentationTime =
@@ -122,7 +122,7 @@ function BigscreenPlayer() {
 
     playerComponent = PlayerComponent(
       playbackElement,
-      { media, enableAudioDescribed, initialPlaybackTime: initialPresentationTime },
+      { media, enableAudioDescribed, initialPlaybackTime: initialPresentationTime, debug },
       mediaSources,
       mediaStateUpdateCallback,
       _callbacks.playerError,

--- a/src/playbackstrategy/msestrategy.js
+++ b/src/playbackstrategy/msestrategy.js
@@ -533,7 +533,7 @@ function MSEStrategy(
           .getDashMetrics()
           .getLatestFragmentRequestHeaderValueByID("video", responseHeader)
         if (responseHeaderValue) {
-          DebugTool.staticMetric(responseHeader, responseHeaderValue)
+          DebugTool.staticMetric(responseHeader.toLowerCase(), responseHeaderValue)
         }
       })
     }

--- a/src/playercomponent.js
+++ b/src/playercomponent.js
@@ -70,7 +70,8 @@ function PlayerComponent(
         {
           enable: bigscreenPlayerData.enableAudioDescribed,
           callback: audioDescribedCallback,
-        }
+        },
+        bigscreenPlayerData?.debug
       )
 
       playbackStrategy.addEventCallback(this, eventCallback)

--- a/src/playercomponent.test.js
+++ b/src/playercomponent.test.js
@@ -151,7 +151,8 @@ describe("Player Component", () => {
         playbackElement,
         undefined,
         undefined,
-        { callback: audioDescribedCallback, enable: false }
+        { callback: audioDescribedCallback, enable: false },
+        undefined
       )
       expect(mockPlaybackStrategyClass).toHaveBeenCalledTimes(1)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,12 +53,17 @@ export type MediaDescriptor = {
   subtitlesRequestTimeout?: number
 }
 
+export type DebugSettings = {
+  fragmentResponseHeaders?: string[]
+}
+
 export type InitData = {
   media: MediaDescriptor
   enableSubtitles?: boolean
   subtitlesAlwaysOnTop?: boolean
   enableAudioDescribed?: boolean
   initialPlaybackTime?: number | PlaybackTime
+  debug?: DebugSettings
 }
 
 export type InitCallbacks = {


### PR DESCRIPTION
📺 What

For MSE browsers, show the headers in `debug.fragmentResponseHeaders ` as static fields in the debug tool overlay.

🛠 How
- Add new optional `debug` object to the initialisation data.
- For each header in `fragmentResponseHeaders` display the value from the latest video fragment response.