### PR TITLE
BADGER-312: Segment timeline fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dashjs": "github:bbc/dash.js#smp-v4.7.3-18",
+        "dashjs": "github:bbc/dash.js#smp-v4.7.3-19",
         "smp-imsc": "github:bbc/imscJS#v1.0.11"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript-eslint": "7.2.0"
   },
   "dependencies": {
-    "dashjs": "github:bbc/dash.js#smp-v4.7.3-18",
+    "dashjs": "github:bbc/dash.js#smp-v4.7.3-19",
     "smp-imsc": "github:bbc/imscJS#v1.0.11"
   },
   "repository": {


### PR DESCRIPTION
📺 What

Updates `dash.js` to incorporate new segment timeline fix: [dash.js/pull/110](https://github.com/bbc/dash.js/pull/110)

🛠 How

- Updates `dash.js` to `v4.7.3-19`
