### PR TITLE
Spike: Failback limit

### DIFF
--- a/src/mediasources.ts
+++ b/src/mediasources.ts
@@ -47,6 +47,10 @@ function MediaSources() {
   let subtitlesRequestTimeout = 5000
   let failoverResetTimeMs = 120000
 
+  // Array of CDN names that failed for the playback session
+  // and we added back in after 120 seconds (failoverResetTimeMs)
+  const failBackCdns: string[] = []
+
   function init(media: MediaDescriptor, setAudioDescribedOn?: boolean): Promise<void> {
     return new Promise((resolve, reject) => {
       if (!media.urls?.length) {
@@ -81,6 +85,7 @@ function MediaSources() {
   }
 
   function failover(failoverParams: FailoverParams): Promise<void> {
+    console.log('*** Failover! ***');
     return new Promise((resolve, reject) => {
       if (!isFailoverInfoValid(failoverParams)) {
         return reject(new TypeError("Invalid failover params"))
@@ -278,15 +283,24 @@ function MediaSources() {
       sources[currentSources] = failoverSort(sources[currentSources])
     }
 
-    const failoverResetToken = setTimeout(() => {
-      if (mediaSource == null || sources[currentSources].length === 0) return
+    const hasFailedBack = failBackCdns.includes(mediaSource.cdn);
 
-      DebugTool.info(`${mediaSource.cdn} has been added back in to available CDNs`)
-      sources[currentSources].push(mediaSource)
-      updateDebugOutput()
-    }, failoverResetTimeMs)
-
-    failoverResetTokens.push(failoverResetToken as unknown as number)
+    // If CDN does not exist in failBackCdns, add
+    // back in to the available mediasource CDNs
+    if (!hasFailedBack) {
+      const failoverResetToken = setTimeout(() => {
+        console.log('*** Adding CDN back! ***')
+        if (mediaSource == null || sources[currentSources].length === 0) return
+  
+        DebugTool.info(`${mediaSource.cdn} has been added back in to available CDNs`)
+        sources[currentSources].push(mediaSource)
+  
+        updateDebugOutput()
+      }, failoverResetTimeMs)
+  
+      failoverResetTokens.push(failoverResetToken as unknown as number)
+      failBackCdns.push(mediaSource.cdn);
+    }
   }
 
   function updateCdns(serviceLocation: string | undefined): void {

--- a/src/mediasources.ts
+++ b/src/mediasources.ts
@@ -45,7 +45,7 @@ function MediaSources() {
 
   // Can be overridden with media.subtitlesRequestTimeout
   let subtitlesRequestTimeout = 5000
-  let failoverResetTimeMs = 120000
+  let failoverResetTimeMs = 5000
 
   // Array of CDN names that failed for the playback session
   // and we added back in after 120 seconds (failoverResetTimeMs)
@@ -85,7 +85,7 @@ function MediaSources() {
   }
 
   function failover(failoverParams: FailoverParams): Promise<void> {
-    console.log('*** Failover! ***');
+    DebugTool.info("*** Failover! ***")
     return new Promise((resolve, reject) => {
       if (!isFailoverInfoValid(failoverParams)) {
         return reject(new TypeError("Invalid failover params"))
@@ -283,23 +283,23 @@ function MediaSources() {
       sources[currentSources] = failoverSort(sources[currentSources])
     }
 
-    const hasFailedBack = failBackCdns.includes(mediaSource.cdn);
+    const hasFailedBack = failBackCdns.includes(mediaSource.cdn)
 
     // If CDN does not exist in failBackCdns, add
     // back in to the available mediasource CDNs
     if (!hasFailedBack) {
       const failoverResetToken = setTimeout(() => {
-        console.log('*** Adding CDN back! ***')
+        DebugTool.info("*** Adding CDN back! ***")
         if (mediaSource == null || sources[currentSources].length === 0) return
-  
+
         DebugTool.info(`${mediaSource.cdn} has been added back in to available CDNs`)
         sources[currentSources].push(mediaSource)
-  
+
         updateDebugOutput()
       }, failoverResetTimeMs)
-  
+
       failoverResetTokens.push(failoverResetToken as unknown as number)
-      failBackCdns.push(mediaSource.cdn);
+      failBackCdns.push(mediaSource.cdn)
     }
   }
 


### PR DESCRIPTION
📺 What

This spike PR limits the number of times a CDN may be added back in to the available CDNs.

🛠 How

Given a CDN has failed and added back in, it may not be added back in should it fail more than once.

✅ Testing [Semi-optional]


[Test Guidelines](https://github.com/bbc/bigscreen-player/wiki/Areas-Impacted)

| Test engineer sign off | :x: |
| ---------------------- | --- |

[How will this change be tested?]

👀 See [optional]

[Describe or add screenshots of any User facing changes]
[If the PR has User Facing changes - this section is mandatory]

♿ Accessibility [optional]

[Any accessibility features or considerations that this PR addresses should be listed here]
